### PR TITLE
Geometry&Structure&Common_Engine-Issues831,832-PolyCurveAreaFix&DistributeOutlinesMigration

### DIFF
--- a/Common_Engine/Common_Engine.csproj
+++ b/Common_Engine/Common_Engine.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\DistributeOutlines.cs" />
     <Compile Include="Create\ConstructionPhase.cs" />
     <Compile Include="Create\Material.cs" />
     <Compile Include="Create\NewElement0D.cs" />

--- a/Common_Engine/Compute/DistributeOutlines.cs
+++ b/Common_Engine/Compute/DistributeOutlines.cs
@@ -1,0 +1,107 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.oM.Common;
+using BH.oM.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Common
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static List<List<List<IElement1D>>> DistributeOutlines(this List<List<IElement1D>> outlines, double tolerance = Tolerance.Distance)
+        {
+            List<Tuple<PolyCurve, List<IElement1D>>> outlineCurves = new List<Tuple<PolyCurve, List<IElement1D>>>();
+            foreach (List<IElement1D> outline in outlines)
+            {
+                PolyCurve outlineCurve = new PolyCurve { Curves = outline.Select(x => x.IGeometry()).ToList() };
+                outlineCurves.Add(new Tuple<PolyCurve, List<IElement1D>>(outlineCurve, outline));
+            }
+            
+            outlineCurves.Sort(delegate (Tuple<PolyCurve, List<IElement1D>> t1, Tuple<PolyCurve, List<IElement1D>> t2)
+            {
+                return t1.Item1.Area().CompareTo(t2.Item1.Area());
+            });
+            outlineCurves.Reverse();
+
+            List<Tuple<PolyCurve, List<IElement1D>, bool>> outlinesByType = new List<Tuple<PolyCurve, List<IElement1D>, bool>>();
+            foreach (Tuple<PolyCurve, List<IElement1D>> o in outlineCurves)
+            {
+                bool assigned = false;
+                for (int i = outlinesByType.Count - 1; i >= 0; i--)
+                {
+                    if (outlinesByType[i].Item1.IsContaining(o.Item1, true, tolerance))
+                    {
+                        outlinesByType.Add(new Tuple<PolyCurve, List<IElement1D>, bool>(o.Item1, o.Item2, !outlinesByType[i].Item3));
+                        assigned = true;
+                        break;
+                    }
+                }
+
+                if (!assigned)
+                    outlinesByType.Add(new Tuple<PolyCurve, List<IElement1D>, bool>(o.Item1, o.Item2, true));
+            }
+
+            List<Tuple<PolyCurve, List<IElement1D>>> panelOutlines = outlinesByType.Where(x => x.Item3 == true).Select(x => new Tuple<PolyCurve, List<IElement1D>>(x.Item1, x.Item2)).ToList();
+            List<Tuple<PolyCurve, List<IElement1D>>> panelOpenings = outlinesByType.Where(x => x.Item3 == false).Select(x => new Tuple<PolyCurve, List<IElement1D>>(x.Item1, x.Item2)).ToList();
+            return panelOutlines.DistributeOpenings(panelOpenings, tolerance);
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static List<List<List<IElement1D>>> DistributeOpenings(this List<Tuple<PolyCurve, List<IElement1D>>> panels, List<Tuple<PolyCurve, List<IElement1D>>> openings, double tolerance = Tolerance.Distance)
+        {
+            List<List<Tuple<PolyCurve, List<IElement1D>>>> result = new List<List<Tuple<PolyCurve, List<IElement1D>>>>();
+            foreach (Tuple<PolyCurve, List<IElement1D>> panel in panels)
+            {
+                result.Add(new List<Tuple<PolyCurve, List<IElement1D>>> { panel });
+            }
+            result.Reverse();
+
+            foreach (Tuple<PolyCurve, List<IElement1D>> opening in openings)
+            {
+                for (int i = 0; i < result.Count; i++)
+                {
+                    if (result[i][0].Item1.IsContaining(opening.Item1, true, tolerance))
+                    {
+                        result[i].Add(opening);
+                        break;
+                    }
+                }
+            }
+
+            return result.Select(x => x.Select(y => y.Item2).ToList()).ToList();
+        }
+
+        /***************************************************/
+    }
+}

