### PR TITLE
Geometry_Engine: issues 980, 1008: Join(iCurve) bug and Circles inside PolyCurves

### DIFF
--- a/Geometry_Engine/Compute/Join.cs
+++ b/Geometry_Engine/Compute/Join.cs
@@ -148,7 +148,15 @@ namespace BH.Engine.Geometry
 
         public static List<PolyCurve> IJoin(this List<ICurve> curves, double tolerance = Tolerance.Distance)
         {
-            List<PolyCurve> sections = curves.Select(c => new PolyCurve { Curves = new List<ICurve> { c.IClone() } }).ToList();
+            List<PolyCurve> sections = new List<PolyCurve>();
+            
+            foreach(ICurve curve in curves)
+            {
+                if (curve is PolyCurve)
+                    sections.Add(curve as PolyCurve);
+                else
+                    sections.Add(new PolyCurve { Curves = curve.ISubParts().ToList() });
+            }
 
             double sqTol = tolerance * tolerance;
             int counter = 0;

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -103,9 +103,7 @@ namespace BH.Engine.Geometry
             Vector startVector = circle.StartPoint() - circle.Centre;
             Vector normal = circle.Normal;
             Double rotAng;
-
             Cartesian system = new Cartesian(circle.Centre, startVector.Normalise(), (circle.PointAtParameter(0.25) - cirCen).Normalise(), normal);
-            
             Arc mainArc = new Arc();
             Arc tmpArc = new Arc();
 
@@ -231,6 +229,13 @@ namespace BH.Engine.Geometry
                     tmpResult.AddRange((crv as Line).SplitAtPoints(subPoints));
                     subPoints.Clear();
                 }
+                else if (crv is Circle)
+                {
+                    List<PolyCurve> tResult = new List<PolyCurve>();
+                    foreach (Arc arc in (crv as Circle).SplitAtPoints(onCurvePoints, tolerance))
+                        tResult.Add(new PolyCurve { Curves = new List<ICurve> { arc } });
+                    result.AddRange(tResult);
+                }
                 else
                     throw new NotImplementedException();
             }
@@ -273,7 +278,7 @@ namespace BH.Engine.Geometry
                 i++;
             }
 
-            if (curve.IsClosed(tolerance))
+            if (curve.IsClosed(tolerance) && !(curve.SubParts()[0] is Circle))
                 if (!curve.StartPoint().IsEqual(onCurvePoints[onCurvePoints.Count - 1]))
                 {
                     List<ICurve> subResultList = new List<ICurve>();
@@ -371,5 +376,24 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
+        /****           TEST METHODS                    ****/
+        /***************************************************/
+        /****     TO BE DELETED BEFORE MERGING!!        ****/
+        /***************************************************/
+
+        public static List<ICurve> ISplitAtPointsTEST(this ICurve curve, List<Point> points, double tolerance = Tolerance.Distance)
+        {
+            if (curve is Circle)
+                curve = new PolyCurve { Curves = { curve } };
+
+            List<ICurve> result = new List<ICurve>();
+            System.Collections.IList splitCurves = SplitAtPoints(curve as dynamic, points, tolerance);
+            for (int i = 0; i < splitCurves.Count; i++)
+            {
+                result.Add(splitCurves[i] as ICurve);
+            }
+
+            return result;
+        }
     }
 }

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -375,25 +375,6 @@ namespace BH.Engine.Geometry
             return result;
         }
 
-        /***************************************************/
-        /****           TEST METHODS                    ****/
-        /***************************************************/
-        /****     TO BE DELETED BEFORE MERGING!!        ****/
-        /***************************************************/
-
-        public static List<ICurve> ISplitAtPointsTEST(this ICurve curve, List<Point> points, double tolerance = Tolerance.Distance)
-        {
-            if (curve is Circle)
-                curve = new PolyCurve { Curves = { curve } };
-
-            List<ICurve> result = new List<ICurve>();
-            System.Collections.IList splitCurves = SplitAtPoints(curve as dynamic, points, tolerance);
-            for (int i = 0; i < splitCurves.Count; i++)
-            {
-                result.Add(splitCurves[i] as ICurve);
-            }
-
-            return result;
-        }
+        /***************************************************/        
     }
 }

