### PR TITLE
Geometry engine issues 343, 637 centroid and normal of a curve

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Modify\Scale.cs" />
     <Compile Include="Modify\SplitAtPoints.cs" />
     <Compile Include="Query\BasisFunction.cs" />
+    <Compile Include="Query\Centroid.cs" />
     <Compile Include="Query\CurveIntersections.cs" />
     <Compile Include="Query\CurveProximity.cs" />
     <Compile Include="Query\Geometry.cs" />

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -179,8 +179,7 @@ namespace BH.Engine.Geometry
 
             return area;
         }
-
-
+        
 
         /***************************************************/
         /**** Public Methods - Interfaces               ****/

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -169,6 +169,20 @@ namespace BH.Engine.Geometry
 
 
         /***************************************************/
+        /**** Public Methods - Vectors                  ****/
+        /***************************************************/
+
+        public static double Area(this Vector v1, Vector v2)
+        {
+            double area = 0;
+            area = Length(CrossProduct(v1, v2)) / 2;
+
+            return area;
+        }
+
+
+
+        /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -110,7 +110,6 @@ namespace BH.Engine.Geometry
 
         }
 
-
         /***************************************************/
 
         public static Point Centroid(this PolyCurve curve)
@@ -226,32 +225,28 @@ namespace BH.Engine.Geometry
             return new Point { X = xc, Y = yc, Z = zc };
 
         }
-
-
+        
         /***************************************************/
 
         public static Point Centroid(this Ellipse ellipse)
         {
             return ellipse.Centre;
         }
-
-        
+                
         /***************************************************/
 
         public static Point Centroid(this Circle circle)
         {
             return circle.Centre;
         }
-
-
+        
         /***************************************************/
 
         public static Point Centroid(this Line line)
         {
             return line.PointAtParameter(0.5);
         }
-
-
+        
         /***************************************************/
 
         [NotImplemented]
@@ -259,14 +254,15 @@ namespace BH.Engine.Geometry
         {
             throw new NotImplementedException();
         }
-                
-       
+        
+        /***************************************************/
+
         [NotImplemented]
         public static Point Centroid(this NurbsCurve nurbsCurve)
         {
             throw new NotImplementedException();
         }
-
+        
         /***************************************************/
         /**** Private methods                           ****/
         /***************************************************/
@@ -283,10 +279,7 @@ namespace BH.Engine.Geometry
 
             return o + ((v / arc.Radius) * length);
         }
-
-        /***************************************************/
-
-        
+                       
         /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
@@ -296,6 +289,6 @@ namespace BH.Engine.Geometry
                 return Centroid(curve as dynamic);
             }
 
