### PR TITLE
Structure_Engine-Issue887-MakeSetInternalElements2DNotReturnNull

### DIFF
--- a/Structure_Engine/Modify/SetInternalElements2D.cs
+++ b/Structure_Engine/Modify/SetInternalElements2D.cs
@@ -36,10 +36,7 @@ namespace BH.Engine.Structure
         public static Opening SetInternalElements2D(this Opening opening, List<IElement2D> internalElements2D)
         {
             if (internalElements2D.Count != 0)
-            {
                 Reflection.Compute.RecordError("Cannot set internal 2D elements to an opening.");
-                return null;
-            }
 
             return opening.GetShallowClone() as Opening;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #887  

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Cannot think of one 😸 But needed for the operations on the IElements2D.