### PR TITLE
Reflection engine issue982 get set nested properties

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -43,32 +43,20 @@ namespace BH.Engine.Reflection
         [Output("result", "New object with its property changed to the new value")]
         public static BHoMObject PropertyValue(this BHoMObject obj, string propName, object value)
         {
-            if (obj == null || propName == null || value == null)
-                return null;
-
-            obj = obj.GetShallowClone() as BHoMObject;
-            string[] props = propName.Split('.');
-
-            if (props.Length > 0)
-            {
-                obj.SetPropertyValue(props[0], value);
-                return obj;
-            }
-            return null;
+            BHoMObject newObject = obj.GetShallowClone() as BHoMObject;
+            newObject.SetPropertyValue(propName, value);
+            return newObject;
         }
 
         /***************************************************/
 
         public static bool SetPropertyValue(this object obj, string propName, object value)
         {
-            if (obj == null || propName == null || value == null)
-                return true;
-
             System.Reflection.PropertyInfo prop = obj.GetType().GetProperty(propName);
 
-            if (prop != null && prop.CanWrite)
+            if (prop != null)
             {
-                if (value.GetType() != prop.PropertyType  && value.GetType().GenericTypeArguments.Length > 0 && prop.PropertyType.GenericTypeArguments.Length > 0)
+                if (value.GetType() != prop.PropertyType && value.GetType().GenericTypeArguments.Length > 0 && prop.PropertyType.GenericTypeArguments.Length > 0)
                 {
                     value = Modify.CastGeneric(value as dynamic, prop.PropertyType.GenericTypeArguments[0]);
                 }
@@ -82,14 +70,13 @@ namespace BH.Engine.Reflection
                 prop.SetValue(obj, value);
                 return true;
             }
-            else if(obj is IBHoMObject)
+            else if (obj is IBHoMObject)
             {
                 IBHoMObject bhomObj = obj as IBHoMObject;
                 if (bhomObj == null) return false;
 
-                if(!(bhomObj is CustomObject))
-                    Compute.RecordWarning($"{bhomObj} not contain any property with the name { propName}." +
-                        $"The value is being set as custom data");
+                if (!(bhomObj is CustomObject))
+                    Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data");
 
                 bhomObj.CustomData[propName] = value;
                 return true;
@@ -136,7 +123,7 @@ namespace BH.Engine.Reflection
 
                 return true;
             }
-            
+
         }
 
 

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -43,18 +43,30 @@ namespace BH.Engine.Reflection
         [Output("result", "New object with its property changed to the new value")]
         public static BHoMObject PropertyValue(this BHoMObject obj, string propName, object value)
         {
-            BHoMObject newObject = obj.GetShallowClone() as BHoMObject;
-            newObject.SetPropertyValue(propName, value);
-            return newObject;
+            if (obj == null || propName == null || value == null)
+                return null;
+
+            obj = obj.GetShallowClone() as BHoMObject;
+            string[] props = propName.Split('.');
+
+            if (props.Length > 0)
+            {
+                obj.SetPropertyValue(props[0], value);
+                return obj;
+            }
+            return null;
         }
 
         /***************************************************/
 
         public static bool SetPropertyValue(this object obj, string propName, object value)
         {
+            if (obj == null || propName == null || value == null)
+                return true;
+
             System.Reflection.PropertyInfo prop = obj.GetType().GetProperty(propName);
 
-            if (prop != null)
+            if (prop != null && prop.CanWrite)
             {
                 if (value.GetType() != prop.PropertyType  && value.GetType().GenericTypeArguments.Length > 0 && prop.PropertyType.GenericTypeArguments.Length > 0)
                 {
@@ -76,7 +88,8 @@ namespace BH.Engine.Reflection
                 if (bhomObj == null) return false;
 
                 if(!(bhomObj is CustomObject))
-                    Compute.RecordWarning("The objects does not contain any property with the name " + propName +". The value is being set as custom data");
+                    Compute.RecordWarning($"{bhomObj} not contain any property with the name { propName}." +
+                        $"The value is being set as custom data");
 
                 bhomObj.CustomData[propName] = value;
                 return true;

--- a/Reflection_Engine/Query/PropertyValue.cs
+++ b/Reflection_Engine/Query/PropertyValue.cs
@@ -39,23 +39,20 @@ namespace BH.Engine.Reflection
         [Output("value", "value of the property")]
         public static object PropertyValue(this object obj, string propName)
         {
-            string[] props = propName.Split('.');
-            foreach (string prop in props)
-            {
-                obj = obj.GetPropertyValue(prop);
-                if (obj == null)
-                    break;
-            }
-
-            return obj;
-        }
-
-        /***************************************************/
-
-        public static object GetPropertyValue(this object obj, string propName)
-        {
             if (obj == null || propName == null)
                 return null;
+
+            if (propName.Contains("."))
+            {
+                string[] props = propName.Split('.');
+                foreach (string innerProp in props)
+                {
+                    obj = obj.PropertyValue(innerProp);
+                    if (obj == null)
+                        break;
+                }
+                return obj;
+            }
 
             System.Reflection.PropertyInfo prop = obj.GetType().GetProperty(propName);
 

--- a/Reflection_Engine/Query/PropertyValue.cs
+++ b/Reflection_Engine/Query/PropertyValue.cs
@@ -70,7 +70,7 @@ namespace BH.Engine.Reflection
                 }
                 else
                 {
-                    Compute.RecordWarning($"{bhom} does not contain a property {propName} or CustomData.{propName}");
+                    Compute.RecordWarning($"{bhom} does not contain a property: {propName}, or: CustomData[{propName}]");
                     return null;
                 }
 
@@ -84,12 +84,15 @@ namespace BH.Engine.Reflection
                 }
                 else
                 {
-                    Compute.RecordWarning($"{dic} does not contain the key {propName}");
+                    Compute.RecordWarning($"{dic} does not contain the key: {propName}");
                     return null;
                 }
             }
             else
+            {
+                Compute.RecordWarning($"This instance of {obj.GetType()} does not contain the property: {propName}");
                 return null;
+            }
         }
 
         /***************************************************/

