### PR TITLE
Solves #878

### DIFF
--- a/Reflection_Engine/Query/Description.cs
+++ b/Reflection_Engine/Query/Description.cs
@@ -54,11 +54,38 @@ namespace BH.Engine.Reflection
         {
             IEnumerable<InputAttribute> inputDesc = parameter.Member.GetCustomAttributes<InputAttribute>().Where(x => x.Name == parameter.Name);
             if (inputDesc.Count() > 0)
+            {
                 return inputDesc.First().Description;
+            }
             else if (parameter.ParameterType != null)
-                return parameter.Name + " is a " + parameter.ParameterType.ToText();
+            {
+                if (parameter.ParameterType.IsInterface)
+                {
+                    Type type = parameter.ParameterType;
+                    string echo = $"This is a {type.ToText()}: ";
+
+                    List<Type> t = type.ImplementingTypes();
+                    int m = Math.Min(15, t.Count);
+
+                    for (int i = 0; i < m; i++)
+                        echo += $"{t[i].ToText()}, ";
+
+                    if (t.Count > m)
+                        echo += "and more...";
+                    else
+                        echo.Remove(echo.Length - 2, 2);
+
+                    return echo;
+                }
+                else
+                {
+                    return parameter.Name + " is a " + parameter.ParameterType.ToText();
+                }
+            }
             else
+            {
                 return "";
+            }
         }
 
         /***************************************************/
@@ -68,9 +95,30 @@ namespace BH.Engine.Reflection
         {
             DescriptionAttribute attribute = type.GetCustomAttribute<DescriptionAttribute>();
             if (attribute != null)
+            {
                 return attribute.Description;
+            }
+            else if (type.IsInterface)
+            {
+                string echo = $"This is a {type.ToText()}: ";
+
+                List<Type> t = type.ImplementingTypes();
+                int m = Math.Min(15, t.Count);
+
+                for (int i = 0; i < m; i++)
+                    echo += $"{t[i].ToText()}, ";
+
+                if (t.Count > m)
+                    echo += "and more...";
+                else
+                    echo.Remove(echo.Length - 2, 2);
+
+                return echo;
+            }
             else
+            {
                 return "This is a " + type.ToText();
+            }
         }
 
         /***************************************************/

--- a/Reflection_Engine/Query/Description.cs
+++ b/Reflection_Engine/Query/Description.cs
@@ -92,7 +92,7 @@ namespace BH.Engine.Reflection
                 if (t.Count > m)
                     echo += "and more...";
                 else
-                    echo.Remove(echo.Length - 2, 2);
+                    echo = echo.Remove(echo.Length - 2, 2);
 
                 return echo;
             }

--- a/Reflection_Engine/Query/Description.cs
+++ b/Reflection_Engine/Query/Description.cs
@@ -57,35 +57,11 @@ namespace BH.Engine.Reflection
             {
                 return inputDesc.First().Description;
             }
-            else if (parameter.ParameterType != null)
-            {
-                if (parameter.ParameterType.IsInterface)
-                {
-                    Type type = parameter.ParameterType;
-                    string echo = $"This is a {type.ToText()}: ";
-
-                    List<Type> t = type.ImplementingTypes();
-                    int m = Math.Min(15, t.Count);
-
-                    for (int i = 0; i < m; i++)
-                        echo += $"{t[i].ToText()}, ";
-
-                    if (t.Count > m)
-                        echo += "and more...";
-                    else
-                        echo.Remove(echo.Length - 2, 2);
-
-                    return echo;
-                }
-                else
-                {
-                    return parameter.Name + " is a " + parameter.ParameterType.ToText();
-                }
-            }
-            else
+            if (parameter.ParameterType == null)
             {
                 return "";
             }
+            return parameter.ParameterType.Description();
         }
 
         /***************************************************/
@@ -93,6 +69,11 @@ namespace BH.Engine.Reflection
         [Description("Return the custom description of a C# class")]
         public static string Description(this Type type)
         {
+            if (type == null)
+            {
+                return "";
+            }
+
             DescriptionAttribute attribute = type.GetCustomAttribute<DescriptionAttribute>();
             if (attribute != null)
             {
@@ -115,10 +96,8 @@ namespace BH.Engine.Reflection
 
                 return echo;
             }
-            else
-            {
-                return "This is a " + type.ToText();
-            }
+
+            return "This is a " + type.ToText();
         }
 
         /***************************************************/

--- a/Reflection_Engine/Query/ImplementedTypes.cs
+++ b/Reflection_Engine/Query/ImplementedTypes.cs
@@ -1,0 +1,55 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Returns all the loaded types that implement the specified interface.")]
+        public static List<Type> ImplementingTypes(this Type @interface)
+        {
+            if (!@interface.IsInterface)
+                return new List<Type>();
+
+            List<Type> implemented = new List<Type>();
+            foreach (Type t in BHoMTypeList())
+            {
+                if (@interface.IsAssignableFrom(t))
+                    implemented.Add(t);
+            }
+            return implemented;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Reflection_Engine/Reflection_Engine.csproj
+++ b/Reflection_Engine/Reflection_Engine.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Modify\Cast.cs" />
     <Compile Include="Query\CurrentAssemblyFolder.cs" />
     <Compile Include="Query\BHoMFolder.cs" />
+    <Compile Include="Query\ImplementedTypes.cs" />
     <Compile Include="Query\Item.cs" />
     <Compile Include="Query\OutputType.cs" />
     <Compile Include="Query\OutputAttributes.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #878

<!-- Add short description of what has been fixed -->
This PR changes the way `interface`s are described in the UIs, by appending all the types that implement the interface to the string.
For example:
If you have `ICurve`, the tooltip in the UI displays only "ICurve".
It now displays: "ICurve: Arc, Circle, Ellipse, Line, Polyline, Polycurve" and all the others I forgot to add.
If the number of types is more than 15, it stops and ends with "...and more".

NB. It does not work yet for lists where the generic type is an interface.


### Test files
<!-- Link to test files to validate the proposed changes -->
Hover on the parameters to get the description.
https://burohappold.sharepoint.com/:f:/s/BHoM/EpZu2DXIL1VGlms6O3XwBz4BZ6usNVH1NeF0FILz3bVy_A?e=cFUgFK

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->