### PR TITLE
Geometry_Engine: Issue918 Update IsContaining for BoundingBoxes

### DIFF
--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -59,7 +59,7 @@ namespace BH.Engine.Geometry
         public static bool IsContaining(this BoundingBox box, IGeometry geometry)
         {
             //return box.IsContaining(geometry.IBounds());
-            return box.IIsContaining(geometry, true, Tolerance.Distance);
+            return box.IsContaining(geometry, true, Tolerance.Distance);
         }
 
         /***************************************************/
@@ -125,7 +125,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static bool IIsContaining(this BoundingBox box, IGeometry geometry, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
+        public static bool IsContaining(this BoundingBox box, IGeometry geometry, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
         {
             return box.IsContaining(geometry.IBounds(), acceptOnEdge, tolerance);
         }

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -59,7 +59,7 @@ namespace BH.Engine.Geometry
         public static bool IsContaining(this BoundingBox box, IGeometry geometry)
         {
             //return box.IsContaining(geometry.IBounds());
-            return box.IsContaining(geometry, true, Tolerance.Distance);
+            return box.IIsContaining(geometry, true, Tolerance.Distance);
         }
 
         /***************************************************/
@@ -125,7 +125,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static bool IsContaining(this BoundingBox box, IGeometry geometry, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
+        public static bool IIsContaining(this BoundingBox box, IGeometry geometry, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
         {
             return box.IsContaining(geometry.IBounds(), acceptOnEdge, tolerance);
         }

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -55,65 +55,33 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [DeprecatedAttribute("2.3", "Reorganised methods, adding tolerance", null, "IsContaining")]
         public static bool IsContaining(this BoundingBox box, IGeometry geometry)
         {
-            return box.IsContaining(geometry.IBounds());
+            //return box.IsContaining(geometry.IBounds());
+            return box.IIsContaining(geometry, true, Tolerance.Distance);
         }
 
         /***************************************************/
 
         public static bool IsContaining(this BoundingBox box1, BoundingBox box2, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
         {
-            //TODO: 2D boxes covered, but what about 1D
-
             Point max1 = box1.Max;
             Point min1 = box1.Min;
             Point max2 = box2.Max;
             Point min2 = box2.Min;
 
-            if (Math.Abs(max1.X - min1.X) <= tolerance)
+            if (acceptOnEdge)
             {
-                if (acceptOnEdge)
-                    return (min2.X >= min1.X - tolerance && max2.X <= max1.X + tolerance &&
-                            min2.Y >= min1.Y - tolerance && max2.Y <= max1.Y + tolerance &&
-                            min2.Z >= min1.Z - tolerance && max2.Z <= max1.Z + tolerance);
-                else
-                    return (min2.X > min1.X - tolerance && max2.X < max1.X + tolerance &&
-                            min2.Y > min1.Y + tolerance && max2.Y < max1.Y - tolerance &&
-                            min2.Z > min1.Z + tolerance && max2.Z < max1.Z - tolerance);
-            }
-            else if ((Math.Abs(max1.Y - min1.Y) <= tolerance))
-            {
-                if (acceptOnEdge)
-                    return (min2.X >= min1.X - tolerance && max2.X <= max1.X + tolerance &&
-                            min2.Y >= min1.Y - tolerance && max2.Y <= max1.Y + tolerance &&
-                            min2.Z >= min1.Z - tolerance && max2.Z <= max1.Z + tolerance);
-                else
-                    return (min2.X > min1.X + tolerance && max2.X < max1.X - tolerance &&
-                            min2.Y > min1.Y - tolerance && max2.Y < max1.Y + tolerance &&
-                            min2.Z > min1.Z + tolerance && max2.Z < max1.Z - tolerance);
-            }
-            else if ((Math.Abs(max1.Z - min1.Z) <= tolerance))
-            {
-                if (acceptOnEdge)
-                    return (min2.X >= min1.X - tolerance && max2.X <= max1.X + tolerance &&
-                            min2.Y >= min1.Y - tolerance && max2.Y <= max1.Y + tolerance &&
-                            min2.Z >= min1.Z - tolerance && max2.Z <= max1.Z + tolerance);
-                else
-                    return (min2.X > min1.X + tolerance && max2.X < max1.X - tolerance &&
-                            min2.Y > min1.Y + tolerance && max2.Y < max1.Y - tolerance &&
-                            min2.Z > min1.Z - tolerance && max2.Z < max1.Z + tolerance);
+                return (min2.X >= min1.X - tolerance && max2.X <= max1.X + tolerance &&
+                        min2.Y >= min1.Y - tolerance && max2.Y <= max1.Y + tolerance &&
+                        min2.Z >= min1.Z - tolerance && max2.Z <= max1.Z + tolerance);
             }
             else
             {
-                if (acceptOnEdge)
-                    return (min2.X >= min1.X - tolerance && max2.X <= max1.X + tolerance &&
-                            min2.Y >= min1.Y - tolerance && max2.Y <= max1.Y + tolerance &&
-                            min2.Z >= min1.Z - tolerance && max2.Z <= max1.Z + tolerance);
-                else
-                    return (min2.X > min1.X + tolerance && max2.X < max1.X - tolerance &&
-                            min2.Y > min1.Y + tolerance && max2.Y < max1.Y - tolerance &&
-                            min2.Z > min1.Z + tolerance && max2.Z < max1.Z - tolerance);
+                return (min2.X > min1.X + tolerance && max2.X < max1.X - tolerance &&
+                        min2.Y > min1.Y + tolerance && max2.Y < max1.Y - tolerance &&
+                        min2.Z > min1.Z + tolerance && max2.Z < max1.Z - tolerance);
             }
         }
 
@@ -121,54 +89,20 @@ namespace BH.Engine.Geometry
 
         public static bool IsContaining(this BoundingBox box, Point pt, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
         {
-            //TODO: 2D boxes covered, but what about 1D
-
             Point max = box.Max;
             Point min = box.Min;
 
-            if (Math.Abs(max.X - min.X) <= tolerance)
+            if (acceptOnEdge)
             {
-                if (acceptOnEdge)
-                    return (pt.X <= max.X + tolerance && pt.X >= min.X - tolerance &&
-                            pt.Y <= max.Y + tolerance && pt.Y >= min.Y - tolerance &&
-                            pt.Z <= max.Z + tolerance && pt.Z >= min.Z - tolerance);
-                else
-                    return (pt.X < max.X + tolerance && pt.X > min.X - tolerance &&
-                            pt.Y < max.Y - tolerance && pt.Y > min.Y + tolerance &&
-                            pt.Z < max.Z - tolerance && pt.Z > min.Z + tolerance);
-            }
-            else if ((Math.Abs(max.Y - min.Y) <= tolerance))
-            {
-                if (acceptOnEdge)
-                    return (pt.X <= max.X + tolerance && pt.X >= min.X - tolerance &&
-                            pt.Y <= max.Y + tolerance && pt.Y >= min.Y - tolerance &&
-                            pt.Z <= max.Z + tolerance && pt.Z >= min.Z - tolerance);
-                else
-                    return (pt.X < max.X - tolerance && pt.X > min.X + tolerance &&
-                            pt.Y < max.Y + tolerance && pt.Y > min.Y - tolerance &&
-                            pt.Z < max.Z - tolerance && pt.Z > min.Z + tolerance);
-            }
-            else if ((Math.Abs(max.Z - min.Z) <= tolerance))
-            {
-                if (acceptOnEdge)
-                    return (pt.X <= max.X + tolerance && pt.X >= min.X - tolerance &&
-                            pt.Y <= max.Y + tolerance && pt.Y >= min.Y - tolerance &&
-                            pt.Z <= max.Z + tolerance && pt.Z >= min.Z - tolerance);
-                else
-                    return (pt.X < max.X - tolerance && pt.X > min.X + tolerance &&
-                            pt.Y < max.Y - tolerance && pt.Y > min.Y + tolerance &&
-                            pt.Z < max.Z + tolerance && pt.Z > min.Z - tolerance);
+                return (pt.X >= min.X - tolerance && pt.X <= max.X + tolerance &&
+                        pt.Y >= min.Y - tolerance && pt.Y <= max.Y + tolerance &&
+                        pt.Z >= min.Z - tolerance && pt.Z <= max.Z + tolerance);
             }
             else
             {
-                if (acceptOnEdge)
-                    return (pt.X <= max.X + tolerance && pt.X >= min.X - tolerance &&
-                            pt.Y <= max.Y + tolerance && pt.Y >= min.Y - tolerance &&
-                            pt.Z <= max.Z + tolerance && pt.Z >= min.Z - tolerance);
-                else
-                    return (pt.X < max.X - tolerance && pt.X > min.X + tolerance &&
-                            pt.Y < max.Y - tolerance && pt.Y > min.Y + tolerance &&
-                            pt.Z < max.Z - tolerance && pt.Z > min.Z + tolerance);
+                return (pt.X > min.X + tolerance && pt.X < max.X - tolerance &&
+                        pt.Y > min.Y + tolerance && pt.Y < max.Y - tolerance &&
+                        pt.Z > min.Z + tolerance && pt.Z < max.Z - tolerance);
             }
         }
 
@@ -187,6 +121,13 @@ namespace BH.Engine.Geometry
                 }
 
             return flag;
+        }
+
+        /***************************************************/
+
+        public static bool IIsContaining(this BoundingBox box, IGeometry geometry, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
+        {
+            return box.IsContaining(geometry.IBounds(), acceptOnEdge, tolerance);
         }
 
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #918 

As mentioned in comment in PR #920 updating and properly testing new methods.
Old methods did not include tolerance and AcceptOnEdge bool.
I also changed them a bit after merge in PR #920 .

### Test files
Test file is [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02_Current&viewpath=%2Fsites%2FBHoM%2F02_Current%2FForms%2FAllItems%2Easpx&id=%2Fsites%2FBHoM%2F02_Current%2F12_Scripts%2F01_Test%20Scripts%2FBHoM_Engine%2FGeometry_Engine%2FQuery)


### Changelog
Updated:
- IsContaining(this BoundingBox box1, BoundingBox box2)
- IsContaining(this BoundingBox box, Point pt)
- IsContaining(this BoundingBox box, IGeometry geometry)

Added:
-  IsContaining(this BoundingBox box, List<Point> pts)


### Additional comments
- We discussed with @pawelbaran the matter of BBoxes which have one (or more) of dimensions equal zero. In such cases, if AcceptOnEgde bool=false, the methods would always return false (as the boxes would consist of egdes only). We agreed that it is correct solution as we have different isContaining methods for planar objects and isOnLine for linear objects.
- I wasn't sure if IsContainig(BBox, IGeometry) should have additional 'I' like an interface. It is not exactly an interface for this method, but refers to different types of input. I've added the 'I' but it may be discussed.