--- a/Common_Engine/Compute/DistributeOutlines.cs
+++ b/Common_Engine/Compute/DistributeOutlines.cs
@@ -78,8 +78,9 @@ namespace BH.Engine.Common
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static List<List<List<IElement1D>>> DistributeOpenings(this List<Tuple<PolyCurve, List<IElement1D>>> panels, List<Tuple<PolyCurve, List<IElement1D>>> openings, double tolerance = Tolerance.Distance)
+        private static List<List<List<IElement1D>>> DistributeOpenings(this List<Tuple<PolyCurve, List<IElement1D>>> panels, List<Tuple<PolyCurve, List<IElement1D>>> openings, double tolerance)
         {
+            double sqTolerance = tolerance * tolerance;
             List<List<Tuple<PolyCurve, List<IElement1D>>>> result = new List<List<Tuple<PolyCurve, List<IElement1D>>>>();
             foreach (Tuple<PolyCurve, List<IElement1D>> panel in panels)
             {
@@ -91,7 +92,7 @@ namespace BH.Engine.Common
             {
                 for (int i = 0; i < result.Count; i++)
                 {
-                    if (result[i][0].Item1.IsContaining(opening.Item1, true, tolerance))
+                    if (result[i][0].Item1.IsContaining(opening.Item1, true, tolerance) && result[i][0].Item1.Area() - opening.Item1.Area() > sqTolerance)
                     {
                         result[i].Add(opening);
                         break;

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -21,6 +21,7 @@
  */
 
 using System.Collections.Generic;
+using BH.oM.Reflection.Attributes;
 using BH.oM.Geometry;
 using System;
 using System.Linq;
@@ -33,6 +34,7 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [DeprecatedAttribute("Moved to Common_Engine")]
         public static List<List<Polyline>> DistributeOutlines(this List<Polyline> outlines, double tolerance = Tolerance.Distance)
         {
             foreach (Polyline p in outlines)
@@ -72,6 +74,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [DeprecatedAttribute("Moved to Common_Engine")]
         public static List<List<ICurve>> DistributeOutlines(this List<ICurve> outlines, double tolerance = Tolerance.Distance)
         {
             foreach (ICurve p in outlines)
@@ -113,6 +116,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods                           ****/
         /***************************************************/
 
+        [DeprecatedAttribute("Moved to Common_Engine")]
         private static List<List<Polyline>> DistributeOpenings(this List<Polyline> panels, List<Polyline> openings, double tolerance = Tolerance.Distance)
         {
             List<List<Polyline>> result = new List<List<Polyline>>();
@@ -139,6 +143,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [DeprecatedAttribute("Moved to Common_Engine")]
         private static List<List<PolyCurve>> DistributeOpenings(this List<PolyCurve> panels, List<PolyCurve> openings, double tolerance = Tolerance.Distance)
         {
             List<List<PolyCurve>> result = new List<List<PolyCurve>>();
@@ -165,6 +170,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [DeprecatedAttribute("Moved to Common_Engine")]
         private static List<List<ICurve>> DistributeOpenings(this List<ICurve> panels, List<ICurve> openings, double tolerance = Tolerance.Distance)
         {
             List<List<ICurve>> result = new List<List<ICurve>>();

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -64,10 +64,13 @@ namespace BH.Engine.Geometry
 
         public static double Area(this PolyCurve curve)
         {
+            if (curve.Curves.Count == 1 && curve.Curves[0] is Circle)
+                return (curve.Curves[0] as Circle).Area();
+
             if (!curve.IsClosed())
                 return 0;
-            Plane p = curve.FitPlane();
 
+            Plane p = curve.FitPlane();
             if (p == null)
                 return 0.0;              // points are collinear
             

--- a/Structure_Engine/Create/PanelPlanar.cs
+++ b/Structure_Engine/Create/PanelPlanar.cs
@@ -97,13 +97,13 @@ namespace BH.Engine.Structure
             {
                 PanelPlanar panel = new PanelPlanar();
                 panel = panel.SetOutlineElements1D(panelOutlines[0]);
-                List<IElement2D> openings = new List<IElement2D>();
+                List<Opening> openings = new List<Opening>();
                 foreach (List<IElement1D> p in panelOutlines.Skip(1))
                 {
-                    IElement2D opening = (panel.NewInternalElement2D() as Opening).SetOutlineElements1D(p);
+                    Opening opening = (new Opening()).SetOutlineElements1D(p);
                     openings.Add(opening);
                 }
-                panel = panel.SetInternalElements2D(openings);
+                panel.Openings = openings;
                 panel.Property = property;
                 panel.Name = name;
                 result.Add(panel);

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -163,6 +163,10 @@
       <Project>{1ad45c88-dd54-48e5-951f-55edfeb70e35}</Project>
       <Name>BHoM_Engine</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Common_Engine\Common_Engine.csproj">
+      <Project>{8d8cd66f-76f3-4750-936d-380d51bc67d6}</Project>
+      <Name>Common_Engine</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Geometry_Engine\Geometry_Engine.csproj">
       <Project>{89ab2dcb-ef87-4cba-b59c-c16a8a71d333}</Project>
       <Name>Geometry_Engine</Name>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #831  #832 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->

Test files is located [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Geometry%26Structure%26Common_Engine-Issues831,832?csf=1&e=mewNjU). BTW, @IsakNaslundBh why is there no `Create.PanelPlanar` test? Weird, as all others are in place ❔ Would be fantastic if you could give it a proper stress-test.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

Small fix to `Area(PolyCurve)`.

`DistributeOutlines` method has been migrated from Geometry_Engine to Common_Engine, which will allow using it in other projects more efficiently. PanelPlanar constructor headers stay the same, only the body changed. All previous methods related to `DistributeOutlines` have been deprecated.


### Additional comments
<!-- As required -->

## PLEASE REVIEW & MERGE QUICKLY AS THIS PR BLOCKS 3 PROJECTS