### PR TITLE
GeometryCommon_Engine-Issues1019,1020-BoundingBoxMethods

### DIFF
--- a/Common_Engine/Common_Engine.csproj
+++ b/Common_Engine/Common_Engine.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Modify\SetOutlineElements1D.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\Area.cs" />
+    <Compile Include="Query\Bounds.cs" />
     <Compile Include="Query\Centroid.cs" />
     <Compile Include="Query\ControlPoints.cs" />
     <Compile Include="Query\ElementCurves.cs" />

--- a/Common_Engine/Query/Bounds.cs
+++ b/Common_Engine/Query/Bounds.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Common
 
         public static BoundingBox Bounds(this IElement0D element0D)
         {
-            return element0D.IGeometry().IBounds();
+            return Geometry.Query.Bounds(element0D.IGeometry());
         }
 
 
@@ -47,7 +47,7 @@ namespace BH.Engine.Common
 
         public static BoundingBox Bounds(this IElement1D element1D)
         {
-            return element1D.IGeometry().IBounds();
+            return Geometry.Query.IBounds(element1D.IGeometry());
         }
 
 
@@ -62,9 +62,9 @@ namespace BH.Engine.Common
             if (elementCurves.Count == 0)
                 return null;
 
-            BoundingBox box = elementCurves[0].IBounds();
+            BoundingBox box = Geometry.Query.IBounds(elementCurves[0]);
             for (int i = 1; i < elementCurves.Count; i++)
-                box += elementCurves[i].IBounds();
+                box += Geometry.Query.IBounds(elementCurves[i]);
 
             return box;
         }
@@ -74,14 +74,14 @@ namespace BH.Engine.Common
         /****        Interface methods         ****/
         /******************************************/
 
-        public static BoundingBox IBounds(this BHoMObject element)
+        public static BoundingBox IBounds(this IObject element)
         {
             return Bounds(element as dynamic);
         }
 
         /******************************************/
 
