### PR TITLE
Geometry_Engine: #924 Add Interfaces to Boolean Intersection / Union / Difference

### DIFF
--- a/Geometry_Engine/Compute/BooleanDifference.cs
+++ b/Geometry_Engine/Compute/BooleanDifference.cs
@@ -248,10 +248,10 @@ namespace BH.Engine.Geometry
             {
                 for (int j = 0; j < tmpResult.Count; j++)
                 {
-                    if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                    if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                     {
                         for (int k = i > j ? i + 1 : j + 1; k < tmpResult.Count(); k++)
-                            if (tmpResult[k].IsGeometricallyEqual(tmpResult[j], tolerance))
+                            if (tmpResult[k].IsSimilarSegment(tmpResult[j], tolerance))
                                 tmpResult.RemoveAt(k);
 
                         if (!tmpResult[i].PointAtParameter(0.5).IsOnCurve(region, tolerance) &&
@@ -398,10 +398,10 @@ namespace BH.Engine.Geometry
             {
                 for (int j = 0; j < tmpResult.Count; j++)
                 {
-                    if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                    if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                     {
                         for (int k = i > j ? i + 1 : j + 1; k < tmpResult.Count(); k++)
-                            if (tmpResult[k].IsGeometricallyEqual(tmpResult[j], tolerance))
+                            if (tmpResult[k].IsSimilarSegment(tmpResult[j], tolerance))
                                 tmpResult.RemoveAt(k);
 
                         if (!tmpResult[i].PointAtParameter(0.5).IsOnCurve(region, tolerance) &&
@@ -551,10 +551,10 @@ namespace BH.Engine.Geometry
             {
                 for (int j = 0; j < tmpResult.Count; j++)
                 {
-                    if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                    if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                     {
                         for (int k = i > j ? i + 1 : j + 1; k < tmpResult.Count(); k++)
-                            if (tmpResult[k].IsGeometricallyEqual(tmpResult[j], tolerance))
+                            if (tmpResult[k].IsSimilarSegment(tmpResult[j], tolerance))
                                 tmpResult.RemoveAt(k);
                         
                         if (!tmpResult[i].IPointAtParameter(0.5).IsOnCurve(region,tolerance) &&

--- a/Geometry_Engine/Compute/BooleanIntersection.cs
+++ b/Geometry_Engine/Compute/BooleanIntersection.cs
@@ -238,115 +238,19 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [DeprecatedAttribute("2.3", "Replace with method for ICurve, ICurve", null, "BooleanIntersection")]
+        [DeprecatedAttribute("2.3", "Replaced with method for ICurve, ICurve", null, "BooleanIntersection")]
         public static List<PolyCurve> BooleanIntersection(this PolyCurve region, PolyCurve refRegion, double tolerance = Tolerance.Distance)
         {
             return (region as ICurve).BooleanIntersection(refRegion, tolerance);
-
-        //    if (!region.IsClosed(tolerance) || !refRegion.IsClosed(tolerance))
-        //    {
-        //        Reflection.Compute.RecordError("Boolean Union works on closed regions.");
-        //        return new List<PolyCurve>();
-        //    }
-
-        //    if (!region.IsCoplanar(refRegion, tolerance))
-        //        return new List<PolyCurve>();
-
-        //    double sqTol = tolerance * tolerance;
-        //    List<PolyCurve> tmpResult = new List<PolyCurve>();
-        //    List<Point> iPts = region.CurveIntersections(refRegion, tolerance);
-
-        //    List<PolyCurve> splitRegion1 = region.SplitAtPoints(iPts, tolerance);
-        //    List<PolyCurve> splitRegion2 = refRegion.SplitAtPoints(iPts, tolerance);
-
-        //    foreach (PolyCurve segment in splitRegion1)
-        //    {
-        //        List<Point> mPts = new List<Point> { segment.IPointAtParameter(0.5) };
-
-        //        if (refRegion.IsContaining(mPts, true, tolerance))
-        //            tmpResult.Add(segment);
-        //    }
-
-        //    foreach (PolyCurve segment in splitRegion2)
-        //    {
-        //        List<Point> cPts = new List<Point> { segment.IPointAtParameter(0.5) };
-
-        //        if (region.IsContaining(cPts, true, tolerance))
-        //            tmpResult.Add(segment);
-        //    }
-
-        //    bool regSameDir = false;
-        //    if (Math.Abs(region.Normal().DotProduct(refRegion.Normal()) - 1) <= tolerance)
-        //        regSameDir = true;
-
-        //    for (int i = 0; i < tmpResult.Count; i++)
-        //    {
-        //        for (int j = 0; j < tmpResult.Count; j++)
-        //        {
-        //            if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
-        //            {
-        //                bool sameDir = tmpResult[i].TangentAtParameter(0.5).IsEqual(tmpResult[j].TangentAtParameter(0.5));
-        //                if ((regSameDir && sameDir) || (!regSameDir && !sameDir))
-        //                {
-        //                    tmpResult.RemoveAt(Math.Min(j, i));
-        //                    if (i > j)
-        //                        i--;
-        //                    else
-        //                        j = 0;
-        //                }
-        //                else
-        //                {
-        //                    tmpResult.RemoveAt(Math.Max(j, i));
-        //                    tmpResult.RemoveAt(Math.Min(j, i));
-        //                    if (i > 0)
-        //                        i--;
-        //                    else
-        //                        j = 0;
-        //                }
-        //            }
-        //        }
-        //    }
-
-        //    List<PolyCurve> result = Join(tmpResult, tolerance);
-
-        //    int res = 0;
-        //    while (res < result.Count)
-        //    {
-        //        if (result[res].Area() <= sqTol)
-        //            result.RemoveAt(res);
-        //        else
-        //            res++;
-        //    }
-
-        //    return result;
         }
 
         /***************************************************/
 
-        [DeprecatedAttribute("2.3", "Replace with method for IEnumerable<ICurve>", null, "BooleanIntersection")]
+        [DeprecatedAttribute("2.3", "Replaced with method for IEnumerable<ICurve>", null, "BooleanIntersection")]
         public static List<PolyCurve> BooleanIntersection(this List<PolyCurve> regions, double tolerance = Tolerance.Distance)
         {
-            return regions.BooleanIntersection(tolerance);
-
-            if (regions.Count < 2)
-                return regions;
-
-            List<PolyCurve> result = new List<PolyCurve>();
-
-            foreach (PolyCurve region in regions)
-            {
-                if (region.Area() <= tolerance)
-                    return result;
-            }
-            result.Add(regions[0]);
-            for (int i = 1; i < regions.Count; i++)
-            {
-                List<PolyCurve> newResult = new List<PolyCurve>();
-                result.ForEach(r => newResult.AddRange(r.BooleanIntersection(regions[i], tolerance)));
-                result = newResult;
-            }
-
-            return result;
+            List<ICurve> regionsICurve = new List<ICurve>(regions);
+            return regionsICurve.BooleanIntersection(tolerance);
         }
 
         /***************************************************/
@@ -450,7 +354,7 @@ namespace BH.Engine.Geometry
         public static List<PolyCurve> BooleanIntersection(this IEnumerable<ICurve> regions, double tolerance = Tolerance.Distance)
         {
             List<ICurve> regionsList = regions.ToList();
-            
+
             List<PolyCurve> regionListPolyCurve = new List<PolyCurve>();
 
             foreach (ICurve curve in regionsList)
@@ -461,9 +365,9 @@ namespace BH.Engine.Geometry
                     regionListPolyCurve.Add(new PolyCurve { Curves = curve.ISubParts().ToList() });
             }
 
-            if (regionListPolyCurve.Count < 2)            
+            if (regionListPolyCurve.Count < 2)
                 return regionListPolyCurve;
-            
+
             List<PolyCurve> result = new List<PolyCurve>();
 
             foreach (PolyCurve region in regionListPolyCurve)
@@ -476,17 +380,17 @@ namespace BH.Engine.Geometry
             for (int i = 1; i < regionListPolyCurve.Count; i++)
             {
                 List<PolyCurve> newResult = new List<PolyCurve>();
-                result.ForEach(r => newResult.AddRange(r.BooleanIntersection(regionListPolyCurve[i], tolerance)));
+                result.ForEach(r => newResult.AddRange(r.BooleanIntersection((ICurve)regionListPolyCurve[i], tolerance)));
                 result = newResult;
             }
 
             return result;
         }
 
-        /***************************************************/
+        /**************************************************
         /***          Private methods                    ***/
         /***************************************************/
-        
+
         private static Boolean IsSimilarSegment(this ICurve curve, ICurve refCurve, double tolerance = Tolerance.Distance)
         {
             double sqTol = tolerance * tolerance;

--- a/Geometry_Engine/Compute/BooleanIntersection.cs
+++ b/Geometry_Engine/Compute/BooleanIntersection.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -237,90 +238,96 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [DeprecatedAttribute("2.3", "Replace with method for ICurve, ICurve", null, "BooleanIntersection")]
         public static List<PolyCurve> BooleanIntersection(this PolyCurve region, PolyCurve refRegion, double tolerance = Tolerance.Distance)
         {
-            if (!region.IsClosed(tolerance) || !refRegion.IsClosed(tolerance))
-            {
-                Reflection.Compute.RecordError("Boolean Union works on closed regions.");
-                return new List<PolyCurve>();
-            }
+            return (region as ICurve).BooleanIntersection(refRegion, tolerance);
 
-            if (!region.IsCoplanar(refRegion, tolerance))
-                return new List<PolyCurve>();
+        //    if (!region.IsClosed(tolerance) || !refRegion.IsClosed(tolerance))
+        //    {
+        //        Reflection.Compute.RecordError("Boolean Union works on closed regions.");
+        //        return new List<PolyCurve>();
+        //    }
 
-            double sqTol = tolerance * tolerance;
-            List<PolyCurve> tmpResult = new List<PolyCurve>();
-            List<Point> iPts = region.CurveIntersections(refRegion, tolerance);
+        //    if (!region.IsCoplanar(refRegion, tolerance))
+        //        return new List<PolyCurve>();
 
-            List<PolyCurve> splitRegion1 = region.SplitAtPoints(iPts, tolerance);
-            List<PolyCurve> splitRegion2 = refRegion.SplitAtPoints(iPts, tolerance);
+        //    double sqTol = tolerance * tolerance;
+        //    List<PolyCurve> tmpResult = new List<PolyCurve>();
+        //    List<Point> iPts = region.CurveIntersections(refRegion, tolerance);
 
-            foreach (PolyCurve segment in splitRegion1)
-            {
-                List<Point> mPts = new List<Point> { segment.IPointAtParameter(0.5) };
+        //    List<PolyCurve> splitRegion1 = region.SplitAtPoints(iPts, tolerance);
+        //    List<PolyCurve> splitRegion2 = refRegion.SplitAtPoints(iPts, tolerance);
 
-                if (refRegion.IsContaining(mPts, true, tolerance))
-                    tmpResult.Add(segment);
-            }
+        //    foreach (PolyCurve segment in splitRegion1)
+        //    {
+        //        List<Point> mPts = new List<Point> { segment.IPointAtParameter(0.5) };
 
-            foreach (PolyCurve segment in splitRegion2)
-            {
-                List<Point> cPts = new List<Point> { segment.IPointAtParameter(0.5) };
+        //        if (refRegion.IsContaining(mPts, true, tolerance))
+        //            tmpResult.Add(segment);
+        //    }
 
-                if (region.IsContaining(cPts, true, tolerance))
-                    tmpResult.Add(segment);
-            }
+        //    foreach (PolyCurve segment in splitRegion2)
+        //    {
+        //        List<Point> cPts = new List<Point> { segment.IPointAtParameter(0.5) };
 
-            bool regSameDir = false;
-            if (Math.Abs(region.Normal().DotProduct(refRegion.Normal()) - 1) <= tolerance)
-                regSameDir = true;
+        //        if (region.IsContaining(cPts, true, tolerance))
+        //            tmpResult.Add(segment);
+        //    }
 
-            for (int i = 0; i < tmpResult.Count; i++)
-            {
-                for (int j = 0; j < tmpResult.Count; j++)
-                {
-                    if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
-                    {
-                        bool sameDir = tmpResult[i].TangentAtParameter(0.5).IsEqual(tmpResult[j].TangentAtParameter(0.5));
-                        if ((regSameDir && sameDir) || (!regSameDir && !sameDir))
-                        {
-                            tmpResult.RemoveAt(Math.Min(j, i));
-                            if (i > j)
-                                i--;
-                            else
-                                j = 0;
-                        }
-                        else
-                        {
-                            tmpResult.RemoveAt(Math.Max(j, i));
-                            tmpResult.RemoveAt(Math.Min(j, i));
-                            if (i > 0)
-                                i--;
-                            else
-                                j = 0;
-                        }
-                    }
-                }
-            }
+        //    bool regSameDir = false;
+        //    if (Math.Abs(region.Normal().DotProduct(refRegion.Normal()) - 1) <= tolerance)
+        //        regSameDir = true;
 
-            List<PolyCurve> result = Join(tmpResult, tolerance);
+        //    for (int i = 0; i < tmpResult.Count; i++)
+        //    {
+        //        for (int j = 0; j < tmpResult.Count; j++)
+        //        {
+        //            if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
+        //            {
+        //                bool sameDir = tmpResult[i].TangentAtParameter(0.5).IsEqual(tmpResult[j].TangentAtParameter(0.5));
+        //                if ((regSameDir && sameDir) || (!regSameDir && !sameDir))
+        //                {
+        //                    tmpResult.RemoveAt(Math.Min(j, i));
+        //                    if (i > j)
+        //                        i--;
+        //                    else
+        //                        j = 0;
+        //                }
+        //                else
+        //                {
+        //                    tmpResult.RemoveAt(Math.Max(j, i));
+        //                    tmpResult.RemoveAt(Math.Min(j, i));
+        //                    if (i > 0)
+        //                        i--;
+        //                    else
+        //                        j = 0;
+        //                }
+        //            }
+        //        }
+        //    }
 
-            int res = 0;
-            while (res < result.Count)
-            {
-                if (result[res].Area() <= sqTol)
-                    result.RemoveAt(res);
-                else
-                    res++;
-            }
+        //    List<PolyCurve> result = Join(tmpResult, tolerance);
 
-            return result;
+        //    int res = 0;
+        //    while (res < result.Count)
+        //    {
+        //        if (result[res].Area() <= sqTol)
+        //            result.RemoveAt(res);
+        //        else
+        //            res++;
+        //    }
+
+        //    return result;
         }
 
         /***************************************************/
 
+        [DeprecatedAttribute("2.3", "Replace with method for IEnumerable<ICurve>", null, "BooleanIntersection")]
         public static List<PolyCurve> BooleanIntersection(this List<PolyCurve> regions, double tolerance = Tolerance.Distance)
         {
+            return regions.BooleanIntersection(tolerance);
+
             if (regions.Count < 2)
                 return regions;
 
@@ -344,7 +351,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static List<ICurve> IBooleanIntersection(this ICurve region, ICurve refRegion, double tolerance = Tolerance.Distance)
+        public static List<PolyCurve> BooleanIntersection(this ICurve region, ICurve refRegion, double tolerance = Tolerance.Distance)
         {
             if (region is NurbsCurve || region is Ellipse || refRegion is NurbsCurve || refRegion is Ellipse)
                 throw new NotImplementedException("NurbsCurves and ellipses are not implemented yet.");
@@ -352,11 +359,11 @@ namespace BH.Engine.Geometry
             if (!region.IIsClosed(tolerance) || !refRegion.IIsClosed(tolerance))
             {
                 Reflection.Compute.RecordError("Boolean Intersection works on closed regions.");
-                return new List<ICurve>();
+                return new List<PolyCurve>();
             }
 
             if (!region.IIsCoplanar(refRegion, tolerance))
-                return new List<ICurve>();
+                return new List<PolyCurve>();
 
             double sqTol = tolerance * tolerance;
             List<ICurve> tmpResult = new List<ICurve>();
@@ -423,12 +430,12 @@ namespace BH.Engine.Geometry
                 }
             }
 
-            List<ICurve> result = IJoin(tmpResult, tolerance).Cast<ICurve>().ToList();
+            List<PolyCurve> result = IJoin(tmpResult, tolerance).ToList();
 
             int res = 0;
             while (res < result.Count)
             {
-                if (result[res].IArea() <= sqTol || !result[res].IIsClosed(tolerance))
+                if (result[res].Area() <= sqTol || !result[res].IIsClosed(tolerance))
                     result.RemoveAt(res);
                 else
                     res++;
@@ -440,26 +447,36 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static List<ICurve> IBooleanIntersection(this List<ICurve> regions, double tolerance = Tolerance.Distance)
+        public static List<PolyCurve> BooleanIntersection(this IEnumerable<ICurve> regions, double tolerance = Tolerance.Distance)
         {
-            if (regions.Count < 2)
+            List<ICurve> regionsList = regions.ToList();
+            
+            List<PolyCurve> regionListPolyCurve = new List<PolyCurve>();
+
+            foreach (ICurve curve in regionsList)
             {
-                return regions;
+                if (curve is PolyCurve)
+                    regionListPolyCurve.Add(curve as PolyCurve);
+                else
+                    regionListPolyCurve.Add(new PolyCurve { Curves = curve.ISubParts().ToList() });
             }
 
-            List<ICurve> result = new List<ICurve>();
+            if (regionListPolyCurve.Count < 2)            
+                return regionListPolyCurve;
+            
+            List<PolyCurve> result = new List<PolyCurve>();
 
-            foreach (ICurve region in regions)
+            foreach (PolyCurve region in regionListPolyCurve)
             {
-                if (region.IArea() <= tolerance)
+                if (region.Area() <= tolerance)
                     return result;
             }
 
-            result.Add(regions[0]);
-            for (int i = 1; i < regions.Count; i++)
+            result.Add(regionListPolyCurve[0]);
+            for (int i = 1; i < regionListPolyCurve.Count; i++)
             {
-                List<ICurve> newResult = new List<ICurve>();
-                result.ForEach(r => newResult.AddRange(r.IBooleanIntersection(regions[i], tolerance)));
+                List<PolyCurve> newResult = new List<PolyCurve>();
+                result.ForEach(r => newResult.AddRange(r.BooleanIntersection(regionListPolyCurve[i], tolerance)));
                 result = newResult;
             }
 

--- a/Geometry_Engine/Compute/BooleanIntersection.cs
+++ b/Geometry_Engine/Compute/BooleanIntersection.cs
@@ -171,7 +171,7 @@ namespace BH.Engine.Geometry
             {
                 for (int j = 0; j < tmpResult.Count; j++)
                 {
-                    if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                    if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                     {
                         bool sameDir = tmpResult[i].TangentAtParameter(0.5).IsEqual(tmpResult[j].TangentAtParameter(0.5));
                         if ((regSameDir && sameDir) || (!regSameDir && !sameDir))
@@ -279,7 +279,7 @@ namespace BH.Engine.Geometry
             {
                 for (int j = 0; j < tmpResult.Count; j++)
                 {
-                    if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                    if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                     {
                         bool sameDir = tmpResult[i].TangentAtParameter(0.5).IsEqual(tmpResult[j].TangentAtParameter(0.5));
                         if ((regSameDir && sameDir) || (!regSameDir && !sameDir))
@@ -315,13 +315,6 @@ namespace BH.Engine.Geometry
             }
 
             return result;
-        }
-
-        /***************************************************/
-
-        public static List<PolyCurve> BooleanIntersection(this Circle region, PolyCurve refRegion, double tolerance = Tolerance.Distance)
-        {
-            return new PolyCurve { Curves = new List<ICurve> { region } }.BooleanIntersection(refRegion);
         }
 
         /***************************************************/
@@ -406,7 +399,7 @@ namespace BH.Engine.Geometry
             {
                  for (int j = 0; j < tmpResult.Count; j++)
                 {
-                    if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                    if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                     {
                         bool sameDir = tmpResult[i].ITangentAtParameter(0.5).IsEqual(tmpResult[j].ITangentAtParameter(0.5));
                         if ((regSameDir && sameDir) || (!regSameDir && !sameDir))
@@ -442,6 +435,7 @@ namespace BH.Engine.Geometry
             }
 
             return result;
+
         }
 
         /***************************************************/
@@ -476,21 +470,19 @@ namespace BH.Engine.Geometry
         /***          Private methods                    ***/
         /***************************************************/
         
-        private static Boolean IsGeometricallyEqual(this ICurve curve, ICurve refCurve, double tolerance = Tolerance.Distance)
+        private static Boolean IsSimilarSegment(this ICurve curve, ICurve refCurve, double tolerance = Tolerance.Distance)
         {
-            Boolean flag1 = false, flag2 = false;
+            double sqTol = tolerance * tolerance;
+            Point sp = curve.IStartPoint();
+            Point rsp = refCurve.IStartPoint();
+            Point mp = curve.IPointAtParameter(0.5);
+            Point rmp = refCurve.IPointAtParameter(0.5);
+            Point ep = curve.IEndPoint();
+            Point rep = refCurve.IEndPoint();
 
-            if (curve.IStartPoint().IsEqual(refCurve.IStartPoint(), tolerance) &&
-                curve.IPointAtParameter(0.5).IsEqual(refCurve.IPointAtParameter(0.5), tolerance) &&
-                curve.IEndPoint().IsEqual(refCurve.IEndPoint(), tolerance))
-                flag1 = true;
-
-            if (curve.IStartPoint().IsEqual(refCurve.IEndPoint(), tolerance) &&
-                curve.IPointAtParameter(0.5).IsEqual(refCurve.IPointAtParameter(0.5), tolerance) &&
-                curve.IEndPoint().IsEqual(refCurve.IStartPoint(), tolerance))
-                flag2 = true;
-
-            return flag1 || flag2;
+            return mp.SquareDistance(rmp) <= sqTol && 
+                   ((sp.SquareDistance(rsp) <= sqTol && ep.SquareDistance(rep) <= sqTol) ||
+                   (sp.SquareDistance(rep) <= sqTol && ep.SquareDistance(rsp) <= sqTol));
         }
 
         /***************************************************/      

--- a/Geometry_Engine/Compute/BooleanUnion.cs
+++ b/Geometry_Engine/Compute/BooleanUnion.cs
@@ -187,7 +187,7 @@ namespace BH.Engine.Geometry
                 {
                     for (int j = 0; j < tmpResult.Count; j++)
                     {
-                        if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                        if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                         {
                             if (tmpResult[i].TangentAtParameter(0.5).IsEqual(tmpResult[j].TangentAtParameter(0.5)))
                             {
@@ -310,7 +310,7 @@ namespace BH.Engine.Geometry
                 {
                     for (int j = 0; j < tmpResult.Count; j++)
                     {
-                        if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                        if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                         {
                             if (tmpResult[i].TangentAtParameter(0.5).IsEqual(tmpResult[j].TangentAtParameter(0.5)))
                             {
@@ -436,7 +436,7 @@ namespace BH.Engine.Geometry
                 {
                     for (int j = 0; j < tmpResult.Count; j++)
                     {
-                        if (i != j && tmpResult[i].IsGeometricallyEqual(tmpResult[j], tolerance))
+                        if (i != j && tmpResult[i].IsSimilarSegment(tmpResult[j], tolerance))
                         {
                             if (tmpResult[i].ITangentAtParameter(0.5).IsEqual(tmpResult[j].ITangentAtParameter(0.5)))
                             {

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -263,7 +263,7 @@ namespace BH.Engine.Geometry
                             j++;
                             break;
                         }
-                        else if (tmpResult[j].IEndPoint().IsEqual(curve.EndPoint()) || (curve.IIsClosed(tolerance) && !curve.IIsClockwise(curve.INormal(), tolerance) && tmpResult[j].IStartPoint().IsEqual(curve.StartPoint())))
+                        else if (tmpResult[j].IEndPoint().IsEqual(curve.EndPoint()) || (curve.IIsClosed(tolerance) && !curve.IIsClockwise(curve.INormal(), tolerance) && tmpResult[j].IEndPoint().IsEqual(curve.StartPoint())))
                         {
                             j++;
                             break;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

closes #924 

Added Interfaces for boolean methods. Now they work on both PolyCurves and Polylines as one input. Circles are are also implemented as singular Circles and as a parts of a PolyCurves. To be discussed is if we need separate Polyline, PolyCurve and Interface methods. I think we could have one method for Polylines as it is faster than others and one universal method for the rest (including Polylines). Method for only PolyCurves is a bit redundant.
I also did some updates in all boolean methods as there appeared new egde cases :wink:

However there are some issues with performance. In some cases BhoM methods are much faster then GH's, but they also can be slower. I give some examples in the thest file.

<!-- Add short description of what has been fixed -->


### Test files
Regular [Intersection](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Compute/BooleanIntersectionV3.gh?csf=1&e=BY2efi)
Regular [Union](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Compute/BooleanUnionV3.gh?csf=1&e=24Lmd4)
Regular [Difference](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Compute/BooleanDifferenceV3.gh?csf=1&e=9jxJpK)
[Performence issues](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Geometry_Engine-issue924-BooleanInterfacesPerformanceIssues/Geometry_Engine-issue924-BooleanInterfacesPerformanceIssues.gh?csf=1&e=SDehQZ)
Regular [SplitAtPoints](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Modify/SplitAtPoints.gh?csf=1&e=65S2CW)


### Changelog

#### Added:
- `Compute.IBooleanIntersection()` method added in the `Geometry_Engine` for `ICurve` and `ICurve` classes
- `Compute.IBooleanIntersection()` method added in the `Geometry_Engine` for `List<ICurve>` class
- `Compute.IBooleanUnion()` method added in the `Geometry_Engine` for `List<ICurve>` class
- `Compute.IBooleanDifference()` method added in the `Geometry_Engine` for `ICurve` and `List<ICurve>` classes

#### Changed:
- `Compute.BooleanIntersection()` method changed in the `Geometry_Engine` for `Polyline` and `Polyline` classes
- `Compute.BooleanUnion()` method changed in the `Geometry_Engine` for `List<Polyline>` class
- `Compute.BooleanDifference()` method changed in the `Geometry_Engine` for `Polyline` and `List<Polyline>` classes
- `Compute.BooleanIntersection()` deprecated method in the `Geometry_Engine` for `PolyCurve` and `PolyCurve` classes
- `Compute.BooleanUnion()` deprecated method in the `Geometry_Engine` for `List<PolyCurve>` class
- `Compute.BooleanDifference()` deprecated method in the `Geometry_Engine` for `PolyCurve` and `List<PolyCurve>` classes

### Additional comments
As said above, I think maybe methods for PolyCurves can be erased. The Interfaces would be our universal methods. Maybe without `I` as they are not interfaces by definition.