-            /***************************************************/
+        /***************************************************/
     }
 }

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -1,0 +1,229 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using BH.Engine.Reflection;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Query
+    {
+
+        /***************************************************/
+        /**** Public Methods - Curves                   ****/
+        /***************************************************/
+
+        public static Point Centroid(this Polyline curve)
+        {
+            if (!curve.IsPlanar())
+            {
+                Reflection.Compute.RecordError("Input must be planar.");
+                return null;
+            }
+            else if (!curve.IsClosed())
+            {
+                Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
+                return null;
+            }
+            else if (curve.IsSelfIntersecting())
+            {
+                Reflection.Compute.RecordWarning("Curve is self intersecting");
+                return null;
+            }
+
+
+            double xc, yc, zc;
+            double xc0 = 0, yc0 = 0, zc0 = 0;
+
+            Point pA = curve.ControlPoints[0];
+            Point pB0 = curve.ControlPoints[1];
+            Point pC0 = curve.ControlPoints[2];
+
+            for (int i = 1; i < curve.ControlPoints.Count - 2; i++)
+            {
+
+                Point pB = curve.ControlPoints[i];
+                Point pC = curve.ControlPoints[i + 1];
+                double triangleArea = Area(pB - pA, pC - pA);
+
+                if (DotProduct(CrossProduct(pB - pA, pC - pA), CrossProduct(pB0 - pA, pC0 - pA)) < 0)
+                {
+                    xc0 -= ((pA.X + pB.X + pC.X) / 3) * triangleArea;
+                    yc0 -= ((pA.Y + pB.Y + pC.Y) / 3) * triangleArea;
+                    zc0 -= ((pA.Z + pB.Z + pC.Z) / 3) * triangleArea;
+                }else
+                {
+                    xc0 += ((pA.X + pB.X + pC.X) / 3) * triangleArea;
+                    yc0 += ((pA.Y + pB.Y + pC.Y) / 3) * triangleArea;
+                    zc0 += ((pA.Z + pB.Z + pC.Z) / 3) * triangleArea;
+                }
+            }
+
+
+            xc = xc0 / Area(curve);
+            yc = yc0 / Area(curve);
+            zc = zc0 / Area(curve);
+
+
+            return new Point { X = xc, Y = yc, Z = zc };
+
+        }
+
+
+        /***************************************************/
+
+        public static Point Centroid(this PolyCurve curve)
+        {
+            if (!curve.IsPlanar())
+            {
+                Reflection.Compute.RecordError("Input must be planar.");
+                return null;
+            }
+            else if (!curve.IsClosed())
+            {
+                Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
+                return null;
+            }
+            else if (curve.IsSelfIntersecting())
+            {
+                Reflection.Compute.RecordWarning("Curve is self intersecting");
+                return null;
+            }
+            
+            double xc, yc, zc;
+            double xc0 = 0, yc0 = 0, zc0 = 0;
+
+            Vector normal = Normal(curve);
+
+            List<Point> pts = new List<Point> { curve.Curves[0].IStartPoint() };
+            foreach (ICurve crv in curve.SubParts())
+            {
+                if (crv is Line)
+                    pts.Add((crv as Line).End);
+                else if (crv is Arc)
+                    pts.Add(crv.IEndPoint());
+                else
+                    throw new NotImplementedException();
+            }
+
+            Point pA = pts[0];
+            Point pB0 = pts[1];
+            Point pC0 = pts[2];
+
+            Vector firstNormal;
+
+            firstNormal = CrossProduct(pB0 - pA, pC0 - pA);
+
+            Boolean dir = DotProduct(normal, firstNormal) > 0;
+
+            for (int i = 1; i < pts.Count - 2; i++)
+            {
+
+                Point pB = pts[i];
+                Point pC = pts[i + 1];
+
+                double triangleArea = Area(pB - pA, pC - pA);
+
+                if (DotProduct(CrossProduct(pB - pA, pC - pA), firstNormal) > 0)
+                {
+                    xc0 += ((pA.X + pB.X + pC.X) / 3) * triangleArea;
+                    yc0 += ((pA.Y + pB.Y + pC.Y) / 3) * triangleArea;
+                    zc0 += ((pA.Z + pB.Z + pC.Z) / 3) * triangleArea;
+                }
+                else
+                {
+                    xc0 -= ((pA.X + pB.X + pC.X) / 3) * triangleArea;
+                    yc0 -= ((pA.Y + pB.Y + pC.Y) / 3) * triangleArea;
+                    zc0 -= ((pA.Z + pB.Z + pC.Z) / 3) * triangleArea;
+                }
+            }
+
+            foreach (ICurve crv in curve.Curves)
+            {
+                if (crv is Arc)
+                {
+                    double alpha = (crv as Arc).EndAngle - (crv as Arc).StartAngle;
+                    double area = (Math.Pow((crv as Arc).Radius, 2) / 2) * (alpha - Math.Sin(alpha));
+
+                    Point p1 = crv.IStartPoint();
+                    Point p2 = PointAtParameter(crv as Arc, 0.5);
+                    Point p3 = crv.IEndPoint();
+
+                    Point arcCentr = circularSegmentCentroid(crv as Arc);
+
+                    if (DotProduct(CrossProduct(p2 - p1, p3 - p1), firstNormal) > 0)
+                    {
+                        xc0 += arcCentr.X * area;
+                        yc0 += arcCentr.Y * area;
+                        zc0 += arcCentr.Z * area;    
+                    }
+                    else
+                    {
+                        xc0 -= arcCentr.X * area;
+                        yc0 -= arcCentr.Y * area;
+                        zc0 -= arcCentr.Z * area;                                        
+                    }
+                }
+            }
+
+
+            if (!dir)
+            {
+                xc0 = -xc0;
+                yc0 = -yc0;
+                zc0 = -zc0;
+            }
+
+            double curveArea = curve.Area();
+
+            xc = xc0 / curveArea;
+            yc = yc0 / curveArea;
+            zc = zc0 / curveArea;
+
+            return new Point { X = xc, Y = yc, Z = zc };
+
+        }
+
+
+        /***************************************************/
+        /**** Private methods                           ****/
+        /***************************************************/
+
+        private static Point circularSegmentCentroid(this Arc arc)
+        {
+            Point o = arc.CoordinateSystem.Origin;
+            double alpha = arc.EndAngle - arc.StartAngle;
+            Point mid = PointAtParameter(arc, 0.5);
+
+            Vector v = mid - o;
+
+            Double length = (4 * arc.Radius * Math.Pow(Math.Sin(alpha / 2),3)) / (3 * (alpha - Math.Sin(alpha)));
+
+            return o + ((v / arc.Radius) * length);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System;
 using BH.Engine.Reflection;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Geometry
 {
@@ -130,9 +131,9 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-           List<ICurve> curveSubParts = curve.SubParts();
-        
-           List<Point> pts = new List<Point> { curveSubParts[0].IStartPoint() };
+            List<ICurve> curveSubParts = curve.SubParts();
+
+            List<Point> pts = new List<Point> { curveSubParts[0].IStartPoint() };
             foreach (ICurve crv in curveSubParts)
             {
                 if (crv is Line)
@@ -197,13 +198,13 @@ namespace BH.Engine.Geometry
                     {
                         xc0 += arcCentr.X * area;
                         yc0 += arcCentr.Y * area;
-                        zc0 += arcCentr.Z * area;    
+                        zc0 += arcCentr.Z * area;
                     }
                     else
                     {
                         xc0 -= arcCentr.X * area;
                         yc0 -= arcCentr.Y * area;
-                        zc0 -= arcCentr.Z * area;                                        
+                        zc0 -= arcCentr.Z * area;
                     }
                 }
             }
@@ -227,6 +228,37 @@ namespace BH.Engine.Geometry
         }
 
 
+        [NotImplemented]
+        public static Point Centroid(this Ellipse ellipse)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        public static Point Centroid(this Arc arc)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        public static Point Centroid(this Circle circle)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        public static Point Centroid(this Line line)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        public static Point Centroid(this NurbsCurve nurbsCurve)
+        {
+            throw new NotImplementedException();
+        }
+
+
         /***************************************************/
         /**** Private methods                           ****/
         /***************************************************/
@@ -239,24 +271,23 @@ namespace BH.Engine.Geometry
 
             Vector v = mid - o;
 
-            Double length = (4 * arc.Radius * Math.Pow(Math.Sin(alpha / 2),3)) / (3 * (alpha - Math.Sin(alpha)));
+            Double length = (4 * arc.Radius * Math.Pow(Math.Sin(alpha / 2), 3)) / (3 * (alpha - Math.Sin(alpha)));
 
             return o + ((v / arc.Radius) * length);
         }
 
         /***************************************************/
 
