### PR TITLE
Geometry engine issues963,989 intersections bug and methods for boolean interfaces

### DIFF
--- a/Geometry_Engine/Compute/ClusterCoplanar.cs
+++ b/Geometry_Engine/Compute/ClusterCoplanar.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -104,6 +104,31 @@ namespace BH.Engine.Geometry
 
                 if (!coplanar)
                     curveClusters.Add(new List<PolyCurve> { p });
+            }
+
+            return curveClusters;
+        }
+
+        /***************************************************/
+
+        public static List<List<ICurve>> IClusterCoplanar(this List<ICurve> curves, double distanceTolerance = Tolerance.Distance)
+        {
+            List<List<ICurve>> curveClusters = new List<List<ICurve>>();
+            foreach (ICurve p in curves)
+            {
+                bool coplanar = false;
+                foreach (List<ICurve> pp in curveClusters)
+                {
+                    if (p.IIsCoplanar(pp[0], distanceTolerance))
+                    {
+                        pp.Add(p);
+                        coplanar = true;
+                        break;
+                    }
+                }
+
+                if (!coplanar)
+                    curveClusters.Add(new List<ICurve> { p });
             }
 
             return curveClusters;

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -232,10 +232,7 @@ namespace BH.Engine.Geometry
                     subPoints.Clear();
                 }
                 else
-                {
                     throw new NotImplementedException();
-                }
-
             }
 
             int i = 0;
@@ -256,7 +253,7 @@ namespace BH.Engine.Geometry
                     subResultList.Add(tmpResult[j]);
                     if (i < onCurvePoints.Count)
                     {
-                        if (tmpResult[j].IEndPoint().IsEqual(onCurvePoints[i]) || (curve.IIsClosed(tolerance) && !curve.IIsClockwise(curve.INormal(),tolerance)&&tmpResult[j].IStartPoint().IsEqual(onCurvePoints[i])))
+                        if (tmpResult[j].IEndPoint().IsEqual(onCurvePoints[i]) || (curve.IIsClosed(tolerance) && !curve.IIsClockwise(curve.INormal(), tolerance) && tmpResult[j].IStartPoint().IsEqual(onCurvePoints[i])))
                         {
                             j++;
                             break;
@@ -269,8 +266,10 @@ namespace BH.Engine.Geometry
                     }
                     j++;
                 }
+
                 if (subResultList.Count > 0)
                     result.Add(new PolyCurve { Curves = subResultList.ToList() });
+
                 i++;
             }
 
@@ -315,7 +314,8 @@ namespace BH.Engine.Geometry
                     if (point.SquareDistance(l.Start) <= sqTol)
                     {
                         intStart = true;
-                        if (i == 0) closed = false;
+                        if (i == 0)
+                            closed = false;
                     }
                     else if (point.SquareDistance(l.End) > sqTol && point.SquareDistance(l) <= sqTol)
                         iPts.Add(point);

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -256,12 +256,12 @@ namespace BH.Engine.Geometry
                     subResultList.Add(tmpResult[j]);
                     if (i < onCurvePoints.Count)
                     {
-                        if (tmpResult[j].IEndPoint().IsEqual(onCurvePoints[i]))
+                        if (tmpResult[j].IEndPoint().IsEqual(onCurvePoints[i]) || (curve.IIsClosed(tolerance) && !curve.IIsClockwise(curve.INormal(),tolerance)&&tmpResult[j].IStartPoint().IsEqual(onCurvePoints[i])))
                         {
                             j++;
                             break;
                         }
-                        else if (tmpResult[j].IEndPoint().IsEqual(curve.EndPoint()))
+                        else if (tmpResult[j].IEndPoint().IsEqual(curve.EndPoint()) || (curve.IIsClosed(tolerance) && !curve.IIsClockwise(curve.INormal(), tolerance) && tmpResult[j].IStartPoint().IsEqual(curve.StartPoint())))
                         {
                             j++;
                             break;

--- a/Geometry_Engine/Query/CurveIntersections.cs
+++ b/Geometry_Engine/Query/CurveIntersections.cs
@@ -191,7 +191,7 @@ namespace BH.Engine.Geometry
                     result.AddRange(CurveIntersections(c1 as dynamic, c2 as dynamic, tolerance));
                 }
             }
-            return result;
+            return result.CullDuplicates(tolerance);
         }
 
         /***************************************************/
@@ -208,7 +208,7 @@ namespace BH.Engine.Geometry
                     result.AddRange(CurveIntersections(c1 as dynamic, c2 as dynamic, tolerance));
                 }
             }
