### PR TITLE
Geometry engine #917 create methods for solids

### DIFF
--- a/Geometry_Engine/Create/Cone.cs
+++ b/Geometry_Engine/Create/Cone.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using System;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        public static Cone Cone(Point centre, Vector axis, double radius = 0.0, double height = 0.0)
+        {
+            return new Cone
+            {
+                Centre = centre,
+                Axis = axis,
+                Radius = radius,
+                Height = height
+            };
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Geometry_Engine/Create/Cuboid.cs
+++ b/Geometry_Engine/Create/Cuboid.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Geometry.CoordinateSystem;
+using System;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        public static Cuboid Cuboid(Cartesian coordinateSystem, double length = 0.0, double depth = 0.0, double height = 0.0)
+        {
+            return new Cuboid
+            {
+                CoordinateSystem = coordinateSystem,
+                Length = length,
+                Depth = depth,
+                Height = height
+            };
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Geometry_Engine/Create/Cylinder.cs
+++ b/Geometry_Engine/Create/Cylinder.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using System;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        public static Cylinder Cylinder(Point centre, Vector axis, double radius = 0.0, double height = 0.0)
+        {
+            return new Cylinder
+            {
+                Centre = centre,
+                Axis = axis,
+                Radius = radius,
+                Height = height
+            };
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Geometry_Engine/Create/Sphere.cs
+++ b/Geometry_Engine/Create/Sphere.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using System;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Sphere Sphere(Point centre, double radius)
+        {
+            return new Sphere
+            {
+                Centre = centre,
+                Radius = radius
+            };
+        }
+    }
+}

--- a/Geometry_Engine/Create/Torus.cs
+++ b/Geometry_Engine/Create/Torus.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using System;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        public static Torus Torus(Point centre, Vector axis, double radiusMajor = 0.0, double radiusMinor = 0.0)
+        {
+            return new Torus
+            {
+                Centre = centre,
+                Axis = axis,
+                RadiusMajor = radiusMajor,
+                RadiusMinor = radiusMinor
+            };
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -68,12 +68,17 @@
     <Compile Include="Compute\SortAlongCurve.cs" />
     <Compile Include="Compute\SortCollinear.cs" />
     <Compile Include="Convert\Polyline.cs" />
+    <Compile Include="Create\Cone.cs" />
     <Compile Include="Create\ConvexHull.cs" />
     <Compile Include="Create\CartesianCoordinateSystem.cs" />
+    <Compile Include="Create\Cuboid.cs" />
+    <Compile Include="Create\Cylinder.cs" />
     <Compile Include="Create\Geometry.cs" />
     <Compile Include="Create\PlanarSurface.cs" />
+    <Compile Include="Create\Sphere.cs" />
     <Compile Include="Create\Surface.cs" />
     <Compile Include="Create\Curve.cs" />
+    <Compile Include="Create\Torus.cs" />
     <Compile Include="Create\Vector.cs" />
     <Compile Include="Create\Point.cs" />
     <Compile Include="Create\PolySurface.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #917

<!-- Add short description of what has been fixed -->
Addition of simple Create methods in the Engine for the Primate Solids:
- [x] Create.Sphere
- [x] Create.Torus
- [x] Create.Cylinder
- [x] Create.Cone
- [x] Create.Cuboid


### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FBHoM_Engine%2FGeometry_Engine%2FGeometry_Engine-issue917-PrimativeSolidCreate&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4

### Additional comments

See related but not dependant issue raised here: 
https://github.com/BHoM/Rhinoceros_Toolkit/issues/93
