### PR TITLE
Geometry_engine-issues-880,896-SplitAtPoints-SortAlongCurve-Distance-etc

### DIFF
--- a/Geometry_Engine/Compute/SortAlongCurve.cs
+++ b/Geometry_Engine/Compute/SortAlongCurve.cs
@@ -34,18 +34,42 @@ namespace BH.Engine.Geometry
         /**** public Methods - Vectors                  ****/
         /***************************************************/
 
-        [NotImplemented]
-        public static List<Point> SortAlongCurve(this List<Point> points, Arc arc)
+        public static List<Point> SortAlongCurve(this List<Point> points, Arc arc, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
-            throw new NotImplementedException();
+            if (arc.Angle() <= angleTolerance)
+                return points.Select(p => p.Clone()).ToList();
+
+            Vector normal = arc.Normal();
+            Vector arcStartVector = arc.StartPoint() - arc.Centre();
+
+            List<Tuple<Point, double>> cData = points.Select(p => new Tuple<Point, double>(p.Clone(), (2 * Math.PI + arcStartVector.SignedAngle(p - arc.Centre(), normal)) % (2 * Math.PI))).ToList();
+
+            cData.Sort(delegate (Tuple<Point, double> d1, Tuple<Point, double> d2)
+            {
+                return d1.Item2.CompareTo(d2.Item2);
+            });
+
+            return cData.Select(d => d.Item1).ToList();
         }
 
         /***************************************************/
 
-        [NotImplemented]
-        public static List<Point> SortAlongCurve(this List<Point> points, Circle circle)
+        public static List<Point> SortAlongCurve(this List<Point> points, Circle circle, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
-            throw new NotImplementedException();
+            if (circle.Radius <= distanceTolerance)
+                return points.Select(p => p.Clone()).ToList();
+
+            Vector normal = circle.Normal();
+            Vector arcStartVector = circle.StartPoint() - circle.Centre;
+
+            List<Tuple<Point, double>> cData = points.Select(p => new Tuple<Point, double>(p.Clone(), (2 * Math.PI + arcStartVector.SignedAngle(p - circle.Centre, normal)) % (2 * Math.PI))).ToList();
+
+            cData.Sort(delegate (Tuple<Point, double> d1, Tuple<Point, double> d2)
+            {
+                return d1.Item2.CompareTo(d2.Item2);
+            });
+
+            return cData.Select(d => d.Item1).ToList();
         }
 
         /***************************************************/
@@ -102,18 +126,111 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
-        public static List<Point> SortAlongCurve(this List<Point> points, PolyCurve curve)
+        
+        public static List<Point> SortAlongCurve(this List<Point> points, PolyCurve curve, double tolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
-            throw new NotImplementedException();
+            List<Point> result = new List<Point>();
+            List<Point> tmpResult = new List<Point>();
+
+            foreach (Point pt in points)
+            {
+                if (pt.IsOnCurve(curve, tolerance))
+                    tmpResult.Add(pt);
+            }
+
+            tmpResult = tmpResult.CullDuplicates();
+
+            if (!tmpResult.Any())
+                return result;
+
+
+            List<Point> subPoints = new List<Point>();
+
+            foreach (ICurve subPart in curve.ISubParts())
+            {
+                if (subPart is Arc)
+                {
+                    foreach (Point pt in tmpResult)
+                    {
+                        if (pt.IsOnCurve(subPart, tolerance))
+                            subPoints.Add(pt);
+                    }
+                    subPoints = subPoints.SortAlongCurve(subPart as Arc);
+                    if (result.Any() && subPoints.Any())
+                    {
+                        if (result[result.Count - 1].IsEqual(subPoints[0]))
+                            result.RemoveAt(result.Count - 1);
+                    }
+                    result.AddRange(subPoints);
+                    subPoints.Clear();
+                }
+                else if (subPart is Line)
+                {
+                    foreach (Point pt in tmpResult)
+                    {
+                        if (pt.IsOnCurve(subPart, tolerance))
+                            subPoints.Add(pt);
+                    }
+                    subPoints = subPoints.SortAlongCurve(subPart as Line);
+
+                    if (result.Any() && subPoints.Any())
+                    {
+                        if (result[result.Count - 1].IsEqual(subPoints[0]))
+                            result.RemoveAt(result.Count - 1);
+                    }
+                    result.AddRange(subPoints);
+                    subPoints.Clear();
+                }
+            }
+
+            result = result.CullDuplicates();
+
+            if (result.Count > tmpResult.Count)
+                result.RemoveAt(result.Count - 1);
+
+            return result;
         }
 
         /***************************************************/
 
