### PR TITLE
Reflection_Engine - Issue 765 - Method to get the current location of the executing BHoM dlls

### DIFF
--- a/Reflection_Engine/Query/CurrentAssemblyFolder.cs
+++ b/Reflection_Engine/Query/CurrentAssemblyFolder.cs
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static string CurrentAssemblyFolder()
+        {
+            return System.IO.Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        }
+
+
+        /***************************************************/
+    }
+}

--- a/Reflection_Engine/Reflection_Engine.csproj
+++ b/Reflection_Engine/Reflection_Engine.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Convert\ToText.cs" />
     <Compile Include="Create\Output.cs" />
     <Compile Include="Modify\Cast.cs" />
+    <Compile Include="Query\CurrentAssemblyFolder.cs" />
     <Compile Include="Query\BHoMFolder.cs" />
     <Compile Include="Query\Item.cs" />
     <Compile Include="Query\OutputType.cs" />


### PR DESCRIPTION
Fixes #765.

Should be easy enought to test:

![image](https://user-images.githubusercontent.com/16853390/51019455-f1b5d400-15b5-11e9-9553-85555c430288.png)

![image](https://user-images.githubusercontent.com/16853390/51019466-f7131e80-15b5-11e9-956b-7545b437b45d.png)

![image](https://user-images.githubusercontent.com/16853390/51019487-1316c000-15b6-11e9-9ad9-2b9d50edce00.png)