-
+        
         /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 
         public static Point ICentroid(this ICurve curve)
-        {
-            return Centroid(curve as dynamic);
-        }
+            {
+                return Centroid(curve as dynamic);
+            }
 
-        /***************************************************/
-
+            /***************************************************/
     }
 }

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -129,9 +129,11 @@ namespace BH.Engine.Geometry
                 Reflection.Compute.RecordWarning("Curve is self intersecting");
                 return null;
             }
-            
-           List<Point> pts = new List<Point> { curve.Curves[0].IStartPoint() };
-            foreach (ICurve crv in curve.SubParts())
+
+           List<ICurve> curveSubParts = curve.SubParts();
+        
+           List<Point> pts = new List<Point> { curveSubParts[0].IStartPoint() };
+            foreach (ICurve crv in curveSubParts)
             {
                 if (crv is Line)
                     pts.Add((crv as Line).End);
@@ -178,7 +180,7 @@ namespace BH.Engine.Geometry
                 }
             }
 
-            foreach (ICurve crv in curve.Curves)
+            foreach (ICurve crv in curveSubParts)
             {
                 if (crv is Arc)
                 {
@@ -189,7 +191,7 @@ namespace BH.Engine.Geometry
                     Point p2 = PointAtParameter(crv as Arc, 0.5);
                     Point p3 = crv.IEndPoint();
 
-                    Point arcCentr = circularSegmentCentroid(crv as Arc);
+                    Point arcCentr = CircularSegmentCentroid(crv as Arc);
 
                     if (DotProduct(CrossProduct(p2 - p1, p3 - p1), firstNormal) > 0)
                     {
@@ -229,7 +231,7 @@ namespace BH.Engine.Geometry
         /**** Private methods                           ****/
         /***************************************************/
 
-        private static Point circularSegmentCentroid(this Arc arc)
+        private static Point CircularSegmentCentroid(this Arc arc)
         {
             Point o = arc.CoordinateSystem.Origin;
             double alpha = arc.EndAngle - arc.StartAngle;
@@ -243,5 +245,18 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
+
+
+        /***************************************************/
+        /**** Public Methods - Interfaces               ****/
+        /***************************************************/
+
+        public static Point ICentroid(this ICurve curve)
+        {
+            return Centroid(curve as dynamic);
+        }
+
+        /***************************************************/
+
     }
 }

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -228,36 +228,44 @@ namespace BH.Engine.Geometry
         }
 
 
-        [NotImplemented]
+        /***************************************************/
+
         public static Point Centroid(this Ellipse ellipse)
         {
-            throw new NotImplementedException();
+            return ellipse.Centre;
         }
+
+        
+        /***************************************************/
+
+        public static Point Centroid(this Circle circle)
+        {
+            return circle.Centre;
+        }
+
+
+        /***************************************************/
+
+        public static Point Centroid(this Line line)
+        {
+            return line.PointAtParameter(0.5);
+        }
+
+
+        /***************************************************/
 
         [NotImplemented]
         public static Point Centroid(this Arc arc)
         {
             throw new NotImplementedException();
         }
-
-        [NotImplemented]
-        public static Point Centroid(this Circle circle)
-        {
-            throw new NotImplementedException();
-        }
-
-        [NotImplemented]
-        public static Point Centroid(this Line line)
-        {
-            throw new NotImplementedException();
-        }
-
+                
+       
         [NotImplemented]
         public static Point Centroid(this NurbsCurve nurbsCurve)
         {
             throw new NotImplementedException();
         }
-
 
         /***************************************************/
         /**** Private methods                           ****/

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -88,8 +88,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
         /**** Public Methods - Curves                   ****/
         /***************************************************/
-
-
+        
         public static Vector Normal(this Polyline curve)
         {
 
@@ -181,15 +180,13 @@ namespace BH.Engine.Geometry
             return normal.Normalise();
         }
 
-
         /***************************************************/
 
         public static Vector Normal(this Circle circle)
         {
             return circle.Normal;
         }
-
-
+        
         /***************************************************/
 
         public static Vector Normal(this Ellipse ellipse)
@@ -198,7 +195,6 @@ namespace BH.Engine.Geometry
             return normal;
         }
 