-        [NotImplemented]
-        public static List<Point> SortAlongCurve(this List<Point> points, Polyline curve)
+        public static List<Point> SortAlongCurve(this List<Point> points, Polyline curve, double tolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
-            throw new NotImplementedException();
+            List<Point> result = new List<Point>();
+            List<Point> tmpResult = new List<Point>();
+
+            foreach (Point pt in points)
+            {
+                if (pt.IsOnCurve(curve, tolerance))
+                    tmpResult.Add(pt);
+            }
+
+            if (!tmpResult.Any())
+                return result;
+            else if (tmpResult.Count == 1)
+                return tmpResult;
+
+
+            List<Point> subPoints = new List<Point>();
+
+            foreach (ICurve subPart in curve.ISubParts())
+            {
+                foreach (Point pt in tmpResult)
+                {
+                    if (pt.IsOnCurve(subPart, tolerance))
+                        subPoints.Add(pt);
+                }
+                subPoints = subPoints.SortAlongCurve(subPart as Line);
+
+                if (result.Any() && subPoints.Any())
+                {
+                    if (result[result.Count - 1].IsEqual(subPoints[0]))
+                        result.RemoveAt(result.Count - 1);
+                }
+                result.AddRange(subPoints);
+                subPoints.Clear();
+            }
+
+            return result;
         }
 
 