-            return result;
+            return result.CullDuplicates(tolerance);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/IsCoplanar.cs
+++ b/Geometry_Engine/Query/IsCoplanar.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -130,6 +130,45 @@ namespace BH.Engine.Geometry
                 }
             }
             
+            return pts.IsCoplanar(tolerance);
+        }
+
+        public static bool IIsCoplanar(this ICurve curve1, ICurve curve2, double tolerance = Tolerance.Distance)
+        {
+            List<Point> pts = new List<Point> { curve1.IStartPoint() };
+
+            foreach (ICurve crv in curve1.ISubParts())
+            {
+                if (crv is Line)
+                    pts.Add((crv as Line).End);
+                else if (crv is Arc)
+                {
+                    pts.Add((crv as Arc).PointAtParameter(0.5));
+                    pts.Add((crv as Arc).EndPoint());
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            pts.Add(curve2.IStartPoint());
+
+            foreach (ICurve crv in curve2.ISubParts())
+            {
+                if (crv is Line)
+                    pts.Add((crv as Line).End);
+                else if (crv is Arc)
+                {
+                    pts.Add((crv as Arc).PointAtParameter(0.5));
+                    pts.Add((crv as Arc).EndPoint());
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
             return pts.IsCoplanar(tolerance);
         }
     }

--- a/Geometry_Engine/Query/LineIntersections.cs
+++ b/Geometry_Engine/Query/LineIntersections.cs
@@ -239,7 +239,7 @@ namespace BH.Engine.Geometry
                     iPts.Add(pt);
             }
 
-            return iPts;
+            return iPts.CullDuplicates(tolerance);
         }
 
         /***************************************************/
@@ -255,7 +255,7 @@ namespace BH.Engine.Geometry
                 iPts.AddRange(c.ILineIntersections(l));
             }
 
-            return iPts;
+            return iPts.CullDuplicates(tolerance);
         }
 
         /***************************************************/
@@ -274,7 +274,7 @@ namespace BH.Engine.Geometry
                 }
             }
 
-            return iPts;
+            return iPts.CullDuplicates(tolerance);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/ParameterAtPoint.cs
+++ b/Geometry_Engine/Query/ParameterAtPoint.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Geometry
             Vector v2 = point - centre;
 
             double angle = v1.SignedAngle(v2, normal) - curve.StartAngle;
-            angle = Math.Abs(angle) < Tolerance.Angle ? 0 : angle;  //Really small negative angles gives wrong result. This solves that problem.
+            angle = (Math.Abs(angle) < Tolerance.Angle) || Math.Abs(angle - 2 * Math.PI) < Tolerance.Angle ? 0 : angle;  //Really small negative angles gives wrong result. This solves that problem.
             return ((angle + 2 * Math.PI) % (2 * Math.PI)) / curve.Angle();
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #963 
Closes #989
Closes #991 

Added interfaces for `ClusterCoplanar` and `IsCoplanar`.
Fixed minor bug that occurred with some of closed polycurves in `SplitAtPoints`
Fixed bug in `CurveIntersections` and `LineIntersections` which caused in returning same intersection points twice.
Fixed bug in `ParameterAtPoint(arc, point)` causing in returning wrong values for negative angles


### Test files
[IsCoplanar](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Query/IsCoplanar.gh?csf=1&e=dFdFca) regular
[ClusterCoplanar](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Compute/ClusterCoplanar.gh?csf=1&e=wJx339) regular
[SplitAtPoints](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Compute/ClusterCoplanar.gh?csf=1&e=wJx339) regular
[ParameterAtPoint](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Query/ParameterAtPoint.gh?csf=1&e=HR3mDj) regular
[ParameterAtPoint](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Geometry_Engine-issue991-ParameterAtPoint(Arc)Bug/Geometry_Engine-issue991-ParameterAtPoint(Arc)Bug.gh?csf=1&e=VAhwzs) issue specific
[Intersections](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/GeometryEngine-issue963-Intersections-Bug/GeometryEngine-issue963-Intersections-Bug.gh?csf=1&e=LzYgfh) issue specific

### Changelog
Added:
- `IClusterCoplanar(List<ICurve>)`
- `IIsCoplanar(ICurve, ICurve)`

Updated:
- `SplitAtPoints(PolyCurve, List<Point>)`
- `LineIntersections(Polyline, Line)`
- `LineIntersections(PolyCurve, Line)`
- `LineIntersections(Polyline, Polyline)`
- `CurveIntersections(PolyCurve, PolyCurve)`
- `CurveIntersections(ICurve, ICurve)`
- `ParameterAtPoint(Arc, Point)`

### Additional comments
<!-- As required -->
These changes are needed to create interfaces for boolean operations which will come in next PR.