### PR TITLE
Reflection entgine issue863 assembly url attribute

### DIFF
--- a/Reflection_Engine/Compute/OpenHelpPage.cs
+++ b/Reflection_Engine/Compute/OpenHelpPage.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Reflection;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Compute
+    {
+        /*******************************************/
+        /**** Public Methods                    ****/
+        /*******************************************/
+
+        public static void IOpenHelpPage(object obj)
+        {
+            if (obj == null)
+            {
+                return;
+            }
+            else if (obj is Type)
+            {
+                OpenHelpPage(obj as Type);
+            }
+            else if (obj is MethodBase)
+            {
+                OpenHelpPage(obj as MethodBase);
+            }
+            else
+            {
+                return;
+            }
+        }
+
+        /*******************************************/
+
+        public static void OpenHelpPage(Type type)
+        {
+            string url = "https://bhom.xyz";
+            if (type != null)
+            {
+                url = BH.Engine.Reflection.Query.Url(type) ?? url;
+            }
+
+            System.Diagnostics.Process.Start(url);
+        }
+
+        /*******************************************/
+
+        public static void OpenHelpPage(MethodBase method)
+        {
+            string url = "https://bhom.xyz";
+            if (method != null)
+            {
+                url = BH.Engine.Reflection.Query.Url(method) ?? url;
+            }
+
+            System.Diagnostics.Process.Start(url);
+        }
+
+        /*******************************************/
+    }
+}

--- a/Reflection_Engine/Query/Url.cs
+++ b/Reflection_Engine/Query/Url.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -31,35 +31,50 @@ namespace BH.Engine.Reflection
     public static partial class Query
     {
         /***************************************************/
-        /**** Public Methods                            ****/
+        /**** Interface Methods                         ****/
         /***************************************************/
 
         public static string IUrl(this object obj)
         {
             if (obj == null)
-                return "";
-
-            return Url(obj as dynamic);
+            {
+                return null;
+            }
+            else if (obj is Type)
+            {
+                return Url(obj as Type);
+            }
+            else if (obj is MethodBase)
+            {
+                return Url(obj as MethodBase);
+            }
+            else
+            {
+                return null;
+            }
         }
 
+
+        /***************************************************/
+        /**** Public Methods                            ****/
         /***************************************************/
 
         public static string Url(this Type type)
         {
             if (type == null)
-                return "";
+                return null;
 
             Assembly ass = type.Assembly;
             if (ass == null)
-                return "";
+                return null;
 
             AssemblyUrlAttribute att = ass.GetCustomAttribute<AssemblyUrlAttribute>();
             if (att == null)
-                return "";
+                return null;
 
             string url = att.Url;
             if (url == "")
-                return "";
+                return null;
 
             List<string> path = new List<string>() { url, "blob/master/" };
             path.Add(ass.GetName().Name);
@@ -79,19 +94,17 @@ namespace BH.Engine.Reflection
         public static string Url(this MethodBase method)
         {
             if (method == null)
-                return "";
+                return null;
 
             Assembly ass = method.DeclaringType.Assembly;
             if (ass == null)
-                return "";
+                return null;
 
             AssemblyUrlAttribute att = ass.GetCustomAttribute<AssemblyUrlAttribute>();
             if (att == null)
-                return "";
+                return null;
 
             string url = att.Url;
-            if (url == "")
-                return "";
 
             List<string> path = new List<string>() { url, "blob/master/" };
             path.Add(ass.GetName().Name);

--- a/Reflection_Engine/Query/Url.cs
+++ b/Reflection_Engine/Query/Url.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static string IUrl(this object obj)
+        {
+            if (obj == null)
+                return "";
+
+            return Url(obj as dynamic);
+        }
+
+        /***************************************************/
+
+        public static string Url(this Type type)
+        {
+            if (type == null)
+                return "";
+
+            Assembly ass = type.Assembly;
+            if (ass == null)
+                return "";
+
+            AssemblyUrlAttribute att = ass.GetCustomAttribute<AssemblyUrlAttribute>();
+            if (att == null)
+                return "";
+
+            string url = att.Url;
+            if (url == "")
+                return "";
+
+            List<string> path = new List<string>() { url, "blob/master/" };
+            path.Add(ass.GetName().Name);
+            path.AddRange(type.Namespace.Split('.').Skip(3));
+            if (type.IsEnum)
+                path.Add("Enums");
+            else if (type.IsInterface)
+                path.Add("Interface");
+            path.Add(type.Name + ".cs");
+            url = System.IO.Path.Combine(path.ToArray());
+
+            return url;
+        }
+
+        /***************************************************/
+
+        public static string Url(this MethodBase method)
+        {
+            if (method == null)
+                return "";
+
+            Assembly ass = method.DeclaringType.Assembly;
+            if (ass == null)
+                return "";
+
+            AssemblyUrlAttribute att = ass.GetCustomAttribute<AssemblyUrlAttribute>();
+            if (att == null)
+                return "";
+
+            string url = att.Url;
+            if (url == "")
+                return "";
+
+            List<string> path = new List<string>() { url, "blob/master/" };
+            path.Add(ass.GetName().Name);
+            path.AddRange(method.DeclaringType.Namespace.Split('.').Skip(3));
+            path.Add(method.DeclaringType.Name);
+            path.Add(method.Name + ".cs");
+            url = System.IO.Path.Combine(path.ToArray());
+
+            return url;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Reflection_Engine/Reflection_Engine.csproj
+++ b/Reflection_Engine/Reflection_Engine.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Query\OutputName.cs" />
     <Compile Include="Query\PropertyAbbreviation.cs" />
     <Compile Include="Query\UnderlyingType.cs" />
+    <Compile Include="Query\Url.cs" />
     <Compile Include="Query\UsedAssemblies.cs" />
     <Compile Include="Query\UsedNamespaces.cs" />
     <Compile Include="Query\InheritedTypes.cs" />

--- a/Reflection_Engine/Reflection_Engine.csproj
+++ b/Reflection_Engine/Reflection_Engine.csproj
@@ -89,6 +89,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compute\DeepDependencies.cs" />
+    <Compile Include="Compute\OpenHelpPage.cs" />
     <Compile Include="Compute\RecordEvent.cs" />
     <Compile Include="Compute\LoadAllAssemblies.cs" />
     <Compile Include="Compute\RunExtentionMethod.cs" />

--- a/Structure_Engine/Properties/AssemblyInfo.cs
+++ b/Structure_Engine/Properties/AssemblyInfo.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Reflection.Attributes;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -55,3 +56,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
 [assembly: AssemblyFileVersion("2.1.0.0")]
+
+// The web address where the code of this project is stored, usually a remote Git repository
+[assembly: AssemblyUrl("https://github.com/BHoM/BHoM_Engine")]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/436
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #863 

<!-- Add short description of what has been fixed -->
This code supports the functionality of the UI to open a webpage when clicking on the "help" of the component. It retrieves the url of the method or object from assembly and type info.

The query is based on the way we structure the files in the project, so if an object is not compliant - i.e. the file that contains it is not in the right place - the web page would report 404.

The `AssemblyUrl` attribute is the one used to store the info about the remote repo web address.
It sits in the Reflecion_oM, so one weakness of this is that all the projects that want to implement the functionality will have a dependency on the Reflection_oM. The alternative is to use attributes that already exist, such as `AssemblyProduct`.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->