### PR TITLE
Serialiser_Engine - Issue 302 - Convert unknown objects into custom objects

### DIFF
--- a/Serialiser_Engine/Convert/Bson.cs
+++ b/Serialiser_Engine/Convert/Bson.cs
@@ -177,7 +177,7 @@ namespace BH.Engine.Serialiser
                 cm.AutoMap();
                 cm.SetDiscriminator(type.FullName);
                 cm.SetDiscriminatorIsRequired(true);
-                cm.SetIgnoreExtraElements(true);   // It would have been nice to use cm.MapExtraElementsProperty("CustomData") but it doesn't work for inherited properties
+                cm.SetIgnoreExtraElements(false);   // It would have been nice to use cm.MapExtraElementsProperty("CustomData") but it doesn't work for inherited properties
                 BsonClassMap.RegisterClassMap(cm);
 
                 BsonSerializer.RegisterDiscriminatorConvention(type, new GenericDiscriminatorConvention());


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #302

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Serializer_Engine/Serialiser_Engine-Issue302-FallbackDeserialisation.gh?csf=1&e=oQMEFJ
![image](https://user-images.githubusercontent.com/16853390/52040682-30b2c600-2573-11e9-9249-2694e0981ad2.png)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
legacy BHoM objects stored in Bson/Json format will now deserialise into a custom objects instead of returning nothing. 

### Additional comments
<!-- As required -->
Notice there are two reasons an object can fail to deserialise:
![image](https://user-images.githubusercontent.com/16853390/52040773-6657af00-2573-11e9-9d99-2dbbb3a33a46.png)
and
![image](https://user-images.githubusercontent.com/16853390/52040809-84bdaa80-2573-11e9-9b1d-3e53efc78e0f.png)
 
This is the first step of a proper handling of legacy objects. See issue #779 for what comes next. For those wondering, the saving and recovery of the BHoM version will be handled there as it is not needed for this first step.