-        public static BoundingBox IBounds(this List<BHoMObject> elements)
+        public static BoundingBox IBounds(this List<IObject> elements)
         {
             if (elements.Count == 0)
                 return null;

--- a/Common_Engine/Query/Bounds.cs
+++ b/Common_Engine/Query/Bounds.cs
@@ -26,6 +26,7 @@ using BH.oM.Common;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BH.Engine.Common
 {
@@ -81,14 +82,16 @@ namespace BH.Engine.Common
 
         /******************************************/
 
-        public static BoundingBox IBounds(this List<IElement> elements)
+        public static BoundingBox IBounds(this IEnumerable<IElement> elements)
         {
-            if (elements.Count == 0)
+            if (elements.Count() == 0)
                 return null;
 
-            BoundingBox box = elements[0].IBounds();
-            for (int i = 1; i < elements.Count; i++)
-                box += elements[i].IBounds();
+            BoundingBox box = elements.First().IBounds();
+            foreach (IElement element in elements.Skip(1))
+            {
+                box += element.IBounds();
+            }
 
             return box;
         }

--- a/Common_Engine/Query/Bounds.cs
+++ b/Common_Engine/Query/Bounds.cs
@@ -74,14 +74,14 @@ namespace BH.Engine.Common
         /****        Interface methods         ****/
         /******************************************/
 
-        public static BoundingBox IBounds(this IObject element)
+        public static BoundingBox IBounds(this IElement element)
         {
             return Bounds(element as dynamic);
         }
 
         /******************************************/
 
-        public static BoundingBox IBounds(this List<IObject> elements)
+        public static BoundingBox IBounds(this List<IElement> elements)
         {
             if (elements.Count == 0)
                 return null;

--- a/Common_Engine/Query/Bounds.cs
+++ b/Common_Engine/Query/Bounds.cs
@@ -1,0 +1,98 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.oM.Base;
+using BH.oM.Common;
+using BH.oM.Geometry;
+using System;
+using System.Collections.Generic;
+
+namespace BH.Engine.Common
+{
+    public static partial class Query
+    {
+        /******************************************/
+        /****            IElement0D            ****/
+        /******************************************/
+
+        public static BoundingBox Bounds(this IElement0D element0D)
+        {
+            return element0D.IGeometry().IBounds();
+        }
+
+
+        /******************************************/
+        /****            IElement1D            ****/
+        /******************************************/
+
+        public static BoundingBox Bounds(this IElement1D element1D)
+        {
+            return element1D.IGeometry().IBounds();
+        }
+
+
+        /******************************************/
+        /****            IElement2D            ****/
+        /******************************************/
+
+        public static BoundingBox Bounds(this IElement2D element2D)
+        {
+            List<ICurve> elementCurves = element2D.ElementCurves(true);
+
+            if (elementCurves.Count == 0)
+                return null;
+
+            BoundingBox box = elementCurves[0].IBounds();
+            for (int i = 1; i < elementCurves.Count; i++)
+                box += elementCurves[i].IBounds();
+
+            return box;
+        }
+
+
+        /******************************************/
+        /****        Interface methods         ****/
+        /******************************************/
+
+        public static BoundingBox IBounds(this BHoMObject element)
+        {
+            return Bounds(element as dynamic);
+        }
+
+        /******************************************/
+
+        public static BoundingBox IBounds(this List<BHoMObject> elements)
+        {
+            if (elements.Count == 0)
+                return null;
+
+            BoundingBox box = elements[0].IBounds();
+            for (int i = 1; i < elements.Count; i++)
+                box += elements[i].IBounds();
+
+            return box;
+        }
+
+        /******************************************/
+    }
+}

--- a/Geometry_Engine/Query/Bounds.cs
+++ b/Geometry_Engine/Query/Bounds.cs
@@ -279,9 +279,9 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static BoundingBox Bounds(this Polyline line)
+        public static BoundingBox Bounds(this Polyline curve)
         {
-            return Bounds(line.ControlPoints);
+            return curve.ControlPoints.Bounds();
         }
 
 
@@ -366,7 +366,7 @@ namespace BH.Engine.Geometry
         /**** public Methods - Others                  ****/
         /***************************************************/
 
-        public static BoundingBox Bounds(List<Point> pts)
+        public static BoundingBox Bounds(this List<Point> pts)
         {
             Point pt = pts[0];
             double minX = pt.X; double minY = pt.Y; double minZ = pt.Z;

--- a/Geometry_Engine/Query/Edges.cs
+++ b/Geometry_Engine/Query/Edges.cs
@@ -35,14 +35,29 @@ namespace BH.Engine.Geometry
 
         public static List<Line> Edges(this BoundingBox box)
         {
+            Point corner1 = box.Min;
+            Point corner2 = new Point { X = box.Min.X, Y = box.Min.Y, Z = box.Max.Z };
+            Point corner3 = new Point { X = box.Min.X, Y = box.Max.Y, Z = box.Max.Z };
+            Point corner4 = new Point { X = box.Min.X, Y = box.Max.Y, Z = box.Min.Z };
+            Point corner5 = new Point { X = box.Max.X, Y = box.Min.Y, Z = box.Min.Z };
+            Point corner6 = new Point { X = box.Max.X, Y = box.Max.Y, Z = box.Min.Z };
+            Point corner7 = box.Max;
+            Point corner8 = new Point { X = box.Max.X, Y = box.Min.Y, Z = box.Max.Z };
+
             return new List<Line>
             {
-                new Line {Start=box.Min, End=new Point {X=box.Max.X,Y=box.Min.Y,Z=box.Min.Z } },
-                new Line {Start=box.Min, End=new Point {X=box.Min.X,Y=box.Max.Y,Z=box.Min.Z } },
-                new Line {Start=box.Min, End=new Point {X=box.Min.X,Y=box.Min.Y,Z=box.Max.Z } },
-                new Line {Start=box.Max, End=new Point {X=box.Min.X,Y=box.Max.Y,Z=box.Max.Z } },
-                new Line {Start=box.Max, End=new Point {X=box.Max.X,Y=box.Min.Y,Z=box.Max.Z } },
-                new Line {Start=box.Max, End=new Point {X=box.Max.X,Y=box.Max.Y,Z=box.Min.Z } }
+                new Line { Start=corner1, End=corner2 },
+                new Line { Start=corner2, End=corner3 },
+                new Line { Start=corner3, End=corner4 },
+                new Line { Start=corner4, End=corner1 },
+                new Line { Start=corner5, End=corner6 },
+                new Line { Start=corner6, End=corner7 },
+                new Line { Start=corner7, End=corner8 },
+                new Line { Start=corner8, End=corner5 },
+                new Line { Start=corner5, End=corner1 },
+                new Line { Start=corner2, End=corner8 },
+                new Line { Start=corner7, End=corner3 },
+                new Line { Start=corner4, End=corner6 }
             };
         }
 

--- a/Geometry_Engine/Query/Edges.cs
+++ b/Geometry_Engine/Query/Edges.cs
@@ -30,6 +30,23 @@ namespace BH.Engine.Geometry
     public static partial class Query
     {
         /***************************************************/
+        /**** Public Methods - Bounding Box             ****/
+        /***************************************************/
+
+        public static List<Line> Edges(this BoundingBox box)
+        {
+            return new List<Line>
+            {
+                new Line {Start=box.Min, End=new Point {X=box.Max.X,Y=box.Min.Y,Z=box.Min.Z } },
+                new Line {Start=box.Min, End=new Point {X=box.Min.X,Y=box.Max.Y,Z=box.Min.Z } },
+                new Line {Start=box.Min, End=new Point {X=box.Min.X,Y=box.Min.Y,Z=box.Max.Z } },
+                new Line {Start=box.Max, End=new Point {X=box.Min.X,Y=box.Max.Y,Z=box.Max.Z } },
+                new Line {Start=box.Max, End=new Point {X=box.Max.X,Y=box.Min.Y,Z=box.Max.Z } },
+                new Line {Start=box.Max, End=new Point {X=box.Max.X,Y=box.Max.Y,Z=box.Min.Z } }
+            };
+        }
+
+        /***************************************************/
         /**** Public Methods - Meshes                   ****/
         /***************************************************/
 

--- a/Geometry_Engine/Query/IsInRange.cs
+++ b/Geometry_Engine/Query/IsInRange.cs
@@ -21,13 +21,14 @@
  */
 
 using BH.oM.Geometry;
+using System.Collections.Generic;
 
 namespace BH.Engine.Geometry
 {
     public static partial class Query
     {
         /***************************************************/
-        /**** Public Methods                            ****/
+        /**** Public Methods - BoundingBox              ****/
         /***************************************************/
 
         public static bool IsInRange(this BoundingBox box1, BoundingBox box2, double tolerance = Tolerance.Distance)
@@ -35,6 +36,48 @@ namespace BH.Engine.Geometry
             return (box1.Min.X <= box2.Max.X + tolerance && box2.Min.X <= box1.Max.X + tolerance &&
                      box1.Min.Y <= box2.Max.Y + tolerance && box2.Min.Y <= box1.Max.Y + tolerance &&
                      box1.Min.Z <= box2.Max.Z + tolerance && box2.Min.Z <= box1.Max.Z + tolerance);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods - Point                    ****/
+        /***************************************************/
+
+        public static bool IsInRange(this Point point, BoundingBox box, double tolerance = Tolerance.Distance)
+        {
+            return box.IsContaining(point, true, tolerance);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods - Curve                    ****/
+        /***************************************************/
+
+        public static bool IsInRange(this ICurve curve, BoundingBox box, double tolerance = Tolerance.Distance)
+        {
+            if (box.IsContaining(curve.IStartPoint()) || box.IsContaining(curve.IEndPoint()))
+                return true;
+
+            List<Plane> bBoxPlanes = new List<Plane>
+            {
+            new Plane { Origin = box.Min, Normal = Vector.XAxis },
+            new Plane { Origin = box.Min, Normal = Vector.YAxis },
+            new Plane { Origin = box.Min, Normal = Vector.ZAxis },
+            new Plane { Origin = box.Max, Normal = Vector.XAxis },
+            new Plane { Origin = box.Max, Normal = Vector.YAxis },
+            new Plane { Origin = box.Max, Normal = Vector.ZAxis }
+            };
+
+            foreach (Plane plane in bBoxPlanes)
+            {
+                foreach (Point point in curve.IPlaneIntersections(plane, tolerance))
+                {
+                    if (box.IsContaining(point, true, tolerance))
+                        return true;
+                }
+            }
+
+            return false;
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/PlaneIntersection.cs
+++ b/Geometry_Engine/Query/PlaneIntersection.cs
@@ -80,6 +80,33 @@ namespace BH.Engine.Geometry
 
 
         /***************************************************/
+        /**** public Methods - Bounding Box             ****/
+        /***************************************************/
+
+        public static Polyline PlaneIntersection(this BoundingBox boundingBox, Plane plane, double tolerance = Tolerance.Distance)
+        {
+            List<Point> controlPoints = new List<Point>();
+            foreach (Line line in boundingBox.Edges())
+            {
+                Point intPt = line.PlaneIntersection(plane);
+                if (intPt != null)
+                    controlPoints.Add(intPt);
+            }
+
+            controlPoints = controlPoints.CullDuplicates(tolerance);
+            if (controlPoints.Count < 2)
+                return null;
+
+            Point average = controlPoints.Average();
+            Vector firstVector = controlPoints[0] - average;
+            controlPoints.Sort(delegate (Point p1, Point p2) { return firstVector.SignedAngle(p1 - average, plane.Normal).CompareTo(firstVector.SignedAngle(p2 - average, plane.Normal)); });
+            controlPoints.Add(controlPoints.First());
+
+            return new Polyline { ControlPoints = controlPoints };
+        }
+
+
+        /***************************************************/
         /**** public Methods - Curves                   ****/
         /***************************************************/
 


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1019 
Closes #1020 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Added regular test files:
- `Bounds(IElement)` - [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FCommon%5FEngine%2FQuery) 
- `Edges(BoundingBox)`, `PlaneIntersection(BoundingBox, Plane)` and `IsInRange(Point/ICurve, BoundingBox)` - [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FQuery)

Errors in the test files are caused by:
- `IsInRange(Point, BoundingBox)` - inbuilt tolerance of Rhino being different from BHoM
- `IsInRange(ICurve, BoundingBox)` - nulls being returned due to lack of support of `Ellipse` and `NurbsCurve`

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added:
- `Query.Bounds()` method added in the `Common_Engine` for `IElement` interfaces
- `Query.Edges()` method added in the `Geometry_Engine` for `BoundingBox` class
- `Query.PlaneIntersection()` method added in the `Geometry_Engine` for `BoundingBox` class
- `Query.IsInRange()` method added in the `Geometry_Engine` for `Point` and `ICurve` classes

### Additional comments
This PR is coordinated with #1022, both should merge seamlessly.