### PR TITLE
Common_Engine-Issues886,889-RightHandNormalAndDistributeOutlinesFix

### DIFF
--- a/Common_Engine/Common_Engine.csproj
+++ b/Common_Engine/Common_Engine.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Query\Geometry.cs" />
     <Compile Include="Query\InternalElements2D.cs" />
     <Compile Include="Query\IsSelfIntersecting.cs" />
+    <Compile Include="Query\Normal.cs" />
     <Compile Include="Query\OutlineElements1D.cs" />
     <Compile Include="Query\OutlineCurve.cs" />
     <Compile Include="Query\ShearModulus.cs" />

--- a/Common_Engine/Common_Engine.csproj
+++ b/Common_Engine/Common_Engine.csproj
@@ -42,6 +42,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
     </Reference>
+    <Reference Include="Reflection_oM">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/Common_Engine/Compute/DistributeOutlines.cs
+++ b/Common_Engine/Compute/DistributeOutlines.cs
@@ -23,6 +23,7 @@
 using BH.Engine.Geometry;
 using BH.oM.Common;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,11 +32,11 @@ namespace BH.Engine.Common
 {
     public static partial class Compute
     {
-        /***************************************************/
-        /**** Public Methods                            ****/
-        /***************************************************/
+        /******************************************/
+        /****            IElement2D            ****/
+        /******************************************/
 
-        public static List<List<List<IElement1D>>> DistributeOutlines(this List<List<IElement1D>> outlines, double tolerance = Tolerance.Distance)
+        public static List<List<List<IElement1D>>> DistributeOutlines(this List<List<IElement1D>> outlines, bool canCutOpenings = true, double tolerance = Tolerance.Distance)
         {
             List<Tuple<PolyCurve, List<IElement1D>>> outlineCurves = new List<Tuple<PolyCurve, List<IElement1D>>>();
             foreach (List<IElement1D> outline in outlines)
@@ -58,7 +59,9 @@ namespace BH.Engine.Common
                 {
                     if (outlinesByType[i].Item1.IsContaining(o.Item1, true, tolerance))
                     {
-                        outlinesByType.Add(new Tuple<PolyCurve, List<IElement1D>, bool>(o.Item1, o.Item2, !outlinesByType[i].Item3));
+                        if (canCutOpenings || i == 0)
+                            outlinesByType.Add(new Tuple<PolyCurve, List<IElement1D>, bool>(o.Item1, o.Item2, !outlinesByType[i].Item3));
+
                         assigned = true;
                         break;
                     }
@@ -71,6 +74,14 @@ namespace BH.Engine.Common
             List<Tuple<PolyCurve, List<IElement1D>>> panelOutlines = outlinesByType.Where(x => x.Item3 == true).Select(x => new Tuple<PolyCurve, List<IElement1D>>(x.Item1, x.Item2)).ToList();
             List<Tuple<PolyCurve, List<IElement1D>>> panelOpenings = outlinesByType.Where(x => x.Item3 == false).Select(x => new Tuple<PolyCurve, List<IElement1D>>(x.Item1, x.Item2)).ToList();
             return panelOutlines.DistributeOpenings(panelOpenings, tolerance);
+        }
+
+        /***************************************************/
+
+        [DeprecatedAttribute("2.3", "Replaced with the same method taking an extra canCutOpenings argument.", null, "DistributeOutlines")]
+        public static List<List<List<IElement1D>>> DistributeOutlines(this List<List<IElement1D>> outlines, double tolerance = Tolerance.Distance)
+        {
+            return outlines.DistributeOutlines(true, tolerance);
         }
 
 

--- a/Common_Engine/Query/Normal.cs
+++ b/Common_Engine/Query/Normal.cs
@@ -1,0 +1,42 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.oM.Geometry;
+using System;
+
+namespace BH.Engine.Common
+{
+    public static partial class Query
+    {
+        /******************************************/
+        /****            IElement2D            ****/
+        /******************************************/
+
+        public static Vector Normal(this IElement2D element2D)
+        {
+            return element2D.IOutlineCurve().Normal();
+        }
+
+        /******************************************/
+    }
+}

--- a/Structure_Engine/Create/PanelPlanar.cs
+++ b/Structure_Engine/Create/PanelPlanar.cs
@@ -92,7 +92,7 @@ namespace BH.Engine.Structure
             List<PanelPlanar> result = new List<PanelPlanar>();
             List<List<IElement1D>> outlineEdges = outlines.Select(x => x.ISubParts().Select(y => new Edge { Curve = y } as IElement1D).ToList()).ToList();
             
-            List<List<List<IElement1D>>> sortedOutlines = outlineEdges.DistributeOutlines();
+            List<List<List<IElement1D>>> sortedOutlines = outlineEdges.DistributeOutlines(true);
             foreach (List<List<IElement1D>> panelOutlines in sortedOutlines)
             {
                 PanelPlanar panel = new PanelPlanar();


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #886 
Closes #889 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
No test file for the Normal method (I believe #872 should be enough), a DistributeOutlines test file is [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FBHoM_Engine%2FCommon_Engine%2FCommon_Engine-Issues886%2C889-RightHandNormalAndDistributeOutlinesFix) - this one should also be safe.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Added Normal method for an IElement2D + an extra argument that makes the `DistributeOutlines` method work correctly on the IElement2D that do not allow cutting holes.


### Additional comments
<!-- As required -->