### PR TITLE
Serialiser_Engine: Return list when FromJson parses a json array

### DIFF
--- a/Serialiser_Engine/Convert/Json.cs
+++ b/Serialiser_Engine/Convert/Json.cs
@@ -80,7 +80,7 @@ namespace BH.Engine.Serialiser
                 {
                     CustomData = new Dictionary<string, object>()
                     {
-                        { "Objects", array.Select(b => Convert.FromBson(b.AsBsonDocument)) }
+                        { "Objects", array.Select(b => Convert.FromBson(b.AsBsonDocument)).ToList() }
                     }
                 };
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #906
<!-- Add short description of what has been fixed -->
When a JsonArray is parsed via `FromJson` method, the method returns the BsonIterator instead of the entire list.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EnPlQvcelkhGihJYzsRDPo0BbzhBqgeFxAw564xkVEpUNA?e=m0E5DF
