### PR TITLE
Geometry_Engine-Issue941-AddBooleanIntersectionForBoundingBoxes

### DIFF
--- a/Geometry_Engine/Compute/BooleanIntersection.cs
+++ b/Geometry_Engine/Compute/BooleanIntersection.cs
@@ -268,5 +268,32 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
+
+        public static BoundingBox BooleanIntersection(this List<BoundingBox> boxes, double tolerance = Tolerance.Distance)
+        {
+            double minX = double.MinValue;
+            double minY = double.MinValue;
+            double minZ = double.MinValue;
+            double maxX = double.MaxValue;
+            double maxY = double.MaxValue;
+            double maxZ = double.MaxValue;
+
+            foreach (BoundingBox box in boxes)
+            {
+                minX = Math.Max(box.Min.X, minX);
+                minY = Math.Max(box.Min.Y, minY);
+                minZ = Math.Max(box.Min.Z, minZ);
+                maxX = Math.Min(box.Max.X, maxX);
+                maxY = Math.Min(box.Max.Y, maxY);
+                maxZ = Math.Min(box.Max.Z, maxZ);
+
+                if (minX > maxX + tolerance || minY > maxY + tolerance || minZ > maxZ + tolerance)
+                    return null;
+            }
+
+            return new BoundingBox { Min = new Point { X = minX, Y = minY, Z = minZ }, Max = new Point { X = maxX, Y = maxY, Z = maxZ } };
+        }
+
+        /***************************************************/
     }
 }

--- a/Geometry_Engine/Compute/BooleanIntersection.cs
+++ b/Geometry_Engine/Compute/BooleanIntersection.cs
@@ -30,6 +30,36 @@ namespace BH.Engine.Geometry
     public static partial class Compute
     {
         /***************************************************/
+        /****      public Methods - Bounding Boxes      ****/
+        /***************************************************/
+
+        public static BoundingBox BooleanIntersection(this List<BoundingBox> boxes, double tolerance = Tolerance.Distance)
+        {
+            double minX = double.MinValue;
+            double minY = double.MinValue;
+            double minZ = double.MinValue;
+            double maxX = double.MaxValue;
+            double maxY = double.MaxValue;
+            double maxZ = double.MaxValue;
+
+            foreach (BoundingBox box in boxes)
+            {
+                minX = Math.Max(box.Min.X, minX);
+                minY = Math.Max(box.Min.Y, minY);
+                minZ = Math.Max(box.Min.Z, minZ);
+                maxX = Math.Min(box.Max.X, maxX);
+                maxY = Math.Min(box.Max.Y, maxY);
+                maxZ = Math.Min(box.Max.Z, maxZ);
+
+                if (minX > maxX + tolerance || minY > maxY + tolerance || minZ > maxZ + tolerance)
+                    return null;
+            }
+
+            return new BoundingBox { Min = new Point { X = minX, Y = minY, Z = minZ }, Max = new Point { X = maxX, Y = maxY, Z = maxZ } };
+        }
+        
+
+        /***************************************************/
         /****          public Methods - Lines           ****/
         /***************************************************/
 
@@ -265,33 +295,6 @@ namespace BH.Engine.Geometry
             }
 
             return result;
-        }
-
-        /***************************************************/
-
-        public static BoundingBox BooleanIntersection(this List<BoundingBox> boxes, double tolerance = Tolerance.Distance)
-        {
-            double minX = double.MinValue;
-            double minY = double.MinValue;
-            double minZ = double.MinValue;
-            double maxX = double.MaxValue;
-            double maxY = double.MaxValue;
-            double maxZ = double.MaxValue;
-
-            foreach (BoundingBox box in boxes)
-            {
-                minX = Math.Max(box.Min.X, minX);
-                minY = Math.Max(box.Min.Y, minY);
-                minZ = Math.Max(box.Min.Z, minZ);
-                maxX = Math.Min(box.Max.X, maxX);
-                maxY = Math.Min(box.Max.Y, maxY);
-                maxZ = Math.Min(box.Max.Z, maxZ);
-
-                if (minX > maxX + tolerance || minY > maxY + tolerance || minZ > maxZ + tolerance)
-                    return null;
-            }
-
-            return new BoundingBox { Min = new Point { X = minX, Y = minY, Z = minZ }, Max = new Point { X = maxX, Y = maxY, Z = maxZ } };
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #941 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test file is [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FBHoM_Engine%2FGeometry_Engine%2FGeometry_Engine-Issue941-AddBooleanIntersectionForBoundingBoxes), the method has been also added to the standard BooleanIntersection test file.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Added BooleanIntersection for the BoundingBoxes.

