### PR TITLE
Fixes #900 updated m_SourceFolder to use appdata

### DIFF
--- a/Library_Engine/Query/Libraries.cs
+++ b/Library_Engine/Query/Libraries.cs
@@ -208,7 +208,7 @@ namespace BH.Engine.Library
         /**** Private Fields                            ****/
         /***************************************************/
 
-        private static readonly string m_sourceFolder = @"C:\Users\" + Environment.UserName + @"\AppData\Roaming\BHoM\DataSets";
+        private static readonly string m_sourceFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), @"BHoM\DataSets");
 
         private static Dictionary<string, string[]> m_libraryStrings = new Dictionary<string, string[]>();
         private static Dictionary<string, List<IBHoMObject>> m_parsedLibrary = new Dictionary<string, List<IBHoMObject>>();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #900 

<!-- Add short description of what has been fixed -->
Updated m_SourceFolder in libraries.cs to use appdata instead of account username.
BHoM\DataSets Should now be found for everyone.