-
         /***************************************************/
 
         [NotImplemented]
@@ -206,28 +202,31 @@ namespace BH.Engine.Geometry
         {
             throw new NotImplementedException();
         }
+        
+        /***************************************************/
 
         [NotImplemented]
         public static Vector Normal(this Arc arc)
         {
             throw new NotImplementedException();
         }
-        
+
+        /***************************************************/
+
         [NotImplemented]
         public static Vector Normal(this Line line)
         {
             throw new NotImplementedException();
         }
+        
+        /***************************************************/
 
         [NotImplemented]
         public static Vector Normal(this NurbsCurve nurbsCurve)
         {
             throw new NotImplementedException();
         }
-
-
-        /***************************************************/
-
+        
         /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -190,6 +190,36 @@ namespace BH.Engine.Geometry
             throw new NotImplementedException();
         }
 
+        [NotImplemented]
+        public static Point Normal(this Ellipse ellipse)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        public static Point Normal(this Arc arc)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        public static Point Normal(this Circle circle)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        public static Point Normal(this Line line)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        public static Point Normal(this NurbsCurve nurbsCurve)
+        {
+            throw new NotImplementedException();
+        }
+
         /***************************************************/
 
 

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -149,24 +149,16 @@ namespace BH.Engine.Geometry
 
             List<Point> pts = new List<Point> { curve.Curves[0].IStartPoint() };
 