--- a/Geometry_Engine/Query/IsClockwise.cs
+++ b/Geometry_Engine/Query/IsClockwise.cs
@@ -138,19 +138,5 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
-
-        /***************************************************/
-        /****           TEST METHODS                    ****/
-        /***************************************************/
-        /****     TO BE DELETED BEFORE MERGING!!        ****/
-        /***************************************************/
-
-        public static bool IIsClockwiseTEST(this ICurve curve, Vector axis, double tolerance = Tolerance.Distance)
-        {
-            if (curve is Circle)
-                curve = new PolyCurve { Curves = { curve } };
-
-            return IsClockwise(curve as PolyCurve, axis, tolerance);
-        }
     }
 }

--- a/Geometry_Engine/Query/IsClockwise.cs
+++ b/Geometry_Engine/Query/IsClockwise.cs
@@ -80,8 +80,8 @@ namespace BH.Engine.Geometry
                 }
                 else if (c is Circle)
                 {
-                    cPts.Add((c as Circle).PointAtParameter(0.3));
-                    cPts.Add((c as Circle).PointAtParameter(0.6));
+                    cPts.Add((c as Circle).PointAtParameter(1.0 / 3));
+                    cPts.Add((c as Circle).PointAtParameter(2.0 / 3));
                     cPts.Add((c as Circle).EndPoint());
                 }
                 else
@@ -125,9 +125,7 @@ namespace BH.Engine.Geometry
 
         public static bool IsClockwise(this Circle curve, Vector axis, double tolerance = Tolerance.Distance)
         {
-            List<Point> cPts = new List<Point> { curve.StartPoint(), curve.PointAtParameter(0.3),
-                                                 curve.PointAtParameter(0.6), curve.EndPoint() };
-            return IsClockwise(new Polyline { ControlPoints = cPts }, axis, tolerance);
+            return axis.DotProduct(curve.Normal()) > 0;
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/IsClockwise.cs
+++ b/Geometry_Engine/Query/IsClockwise.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -75,8 +75,14 @@ namespace BH.Engine.Geometry
                     cPts.Add(c.IEndPoint());
                 else if (c is Arc)
                 {
-                    cPts.Add(c.IPointAtParameter(0.5));
-                    cPts.Add(c.IEndPoint());
+                    cPts.Add((c as Arc).PointAtParameter(0.5));
+                    cPts.Add((c as Arc).EndPoint());
+                }
+                else if (c is Circle)
+                {
+                    cPts.Add((c as Circle).PointAtParameter(0.3));
+                    cPts.Add((c as Circle).PointAtParameter(0.6));
+                    cPts.Add((c as Circle).EndPoint());
                 }
                 else
                     throw new NotImplementedException();
@@ -115,16 +121,38 @@ namespace BH.Engine.Geometry
             return ((normal.DotProduct(axis) < 0) != (arc.Angle() > Math.PI));       
         }
 
+        /***************************************************/
+
+        public static bool IsClockwise(this Circle curve, Vector axis, double tolerance = Tolerance.Distance)
+        {
+            List<Point> cPts = new List<Point> { curve.StartPoint(), curve.PointAtParameter(0.3),
+                                                 curve.PointAtParameter(0.6), curve.EndPoint() };
+            return IsClockwise(new Polyline { ControlPoints = cPts }, axis, tolerance);
+        }
 
         /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
-        
+
         public static bool IIsClockwise(this ICurve curve, Vector axis, double tolerance = Tolerance.Distance)
         {
             return IsClockwise(curve as dynamic, axis, tolerance);
         }
 
         /***************************************************/
+
+        /***************************************************/
+        /****           TEST METHODS                    ****/
+        /***************************************************/
+        /****     TO BE DELETED BEFORE MERGING!!        ****/
+        /***************************************************/
+
+        public static bool IIsClockwiseTEST(this ICurve curve, Vector axis, double tolerance = Tolerance.Distance)
+        {
+            if (curve is Circle)
+                curve = new PolyCurve { Curves = { curve } };
+
+            return IsClockwise(curve as PolyCurve, axis, tolerance);
+        }
     }
 }