@@ -121,9 +238,9 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 
-        public static List<Point> ISortAlongCurve(this List<Point> points, ICurve curve)
+        public static List<Point> ISortAlongCurve(this List<Point> points, ICurve curve, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
-            return SortAlongCurve(points, curve as dynamic);
+            return SortAlongCurve(points, curve as dynamic, distanceTolerance, angleTolerance);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -198,7 +198,7 @@ namespace BH.Engine.Geometry
 
             foreach (Point p in points)
             {
-                if (p.IsOnCurve(curve))
+                if (p.IsOnCurve(curve, tolerance))
                     onCurvePoints.Add(p);
             }
 

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -34,19 +34,69 @@ namespace BH.Engine.Geometry
         /****          Split curve at points            ****/
         /***************************************************/
 
-        [NotImplemented]
         public static List<Arc> SplitAtPoints(this Arc arc, List<Point> points, double tolerance = Tolerance.Distance)
         {
-            throw new NotImplementedException();
+            if (!points.Any())
+                return new List<Arc> { arc.Clone() };
+
+            List<Arc> result = new List<Arc>();
+            List<Point> cPts = new List<Point>();
+            List<Point> sPts = new List<Point>();
+            Vector normal = arc.Normal();
+            
+            foreach (Point point in points)
+            {
+                if (point.IsOnCurve(arc, tolerance))
+                    cPts.Add(point);
+            }
+
+            if (cPts.Count > 0)
+            {
+                sPts.Add(arc.StartPoint());
+                sPts.AddRange(cPts.SortAlongCurve(arc, tolerance));
+                sPts.Add(arc.EndPoint());
+                sPts = sPts.CullDuplicates(tolerance);
+                Double startAng = arc.StartAngle;
+                Double endAng = arc.EndAngle;
+                Double tmpAng = 0;
+                Arc tmpArc;
+
+                for (int i = 1; i < sPts.Count; i++)
+                {
+                    tmpArc = arc.Clone();
+
+                    tmpArc.StartAngle = startAng;
+                    tmpAng = (2 * Math.PI + (sPts[i - 1] - arc.Centre()).SignedAngle(sPts[i] - arc.Centre(), normal)) % (2 * Math.PI);
+                    endAng = startAng + tmpAng;
+                    tmpArc.EndAngle = endAng;
+                    result.Add(tmpArc);
+                    startAng = endAng;
+                }
+
+            }
+            else
+                result.Add(arc.Clone());
+
+            return result;
         }
 
         /***************************************************/
 
-        [NotImplemented]
-        public static List<Arc> SplitAtPoints(this Circle circle, List<Point> points, double tolerance = Tolerance.Distance)
-        {
-            throw new NotImplementedException();
-        }
+
+        //public static List<Arc> SplitAtPoints(this Circle circle, List<Point> points, double tolerance = Tolerance.Distance)
+        //{
+        //    List<Arc> result = new List<Arc>();
+        //    List<Point> cPts = new List<Point>();
+        //    List<Point> sPts = new List<Point>();
+        //    Vector normal = circle.Normal();
+
+        //    foreach (Point point in points)
+        //    {
+        //        if (point.IsOnCurve(circle, tolerance))
+        //            cPts.Add(point);
+        //    }
+
+        //}
 
         /***************************************************/
 
@@ -87,10 +137,97 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static List<PolyCurve> SplitAtPoints(this PolyCurve curve, List<Point> points, double tolerance = Tolerance.Distance)
         {
-            throw new NotImplementedException();
+            if (points.Count == 0)
+                return new List<PolyCurve> { curve.Clone() };
+
+            List<PolyCurve> result = new List<PolyCurve>();
+            List<ICurve> tmpResult = new List<ICurve>();
+            List<Point> subPoints = new List<Point>();
+            List<Point> onCurvePoints = new List<Point>();
+
+            onCurvePoints = points.SortAlongCurve(curve);
+
+            if (onCurvePoints.Count == 0)
+                return new List<PolyCurve> { curve.Clone() };
+
+
+            foreach (ICurve crv in curve.SubParts())
+            {
+                if (crv is Arc)
+                {
+                    foreach (Point point in onCurvePoints)
+                    {
+                        if (point.IsOnCurve(crv, tolerance))
+                            subPoints.Add(point);
+                    }
+                    tmpResult.AddRange((crv as Arc).SplitAtPoints(subPoints));
+                    subPoints.Clear();
+                }
+                else if (crv is Line)
+                {
+                    foreach (Point point in onCurvePoints)
+                    {
+                        if (point.IsOnCurve(crv, tolerance))
+                            subPoints.Add(point);
+                    }
+                    tmpResult.AddRange((crv as Line).SplitAtPoints(subPoints));
+                    subPoints.Clear();
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+
+            }
+
+            int i = 0;
+            int j = 0;
+
+            if (curve.IStartPoint().IsEqual(onCurvePoints[0]))
+            {
+                onCurvePoints.Add(onCurvePoints[0]);
+                onCurvePoints.RemoveAt(0);
+            }
+
+            while (i <= onCurvePoints.Count)
+            {
+                List<ICurve> subResultList = new List<ICurve>();
+
+                while (j < tmpResult.Count)
+                {
+                    subResultList.Add(tmpResult[j]);
+                    if (i < onCurvePoints.Count)
+                    {
+                        if (tmpResult[j].IEndPoint().IsEqual(onCurvePoints[i]))
+                        {
+                            j++;
+                            break;
+                        }
+                    }
+                    j++;
+                }
+                if (subResultList.Count > 0)
+                    result.Add(new PolyCurve { Curves = subResultList.ToList() });
+                i++;
+            }
+
+            if (curve.IsClosed(tolerance))
+                if (!curve.StartPoint().IsEqual(onCurvePoints[onCurvePoints.Count - 1]))
+                {
+                    List<ICurve> subResultList = new List<ICurve>();
+                    foreach (ICurve subCrv in result[result.Count - 1].ISubParts())
+                        subResultList.Add(subCrv);
+                    foreach (ICurve subCrv in result[0].ISubParts())
+                        subResultList.Add(subCrv);
+                    result.RemoveAt(0);
+                    result.RemoveAt(result.Count - 1);
+                    result.Add(new PolyCurve { Curves = subResultList.ToList() });
+                }
+
+
+            return result;
         }
 
         /***************************************************/
@@ -102,7 +239,7 @@ namespace BH.Engine.Geometry
 
             List<Polyline> result = new List<Polyline>();
             List<Line> segments = curve.SubParts();
-            Polyline section = new Polyline {ControlPoints = new List<Point>() };
+            Polyline section = new Polyline { ControlPoints = new List<Point>() };
             bool closed = curve.IsClosed(tolerance);
             double sqTol = tolerance * tolerance;
 
@@ -129,7 +266,7 @@ namespace BH.Engine.Geometry
                     result.Add(section);
                     section = new Polyline { ControlPoints = new List<Point> { l.Start.Clone() } };
                 }
-                
+
                 if (iPts.Count > 0)
                 {
                     iPts = iPts.CullDuplicates(tolerance);
@@ -173,5 +310,66 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        public static List<ICurve> TmpSplit(this PolyCurve curve, List<Point> points, double tolerance = Tolerance.Distance)
+        {
+            if (points.Count == 0)
+                return new List<ICurve> { curve.Clone() };
+
+            List<ICurve> tmpResult = new List<ICurve>();
+            List<Point> subPoints = new List<Point>();
+            List<Point> onCurvePoints = new List<Point>();
+
+            onCurvePoints = points.SortAlongCurve(curve);
+            onCurvePoints = onCurvePoints.CullDuplicates();
+
+            if (onCurvePoints.Count == 0)
+                return new List<ICurve> { curve.Clone() };
+
+
+            foreach (ICurve crv in curve.SubParts())
+            {
+                if (crv is Arc)
+                {
+                    foreach (Point point in onCurvePoints)
+                    {
+                        if (point.IsOnCurve(crv, tolerance))
+                            subPoints.Add(point);
+                    }
+                    tmpResult.AddRange((crv as Arc).SplitAtPoints(subPoints));
+                    subPoints.Clear();
+                }
+                else if (crv is Line)
+                {
+                    foreach (Point point in onCurvePoints)
+                    {
+                        if (point.IsOnCurve(crv, tolerance))
+                            subPoints.Add(point);
+                    }
+                    tmpResult.AddRange((crv as Line).SplitAtPoints(subPoints));
+                    subPoints.Clear();
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+                return tmpResult;
+            
+        }
     }
 }

--- a/Geometry_Engine/Query/ClosestPoint.cs
+++ b/Geometry_Engine/Query/ClosestPoint.cs
@@ -84,6 +84,8 @@ namespace BH.Engine.Geometry
             return arc.ClosestPoint(point, Tolerance.Distance);
         }
 
+        /***************************************************/
+
         public static Point ClosestPoint(this Arc curve, Point point, double tolerance = Tolerance.Distance)
         {
             if (point.SquareDistance(curve.Centre()) <= tolerance * tolerance)
@@ -126,8 +128,7 @@ namespace BH.Engine.Geometry
         {
             throw new NotImplementedException();
         }
-
-
+        
         /***************************************************/
 
         public static Point ClosestPoint(this PolyCurve curve, Point point)

--- a/Geometry_Engine/Query/ClosestPoint.cs
+++ b/Geometry_Engine/Query/ClosestPoint.cs
@@ -78,15 +78,24 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
+        [DeprecatedAttribute("2.3", "Replaced with method checking if point is arc.centre due to issue 896", null, "ClosestPoint")]
         public static Point ClosestPoint(this Arc arc, Point point)
         {
-            Point center = arc.Centre();
-            Point midPoint = arc.PointAtParameter(0.5);
-            Plane p = arc.FitPlane();
+            return arc.ClosestPoint(point, Tolerance.Distance);
+        }
 
-            Point onCircle = center + (point.Project(p) - center).Normalise() * arc.Radius;
-            double sqrd = midPoint.SquareDistance(arc.StartPoint());
-            return midPoint.SquareDistance(onCircle) <= sqrd ? onCircle : onCircle.ClosestPoint(new List<Point> { arc.StartPoint(), arc.EndPoint() });
+        public static Point ClosestPoint(this Arc curve, Point point, double tolerance = Tolerance.Distance)
+        {
+            if (point.SquareDistance(curve.Centre()) <= tolerance * tolerance)
+                return curve.StartPoint();
+
+            Point center = curve.Centre();
+            Point midPoint = curve.PointAtParameter(0.5);
+            Plane p = curve.FitPlane();
+
+            Point onCircle = center + (point.Project(p) - center).Normalise() * curve.Radius;
+            double sqrd = midPoint.SquareDistance(curve.StartPoint());
+            return midPoint.SquareDistance(onCircle) <= sqrd ? onCircle : onCircle.ClosestPoint(new List<Point> { curve.StartPoint(), curve.EndPoint() });
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/CurveIntersections.cs
+++ b/Geometry_Engine/Query/CurveIntersections.cs
@@ -179,6 +179,20 @@ namespace BH.Engine.Geometry
             return curve1.LineIntersections(curve2, false, tolerance);
         }
 
+        /***************************************************/
+
+        public static List<Point> CurveIntersections(this PolyCurve curve1, PolyCurve curve2, double tolerance = Tolerance.Distance)
+        {
+            List<Point> result = new List<Point>();
+            foreach (ICurve c1 in curve1.SubParts())
+            {
+                foreach (ICurve c2 in curve2.SubParts())
+                {
+                    result.AddRange(CurveIntersections(c1 as dynamic, c2 as dynamic, tolerance));
+                }
+            }
+            return result;
+        }
 
         /***************************************************/
         /**** Public Methods - Interfaces               ****/

--- a/Geometry_Engine/Query/Distance.cs
+++ b/Geometry_Engine/Query/Distance.cs
@@ -113,6 +113,14 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [NotImplemented]
+        public static double Distance(this Point point, Ellipse ellipse)
+        {
+            throw new NotImplementedException();
+        }
+
+        /***************************************************/
+
         public static double Distance(this Point point, Polyline curve)
         {
             return point.Distance(curve.ClosestPoint(point));

--- a/Geometry_Engine/Query/IsCoplanar.cs
+++ b/Geometry_Engine/Query/IsCoplanar.cs
@@ -93,5 +93,44 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
+
+        public static bool IsCoplanar(this PolyCurve curve1, PolyCurve curve2, double tolerance = Tolerance.Distance)
+        {
+            List<Point> pts = new List<Point> { curve1.Curves[0].IStartPoint() };
+
+            foreach (ICurve crv in curve1.SubParts())
+            {
+                if (crv is Line)
+                    pts.Add((crv as Line).End);
+                else if (crv is Arc)
+                {
+                    pts.Add((crv as Arc).PointAtParameter(0.5));
+                    pts.Add((crv as Arc).EndPoint());
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            pts.Add(curve2.Curves[0].IStartPoint());
+
+            foreach (ICurve crv in curve2.ISubParts())
+            {
+                if (crv is Line)
+                    pts.Add((crv as Line).End);
+                else if (crv is Arc)
+                {
+                    pts.Add((crv as Arc).PointAtParameter(0.5));
+                    pts.Add((crv as Arc).EndPoint());
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+            
+            return pts.IsCoplanar(tolerance);
+        }
     }
 }

--- a/Geometry_Engine/Query/IsOnCurve.cs
+++ b/Geometry_Engine/Query/IsOnCurve.cs
@@ -24,6 +24,7 @@ using BH.oM.Geometry;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Geometry
 {
@@ -42,6 +43,69 @@ namespace BH.Engine.Geometry
             double minTol = (distToStart + distToEnd) - tolerance;
 
             return line.Length() >= minTol && line.Length() <= maxTol;
+        }
+
+        /***************************************************/
+        /**** Public Methods - Curves                   ****/
+        /***************************************************/
+
+        public static bool IsOnCurve(this Point point, Arc curve, double tolerance = Tolerance.Distance)
+        {
+            return point.Distance(curve) < tolerance;
+        }
+
+        /***************************************************/
+
+        public static bool IsOnCurve(this Point point, Circle curve, double tolerance = Tolerance.Distance)
+        {
+            return point.Distance(curve) < tolerance;
+        }
+
+        /***************************************************/
+
+        [NotImplemented]
+        public static bool IsOnCurve(this Point point, Ellipse curve, double tolerance = Tolerance.Distance)
+        {
+            throw new NotImplementedException();
+        }
+
+        /***************************************************/
+
+        public static bool IsOnCurve(this Point point, Line curve, double tolerance = Tolerance.Distance)
+        {
+            return point.Distance(curve) < tolerance;
+        }
+
+        /***************************************************/
+
+        [NotImplemented]
+        public static bool IsOnCurve(this Point point, NurbsCurve curve, double tolerance = Tolerance.Distance)
+        {
+            throw new NotImplementedException();
+        }
+
+        /***************************************************/
+
+        public static bool IsOnCurve(this Point point, PolyCurve curve, double tolerance = Tolerance.Distance)
+        {
+            return point.Distance(curve) < tolerance;
+        }
+
+        /***************************************************/
+
+        public static bool IsOnCurve(this Point point, Polyline curve, double tolerance = Tolerance.Distance)
+        {
+            return point.Distance(curve) < tolerance;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods - Interfaces               ****/
+        /***************************************************/
+
+        public static bool IsOnCurve(this Point point, ICurve curve, double tolerance = Tolerance.Distance)
+        {
+            return IsOnCurve(point, curve as dynamic, tolerance);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -202,13 +202,31 @@ namespace BH.Engine.Geometry
         {
             throw new NotImplementedException();
         }
-        
+
         /***************************************************/
 
-        [NotImplemented]
         public static Vector Normal(this Arc arc)
         {
-            throw new NotImplementedException();
+            Vector normal = new Vector { X = 0, Y = 0, Z = 0 };
+
+            List<Point> pts = new List<Point> { arc.IStartPoint() };
+
+            int numb = 4;
+            List<Point> aPts = arc.SamplePoints(numb);
+            for (int i = 1; i < aPts.Count; i++)
+                pts.Add(aPts[i]);
+
+            Point pA = pts[0];
+
+            for (int i = 1; i < pts.Count - 1; i++)
+            {
+                Point pB = pts[i];
+                Point pC = pts[i + 1];
+
+                normal += CrossProduct((pB - pA).Normalise(), (pC - pB).Normalise());
+                normal += CrossProduct(pB - pA, pC - pA);
+            }
+            return normal.Normalise();
         }
 
         /***************************************************/


### PR DESCRIPTION
Closes #880 
Closes #896 


### Test files
Test files are [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5Fengine%2Dissues%2D880%2C896%2DSplitAtPoints%2DSortAlongCurve%2DDistance%2Detc)


### Changelog
New methods added:
- SortAlongCurve: Arc, Circle, PolyCurve
- SplitAtPoints: Arc, Circle PolyCurve
- Normal: Arc

Rewrited code for new inputs:
- IsCoplanar: PoluCurve (rewrited from polylines)
- IsOnCurve: everything but nurbs and ellipse. (Refer to Distance())
- Join: List PolyCurve (rewrited from Join(List ICurve))
- CurveIntersections: PolyCurve, PolyCurve (rewrited from CurveIntersections(ICurve, ICurve))

Fixed:
- ClosestPoint(Arc,Point) now checks if the point is arc.centre and then always returns StartPoint. It caused bug in Distance() -> #896  . Previous method is deprecated and functionality is preserved.

### Additional comments
These are all methods which were necessery to create booleanMethods for PolyCurves (#874 ). They are coming in another PR right after this one get merged.