-            foreach (ICurve crv in curve.Curves)
+            foreach (ICurve crv in curve.ISubParts())
             {
                 if (crv is Line)
-                {
                     pts.Add((crv as Line).End);
-                }
                 else if (crv is Arc)
                 {
-
                     int numb = 4;
-
                     List<Point> aPts = crv.SamplePoints(numb);
-
                     for (int i = 1; i < aPts.Count; i++)
-                    {
                         pts.Add(aPts[i]);
-
-                    }
                 }
                 else
                 {
@@ -196,6 +188,18 @@ namespace BH.Engine.Geometry
         public static List<Vector> Normals(this ISurface surface)
         {
             throw new NotImplementedException();
+        }
+
+        /***************************************************/
+
+
+        /***************************************************/
+        /**** Public Methods - Interfaces               ****/
+        /***************************************************/
+
+        public static Vector INormal(this ICurve curve)
+        {
+            return Normal(curve as dynamic);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -184,6 +184,23 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static Vector Normal(this Circle circle)
+        {
+            return circle.Normal;
+        }
+
+
+        /***************************************************/
+
+        public static Vector Normal(this Ellipse ellipse)
+        {
+            Vector normal = (ellipse.Axis1).CrossProduct(ellipse.Axis2);
+            return normal;
+        }
+
+
+        /***************************************************/
+
         [NotImplemented]
         public static List<Vector> Normals(this ISurface surface)
         {
@@ -191,37 +208,25 @@ namespace BH.Engine.Geometry
         }
 
         [NotImplemented]
-        public static Point Normal(this Ellipse ellipse)
+        public static Vector Normal(this Arc arc)
+        {
+            throw new NotImplementedException();
+        }
+        
+        [NotImplemented]
+        public static Vector Normal(this Line line)
         {
             throw new NotImplementedException();
         }
 
         [NotImplemented]
-        public static Point Normal(this Arc arc)
+        public static Vector Normal(this NurbsCurve nurbsCurve)
         {
             throw new NotImplementedException();
         }
 
-        [NotImplemented]
-        public static Point Normal(this Circle circle)
-        {
-            throw new NotImplementedException();
-        }
-
-        [NotImplemented]
-        public static Point Normal(this Line line)
-        {
-            throw new NotImplementedException();
-        }
-
-        [NotImplemented]
-        public static Point Normal(this NurbsCurve nurbsCurve)
-        {
-            throw new NotImplementedException();
-        }
 
         /***************************************************/
-
 
         /***************************************************/
         /**** Public Methods - Interfaces               ****/

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -86,6 +86,111 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
+        /**** Public Methods - Curves                   ****/
+        /***************************************************/
+
+
+        public static Vector Normal(this Polyline curve)
+        {
+
+            if (!curve.IsPlanar())
+            {
+                Reflection.Compute.RecordError("Input must be planar.");
+                return null;
+            }
+            else if (!curve.IsClosed())
+            {
+                Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
+                return null;
+            }
+            else if (curve.IsSelfIntersecting())
+            {
+                Reflection.Compute.RecordWarning("Curve is self intersecting");
+                return null;
+            }
+
+            Vector normal = new Vector { X = 0, Y = 0, Z = 0 };
+
+            for (int i = 0; i < curve.ControlPoints.Count - 1; i++)
+            {
+                Point pA = curve.ControlPoints[i];
+                Point pB = curve.ControlPoints[i + 1];
+                Point pC = curve.ControlPoints[(i + 2) % curve.ControlPoints.Count];
+
+                normal += CrossProduct(pB - pA, pC - pB);
+            }
+
+            return normal.Normalise();
+        }
+
+        /***************************************************/
+
+        public static Vector Normal(this PolyCurve curve)
+        {
+
+            if (!curve.IsPlanar())
+            {
+                Reflection.Compute.RecordError("Input must be planar.");
+                return null;
+            }
+            else if (!curve.IsClosed())
+            {
+                Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
+                return null;
+            }
+            else if (curve.IsSelfIntersecting())
+            {
+                Reflection.Compute.RecordWarning("Curve is self intersecting");
+                return null;
+            }
+
+
+            Vector normal = new Vector { X = 0, Y = 0, Z = 0 };
+
+            List<Point> pts = new List<Point> { curve.Curves[0].IStartPoint() };
+
+            foreach (ICurve crv in curve.Curves)
+            {
+                if (crv is Line)
+                {
+                    pts.Add((crv as Line).End);
+                }
+                else if (crv is Arc)
+                {
+
+                    int numb = 4;
+
+                    List<Point> aPts = crv.SamplePoints(numb);
+
+                    for (int i = 1; i < aPts.Count; i++)
+                    {
+                        pts.Add(aPts[i]);
+
+                    }
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            Point pA = pts[0];
+
+            for (int i = 1; i < pts.Count - 1; i++)
+            {
+                Point pB = pts[i];
+                Point pC = pts[i + 1];
+
+                normal += CrossProduct((pB - pA).Normalise(), (pC - pB).Normalise());
+                normal += CrossProduct(pB - pA, pC - pA);
+            }
+
+
+            return normal.Normalise();
+        }
+
+
+        /***************************************************/
 
         [NotImplemented]
         public static List<Vector> Normals(this ISurface surface)
@@ -96,3 +201,4 @@ namespace BH.Engine.Geometry
         /***************************************************/
     }
 }
+


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->



   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #343 
Closes #637

Adding methods centroid(polyline) calculating a center of mass of planar polyline and centroid(polycurve) for planar polycurve (consisting of arcs and lines only).

Adding methods for polylines and polycurves to Normal() calculating normal vector; always according to the right-hand rule.


### Test files
[Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssues343%2C637%2DCentroidAndNormalOfACurve) is the GH test file for both methods.


### Changelog
**Added:**

- Centroid(Polyline), Centroid(PolyCurve)
- Normal(Polyline), Normal(PolyCurve)



<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
There are some errors (less than 0,5% of tested samples) in Normal(PolyCurve) method. In my understanig of normal vector those are caused by GH. The code works fine.