### PR TITLE
Centring Sections around the origin

### DIFF
--- a/Structure_Engine/Create/ConcreteSection.cs
+++ b/Structure_Engine/Create/ConcreteSection.cs
@@ -26,6 +26,7 @@ using BH.oM.Structure.Properties.Section;
 using BH.oM.Structure.Properties.Section.ShapeProfiles;
 using BH.oM.Structure.Properties.Section.Reinforcement;
 using BH.oM.Geometry;
+using BH.oM.Reflection;
 using BH.oM.Common.Materials;
 using System.Linq;
 
@@ -68,8 +69,10 @@ namespace BH.Engine.Structure
 
         public static ConcreteSection ConcreteSectionFromProfile(IProfile profile, Material material = null, string name = "", List<Reinforcement> reinforcement = null)
         {
-            List<ICurve> edges = profile.Edges.ToList();
-            Dictionary<string, object> constants = Compute.Integrate(edges, Tolerance.MicroDistance);
+            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
+
+            profile = result.Item1;
+            Dictionary<string, object> constants = result.Item2;
 
             constants["J"] = profile.ITorsionalConstant();
             constants["Iw"] = profile.IWarpingConstant();

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -26,6 +26,7 @@ using BH.oM.Structure.Properties.Section;
 using BH.oM.Structure.Properties.Section.ShapeProfiles;
 using BH.oM.Geometry;
 using BH.oM.Common.Materials;
+using BH.oM.Reflection;
 using System.Linq;
 
 
@@ -112,9 +113,10 @@ namespace BH.Engine.Structure
 
         public static SteelSection SteelSectionFromProfile(IProfile profile, Material material = null, string name = "")
         {
+            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
 
-            List<ICurve> edges = profile.Edges.ToList();
-            Dictionary<string, object> constants = Compute.Integrate(edges, Tolerance.MicroDistance);
+            profile = result.Item1;
+            Dictionary<string, object> constants = result.Item2;
 
             constants["J"] = profile.ITorsionalConstant();
             constants["Iw"] = profile.IWarpingConstant();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #663 

<!-- Add short description of what has been fixed -->
Adding integrate method for section profile, centring all sections around the global origin. Changed the SteelSectionFromProfile and ConcreteSectionFromProfile to call this method instead.



### Test files
<!-- Link to test files to validate the proposed changes -->
[Section Curve Alignment.zip](https://github.com/BHoM/BHoM_Engine/files/2868662/Section.Curve.Alignment.zip)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->