--- a/Geometry_Engine/Query/IsCoplanar.cs
+++ b/Geometry_Engine/Query/IsCoplanar.cs
@@ -107,6 +107,11 @@ namespace BH.Engine.Geometry
                     pts.Add((crv as Arc).PointAtParameter(0.5));
                     pts.Add((crv as Arc).EndPoint());
                 }
+                else if (crv is Circle)
+                {
+                    pts.Add((crv as Circle).PointAtParameter(0.3));
+                    pts.Add((crv as Circle).PointAtParameter(0.6));
+                }
                 else
                 {
                     throw new NotImplementedException();
@@ -124,6 +129,11 @@ namespace BH.Engine.Geometry
                     pts.Add((crv as Arc).PointAtParameter(0.5));
                     pts.Add((crv as Arc).EndPoint());
                 }
+                else if (crv is Circle)
+                {
+                    pts.Add((crv as Circle).PointAtParameter(0.3));
+                    pts.Add((crv as Circle).PointAtParameter(0.6));
+                }
                 else
                 {
                     throw new NotImplementedException();
@@ -132,6 +142,8 @@ namespace BH.Engine.Geometry
             
             return pts.IsCoplanar(tolerance);
         }
+
+        /***************************************************/
 
         public static bool IIsCoplanar(this ICurve curve1, ICurve curve2, double tolerance = Tolerance.Distance)
         {
@@ -145,6 +157,11 @@ namespace BH.Engine.Geometry
                 {
                     pts.Add((crv as Arc).PointAtParameter(0.5));
                     pts.Add((crv as Arc).EndPoint());
+                }
+                else if (crv is Circle)
+                {
+                    pts.Add((crv as Circle).PointAtParameter(0.3));
+                    pts.Add((crv as Circle).PointAtParameter(0.6));
                 }
                 else
                 {
@@ -162,6 +179,72 @@ namespace BH.Engine.Geometry
                 {
                     pts.Add((crv as Arc).PointAtParameter(0.5));
                     pts.Add((crv as Arc).EndPoint());
+                }
+                else if (crv is Circle)
+                {
+                    pts.Add((crv as Circle).PointAtParameter(0.3));
+                    pts.Add((crv as Circle).PointAtParameter(0.6));
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            return pts.IsCoplanar(tolerance);
+        }
+
+        /***************************************************/
+        /****           TEST METHODS                    ****/
+        /***************************************************/
+        /****     TO BE DELETED BEFORE MERGING!!        ****/
+        /***************************************************/
+
+        public static bool IsCoplanarTEST(this ICurve curve1, ICurve curve2, double tolerance = Tolerance.Distance)
+        {
+            if (curve1 is Circle)
+                curve1 = new PolyCurve { Curves = { curve1 } };
+
+            if (curve1 is Circle)
+                curve1 = new PolyCurve { Curves = { curve1 } };
+
+            List<Point> pts = new List<Point> { curve1.IStartPoint() };
+
+            foreach (ICurve crv in curve1.ISubParts())
+            {
+                if (crv is Line)
+                    pts.Add((crv as Line).End);
+                else if (crv is Arc)
+                {
+                    pts.Add((crv as Arc).PointAtParameter(0.5));
+                    pts.Add((crv as Arc).EndPoint());
+                }
+                else if (crv is Circle)
+                {
+                    pts.Add((crv as Circle).PointAtParameter(0.3));
+                    pts.Add((crv as Circle).PointAtParameter(0.6));
+                }
+                else
+                {
+                    throw new NotImplementedException();
+                }
+            }
+
+            pts.Add(curve2.IStartPoint());
+
+            foreach (ICurve crv in curve2.ISubParts())
+            {
+                if (crv is Line)
+                    pts.Add((crv as Line).End);
+                else if (crv is Arc)
+                {
+                    pts.Add((crv as Arc).PointAtParameter(0.5));
+                    pts.Add((crv as Arc).EndPoint());
+                }
+                else if (crv is Circle)
+                {
+                    pts.Add((crv as Circle).PointAtParameter(0.3));
+                    pts.Add((crv as Circle).PointAtParameter(0.6));
                 }
                 else
                 {

--- a/Geometry_Engine/Query/IsCoplanar.cs
+++ b/Geometry_Engine/Query/IsCoplanar.cs
@@ -194,65 +194,6 @@ namespace BH.Engine.Geometry
             return pts.IsCoplanar(tolerance);
         }
 
-        /***************************************************/
-        /****           TEST METHODS                    ****/
-        /***************************************************/
-        /****     TO BE DELETED BEFORE MERGING!!        ****/
-        /***************************************************/
-
-        public static bool IsCoplanarTEST(this ICurve curve1, ICurve curve2, double tolerance = Tolerance.Distance)
-        {
-            if (curve1 is Circle)
-                curve1 = new PolyCurve { Curves = { curve1 } };
-
-            if (curve1 is Circle)
-                curve1 = new PolyCurve { Curves = { curve1 } };
-
-            List<Point> pts = new List<Point> { curve1.IStartPoint() };
-
-            foreach (ICurve crv in curve1.ISubParts())
-            {
-                if (crv is Line)
-                    pts.Add((crv as Line).End);
-                else if (crv is Arc)
-                {
-                    pts.Add((crv as Arc).PointAtParameter(0.5));
-                    pts.Add((crv as Arc).EndPoint());
-                }
-                else if (crv is Circle)
-                {
-                    pts.Add((crv as Circle).PointAtParameter(0.3));
-                    pts.Add((crv as Circle).PointAtParameter(0.6));
-                }
-                else
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            pts.Add(curve2.IStartPoint());
-
-            foreach (ICurve crv in curve2.ISubParts())
-            {
-                if (crv is Line)
-                    pts.Add((crv as Line).End);
-                else if (crv is Arc)
-                {
-                    pts.Add((crv as Arc).PointAtParameter(0.5));
-                    pts.Add((crv as Arc).EndPoint());
-                }
-                else if (crv is Circle)
-                {
-                    pts.Add((crv as Circle).PointAtParameter(0.3));
-                    pts.Add((crv as Circle).PointAtParameter(0.6));
-                }
-                else
-                {
-                    throw new NotImplementedException();
-                }
-            }
-
-            return pts.IsCoplanar(tolerance);
-        }
+        /***************************************************/        
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

closes #1008
addresses #980

Fixed `Join (List<ICurve>)` so now if there is PolyCurve as input it will stay unchanged and will not be wrapped into another PolyCurve.
Updated `SplitAtPoints`, `IsClockwise` and `IsCoplanar` `(PolyCurve)` so now when a Circle is a part of PolyCurve, these methods would return correct values. Also created `IsClockwise(Circle)`.

<!-- Add short description of what has been fixed -->


### Test files
Join - regular test [file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Modify/Join.gh?csf=1&e=Dt1zjb)
SplitAtPoints, IsClockwise and IsCoplanar - [issue specific test](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Geometry_Engine-issue980-CircleInPolycurveIssue/Geometry_Engine-issue980-CircleInPolycurveIssue.gh?csf=1&e=kgMlaN). As grasshopper immediately casts everything, there was a problem with providing input as Circle inside a PolyCurve. I've made additional 3 test methods which at the first step cast Circle to PolyCurve and then work exactly same as regular ones. They are all in this test file. **THEY NEED TO BE DELETED BEFORE MERGING.** 
I've updated some of regular test files to check if after updates all methods work as they did.
SplitAtPoints - [click](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Modify/SplitAtPoints.gh?csf=1&e=BmLIQd)
IsClockwise - [click](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Query/IsClockwise.gh?csf=1&e=fz56Xb)
IsCoplanar - [click](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Query/IsCoplanar.gh?csf=1&e=Z2mUaq)


### Changelog
Updated:
- `Join (List<ICurve>)`
- `SplitAtPoints(PolyCurve)`
- `IsClockwise<PolyCurve>)`
- `IsCoplanar(PolyCurve)`

Added:
- `IsClockwise(Circle)`

### Additional comments
As soon as this PR will be merged I will push another with Interfaces for Boolean operations on regions.
Edit: I just realized that I said so two PRs ago, but it was before we decided that Circular panels should also be included 😄 