### PR TITLE
Environment_Engine: Set construction by type

### DIFF
--- a/Environment_Engine/Modify/SetConstruction.cs
+++ b/Environment_Engine/Modify/SetConstruction.cs
@@ -68,7 +68,7 @@ namespace BH.Engine.Environment
 
         [Description("Update a new construction to a collection of openings which match the given type from their Origin Context Fragment")]
         [Input("openings", "A collection of Environment Openings to set the construction of")]
-        [Input("typeNames", "The type names of the panels to update - if any panels type name is contained in the list given it will have its construction updated")]
+        [Input("typeNames", "The type names of the openings to update - if any openings type name is contained in the list given it will have its construction updated")]
         [Input("newConstruction", "The new construction to assign to the openings")]
         [Output("openings", "The collection of Environment Openings with an updated construction")]
         public static List<Opening> SetConstructions(this List<Opening> openings, List<string> typeNames, IConstruction newConstruction)
@@ -88,6 +88,19 @@ namespace BH.Engine.Environment
             }
 
             return returnOpenings;
+        }
+
+        [Description("Update a new construction to a collection of openings which match the given type from their Origin Context Fragment")]
+        [Input("panels", "A collection of Environment Panels to update the hosted openings constructions of")]
+        [Input("typeNames", "The type names of the openings to update - if any openings type name is contained in the list given it will have its construction updated")]
+        [Input("newConstruction", "The new construction to assign to the openings")]
+        [Output("panels", "The collection of Environment Panels with updated construction on the hosted openings")]
+        public static List<Panel> SetOpeningConstruction(this List<Panel> panels, List<string> typeNames, IConstruction newConstruction)
+        {
+            foreach(Panel p in panels)
+                p.Openings = p.Openings.SetConstructions(typeNames, newConstruction);
+
+            return panels;
         }
     }
 }

--- a/Environment_Engine/Modify/SetConstruction.cs
+++ b/Environment_Engine/Modify/SetConstruction.cs
@@ -44,19 +44,19 @@ namespace BH.Engine.Environment
 
         [Description("Update a new construction to a collection of panels which match the given type from their Origin Context Fragment")]
         [Input("panels", "A collection of Environment Panels to set the construction of")]
-        [Input("type", "The type name of the panels to update")]
+        [Input("typeNames", "The type names of the panels to update - if any panels type name is contained in the list given it will have its construction updated")]
         [Input("newConstruction", "The new construction to assign to the panels")]
         [Output("panels", "The collection of Environment Panels with an updated construction")]
-        public static List<Panel> SetConstructions(this List<Panel> panels, string type, IConstruction newConstruction)
+        public static List<Panel> SetConstructions(this List<Panel> panels, List<string> typeNames, IConstruction newConstruction)
         {
             List<Panel> returnPanels = new List<Panel>();
 
             foreach (Panel p in panels)
             {
                 OriginContextFragment context = p.FindFragment<OriginContextFragment>(typeof(OriginContextFragment));
-                if (context == null || context.TypeName != type)
+                if (context == null || !typeNames.Contains(context.TypeName))
                     returnPanels.Add(p);
-                else if (context != null && context.TypeName == type)
+                else if (context != null && typeNames.Contains(context.TypeName))
                 {
                     p.Construction = newConstruction;
                     returnPanels.Add(p);
@@ -68,19 +68,19 @@ namespace BH.Engine.Environment
 
         [Description("Update a new construction to a collection of openings which match the given type from their Origin Context Fragment")]
         [Input("openings", "A collection of Environment Openings to set the construction of")]
-        [Input("type", "The type name of the openings to update")]
+        [Input("typeNames", "The type names of the panels to update - if any panels type name is contained in the list given it will have its construction updated")]
         [Input("newConstruction", "The new construction to assign to the openings")]
         [Output("openings", "The collection of Environment Openings with an updated construction")]
-        public static List<Opening> SetConstructions(this List<Opening> openings, string type, IConstruction newConstruction)
+        public static List<Opening> SetConstructions(this List<Opening> openings, List<string> typeNames, IConstruction newConstruction)
         {
             List<Opening> returnOpenings = new List<Opening>();
 
             foreach (Opening o in openings)
             {
                 OriginContextFragment context = o.FindFragment<OriginContextFragment>(typeof(OriginContextFragment));
-                if (context == null || context.TypeName != type)
+                if (context == null || !typeNames.Contains(context.TypeName))
                     returnOpenings.Add(o);
-                else if (context != null && context.TypeName == type)
+                else if (context != null && typeNames.Contains(context.TypeName))
                 {
                     o.OpeningConstruction = newConstruction;
                     returnOpenings.Add(o);

--- a/Environment_Engine/Query/Absorptance.cs
+++ b/Environment_Engine/Query/Absorptance.cs
@@ -57,7 +57,10 @@ namespace BH.Engine.Environment
 
             double value = 0;
             foreach (Absorptance a in absorptances)
-                value += a.Value;
+            {
+                if(a != null)
+                    value += a.Value;
+            }
 
             Absorptance rtn = new Absorptance();
             rtn.AbsorptanceUnit = AbsorptanceUnit.Percent;

--- a/Physical_Engine/Create/Layer.cs
+++ b/Physical_Engine/Create/Layer.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Physical
         [Description("Returns a Layer object")]
         [Input("name", "The name of the layer, default empty string")]
         [Input("material", "The material this layer is made up of, default null")]
-        [Input("thickness", "The thickness of this material layer, default 0.0")]
+        [Input("thickness", "The thickness of this material layer in meters, default 0.0")]
         [Output("A Layer object providing an instantiated use of a material with a given thickness")]
         public static Layer Layer(string name = "", Material material = null, double thickness = 0.0)
         {


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #958 
Fixes #955 


### Test files
Current macro test files


### Changelog
#### Changed
 - Changed function for setting construction by type as per #958 to allow multiple type names to be given
 - Changed Absorptance method to provide protection in the event of a `null` absorptance object
 - Changed input description for Physical Layer Create method
#### Added
 - Added function to set constructions by type for hosted openings