### PR TITLE
Reflection_Engine - Warning message for set property

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -72,14 +72,13 @@ namespace BH.Engine.Reflection
             }
             else if(obj is IBHoMObject)
             {
+                IBHoMObject bhomObj = obj as IBHoMObject;
+                if (bhomObj == null) return false;
 
-                IBHoMObject cust = obj as IBHoMObject;
-                if (cust == null) return false;
+                if(!(bhomObj is CustomObject))
+                    Compute.RecordWarning("The objects does not contain any property with the name " + propName +". The value is being set as custom data");
 
-                // This was more annoying than useful
-                //Compute.RecordWarning("No property with the provided name found. The value is being set as custom data");
-
-                cust.CustomData[propName] = value;
+                bhomObj.CustomData[propName] = value;
                 return true;
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #835

<!-- Add short description of what has been fixed -->

Adding warning message if property is set to custom data and the object worked on is not a custom object

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Reflection_Engine/Reflection_Engine-Issue835-SetPropertyWarnings.gh?csf=1&e=65IhPI
