### PR TITLE
Geometry_Engine-Issue1004-IBoundsMethodBreaksIfObjectIsNull

### DIFF
--- a/Geometry_Engine/Query/Bounds.cs
+++ b/Geometry_Engine/Query/Bounds.cs
@@ -427,7 +427,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods - Fallback                ****/
         /***************************************************/
 
-        private static BoundingBox Bounds(object value)
+        private static BoundingBox Bounds(IGeometry geometry)
         {
             return null;
         }

--- a/Geometry_Engine/Query/Bounds.cs
+++ b/Geometry_Engine/Query/Bounds.cs
@@ -416,7 +416,20 @@ namespace BH.Engine.Geometry
 
         public static BoundingBox IBounds(this IGeometry geometry)
         {
+            if (geometry == null)
+                return null;
+
             return Bounds(geometry as dynamic);
+        }
+
+
+        /***************************************************/
+        /**** Private Methods - Fallback                ****/
+        /***************************************************/
+
+        private static BoundingBox Bounds(object value)
+        {
+            return null;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1004 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Dedicated test file located [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1004%2DIBoundsMethodBreaksIfObjectIsNull).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added:
- Added null checks that prevent the code from breaking when no geometrical bounds are found for an object

### Additional comments
Should not interfere with #1022 as modifying different files.