### PR TITLE
Serialisation of IImmutable objects, Issue 767

### DIFF
--- a/Serialiser_Engine/Objects/MemberMapConventions/ImmutableBHoMClassMapConvention.cs
+++ b/Serialiser_Engine/Objects/MemberMapConventions/ImmutableBHoMClassMapConvention.cs
@@ -41,11 +41,6 @@ namespace BH.Engine.Serialiser.MemberMapConventions
                 return;
             }
 
-            if (typeInfo.GetConstructor(Type.EmptyTypes) != null)
-            {
-                return;
-            }
-
             if (typeInfo.GetInterface("IImmutable") == null)
             {
                 return; // only applies to classes that inherit from IImutable


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #767 

 <!-- Add short description of what has been fixed -->

Removing requirement for IImmutable class map convention to have no empty constructor. Doing this to allow correct serialisation of IImmutable objects where the developer has opted to have an empty standard constructor.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Serializer_Engine/Serialiser_Engine-Issue%20767-Serialisation%20of%20IImutable%20objects.gh?csf=1&e=myIaQc

