### PR TITLE
Structure_Engine: Adding Geometry() method To PanelPlanar

### DIFF
--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -23,6 +23,7 @@
 using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Properties.Section;
+using BH.Engine.Common;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -58,6 +59,16 @@ namespace BH.Engine.Structure
         public static IGeometry Geometry(this PanelFreeForm contour)
         {
             return contour.Surface;
+        }
+
+        /***************************************************/
+
+        public static IGeometry Geometry(this PanelPlanar panel)
+        {
+            return Engine.Geometry.Create.PlanarSurface(
+                Engine.Geometry.Modify.IJoin(panel.ExternalEdges.Select(x => x.Curve).ToList()).FirstOrDefault(),
+                panel.Openings.SelectMany(x => Engine.Geometry.Modify.IJoin(x.Edges.Select(y => y.Curve).ToList())).Cast<ICurve>().ToList()
+            );
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #859 

<!-- Add short description of what has been fixed -->
Adding Geometry() method to the PanelPlanar returning a PlanarSurface

### Test files
<!-- Link to test files to validate the proposed changes -->

All panels should now automatically display their centre plane geometry, so any GH script using PanelPlanar should work for testing this.

Also, see simple script here:

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Structure_Engine/Structure_Engine-Issue859-GeometryForPanelPlanar?csf=1&e=2LqibL

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

#### Added:
- Geometry() method added for PanelPlanar automatically displaying its geometry in GH

### Additional comments
<!-- As required -->

![image](https://user-images.githubusercontent.com/22005920/54279228-d440be80-4594-11e9-9a7a-ee701d26ded6.png)
