### PR TITLE
Structure_Engine: Updating FramingELementProperties to handle non-linebased centreliens

### DIFF
--- a/Structure_Engine/Create/FramingElement.cs
+++ b/Structure_Engine/Create/FramingElement.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -23,6 +23,8 @@
 using BH.oM.Structure.Elements;
 using BH.oM.Structure.Properties.Framing;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Structure
 {
@@ -32,7 +34,19 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Deprecated("2.3", "Deprecated by method accepting a ICurve", null, "FramingElement")]
         public static FramingElement FramingElement(Line locationCurve, IFramingElementProperty property, StructuralUsage1D structuralUsage= StructuralUsage1D.Beam, string name = "")
+        {
+            return new FramingElement { LocationCurve = locationCurve, Property = property, StructuralUsage = structuralUsage, Name = name };
+        }
+
+        /***************************************************/
+        [Description("Creates a framing elements from a curve and a property")]
+        [Input("locationCurve", "The centreline curve of the framing element")]
+        [Input("property", "The property to be used on the framing element. The most simple version for this would be the ConstantFramingElementProperty, used for beams with constant section and rotation along the full element")]
+        [Input("structuralUsage", "Describes the usage of the element.")]
+        [Input("name", "The name of the element.")]
+        public static FramingElement FramingElement(ICurve locationCurve, IFramingElementProperty property, StructuralUsage1D structuralUsage = StructuralUsage1D.Beam, string name = "")
         {
             return new FramingElement { LocationCurve = locationCurve, Property = property, StructuralUsage = structuralUsage, Name = name };
         }

--- a/Structure_Engine/Create/FramingElementProperty.cs
+++ b/Structure_Engine/Create/FramingElementProperty.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -23,6 +23,8 @@
 using BH.oM.Structure.Properties.Framing;
 using BH.oM.Structure.Properties.Section;
 using BH.oM.Geometry;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Structure
 {
@@ -32,8 +34,16 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Constructs the simplest type of FramingELementProperty, with constant section proeprty along the element as well as a constant orientation angle along the element")]
+        [Input("sectionProperty", "The section property used by the element. Constant along the whole element")]
+        [Input("orientationAngle", "orientation angle of the element. Constant along the whole element")]
+        [Input("name", "Name of the ConstantFramingElementProeprty. If no name is provided, the name of the provided SectionProeprty will be used")]
         public static ConstantFramingElementProperty ConstantFramingElementProperty(ISectionProperty sectionProperty, double orientationAngle, string name = "")
         {
+            //If no name is provided, use the name of the section proeprty
+            if (string.IsNullOrWhiteSpace(name) && !string.IsNullOrWhiteSpace(sectionProperty.Name))
+                name = sectionProperty.Name;
+
             return new ConstantFramingElementProperty { SectionProperty = sectionProperty, OrientationAngle = orientationAngle, Name = name };
         }
 

--- a/Structure_Engine/Query/AnalyticalBars.cs
+++ b/Structure_Engine/Query/AnalyticalBars.cs
@@ -64,7 +64,7 @@ namespace BH.Engine.Structure
         {
             if (centreLine is NurbsCurve)
             {
-                Engine.Reflection.Compute.RecordError("The analytical bars method is currently not supported for NurbsCurves.");
+                Engine.Reflection.Compute.RecordError("The analytical bars method is currently not supported for NurbsCurves. Please use another method to split up the nurbs to polylines that can be used to construct the bars.");
                 return new List<Bar>();
             }
             return centreLine.ISubParts().SelectMany(x => x.ICollapseToPolyline(angleTolerance, maxNbBars).SubParts()).Select(x => Create.Bar(x, property.SectionProperty, property.OrientationAngle, Create.BarReleaseFixFix(), BarFEAType.Flexural, name)).ToList();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #802 

<!-- Add short description of what has been fixed -->
- Adding new Create method for FramingELement accepting ICurve isntead of just Line
- Deprecating old Create method for FramingElement
- Adding description for Create method for ConstantFramingElementProperty and taking name from SectionProperty if no name is provided
- Updating AnalyticalBars method to handle non-linear elements

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Structure_Engine/Structure_Engine-Issue802-UpdateFramingElementMethods?csf=1&e=CfEsTr