--- a/Reflection_Engine/Query/PropertyValue.cs
+++ b/Reflection_Engine/Query/PropertyValue.cs
@@ -39,31 +39,57 @@ namespace BH.Engine.Reflection
         [Output("value", "value of the property")]
         public static object PropertyValue(this object obj, string propName)
         {
+            string[] props = propName.Split('.');
+            foreach (string prop in props)
+            {
+                obj = obj.GetPropertyValue(prop);
+                if (obj == null)
+                    break;
+            }
+
+            return obj;
+        }
+
+        /***************************************************/
+
+        public static object GetPropertyValue(this object obj, string propName)
+        {
+            if (obj == null || propName == null)
+                return null;
+
             System.Reflection.PropertyInfo prop = obj.GetType().GetProperty(propName);
 
             if (prop != null)
+            {
                 return prop.GetValue(obj);
+            }
             else if (obj is IBHoMObject)
             {
                 IBHoMObject bhom = obj as IBHoMObject;
                 if (bhom.CustomData.ContainsKey(propName))
                 {
+                    Compute.RecordNote($"{propName} is stored in CustomData");
                     return bhom.CustomData[propName];
                 }
                 else
                 {
-                    Compute.RecordWarning("The object does not contain a property of that name");
+                    Compute.RecordWarning($"{bhom} does not contain a property {propName} or CustomData.{propName}");
                     return null;
                 }
-                    
+
             }
             else if (obj is IDictionary)
             {
                 IDictionary dic = obj as IDictionary;
                 if (dic.Contains(propName))
+                {
                     return dic[propName];
+                }
                 else
+                {
+                    Compute.RecordWarning($"{dic} does not contain the key {propName}");
                     return null;
+                }
             }
             else
                 return null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #982
<!-- Add short description of what has been fixed -->
Get method for nested properties allows to use the form `PropOne.PropTwo` as input in the GetProperty method.
The `SetPropertyValue`, at the moment, cannot work that way. The BHoM_Engine project, where the `DeepClone` resides, references the Reflection_Engine. Trying to use any cloning functionality would result in a circular dependency.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Reflection_Engine/Reflection_Engine-Issue985-IsDeprecatedInterfaceMethod/ReflectionEngine-Issue982-GetSetNestedProperties.gh?csf=1&e=2RnGdv
