### PR TITLE
Common_Engine: issue 1016 Update Area and Centroid and fix Gemetry_Engine BooleanUnion bug

### DIFF
--- a/Common_Engine/Query/Area.cs
+++ b/Common_Engine/Query/Area.cs
@@ -36,24 +36,12 @@ namespace BH.Engine.Common
 
         public static double Area(this IElement2D element2D)
         {
-            //TODO: make this work for PolyCurves (Booleans needed)
+            double result = element2D.IOutlineCurve().IArea();
 
-            double result = element2D.IOutlineCurve().Area();
+            List<PolyCurve> openings = element2D.IInternalOutlineCurves().BooleanUnion();
 
-            List<Polyline> openings = new List<Polyline>();
-            foreach (PolyCurve o in element2D.IInternalOutlineCurves())
-            {
-                Polyline p = o.ToPolyline();
-                if (p == null)
-                    throw new NotImplementedException();
-
-                openings.Add(p);
-            }
-
-            foreach (Polyline p in openings.BooleanUnion())
-            {
-                result -= p.Area();
-            }
+            foreach (PolyCurve o in openings)
+                result -= o.Area();
 
             return result;
         }

--- a/Common_Engine/Query/Centroid.cs
+++ b/Common_Engine/Query/Centroid.cs
@@ -20,9 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Geometry;
 using BH.oM.Common;
 using BH.oM.Geometry;
 using System;
+using System.Collections.Generic;
 
 namespace BH.Engine.Common
 {
@@ -45,8 +47,27 @@ namespace BH.Engine.Common
 
         public static Point Centroid(this IElement2D element2D)
         {
-            //TODO: find a proper centre of weight of a panel (not an average of control points)
-            throw new NotImplementedException();
+            Point tmp = Geometry.Query.Centroid(element2D.IOutlineCurve());
+            Double area = Geometry.Query.Area(element2D.IOutlineCurve());
+
+            Double x = tmp.X * area;
+            Double y = tmp.Y * area;
+            Double z = tmp.Z * area;
+
+
+            List<PolyCurve> openings = Geometry.Compute.BooleanUnion(element2D.IInternalOutlineCurves());
+
+            foreach (ICurve o in openings)
+            {
+                Point oTmp = Geometry.Query.ICentroid(o);
+                Double oArea = o.IArea();
+                x -= oTmp.X * oArea;
+                y -= oTmp.Y * oArea;
+                z -= oTmp.Z * oArea;
+                area -= oArea;
+            }
+            area = element2D.Area();
+            return new Point { X = x / area, Y = y / area, Z = z / area };
         }
 
         /******************************************/

--- a/Common_Engine/Query/Centroid.cs
+++ b/Common_Engine/Query/Centroid.cs
@@ -48,11 +48,11 @@ namespace BH.Engine.Common
         public static Point Centroid(this IElement2D element2D)
         {
             Point tmp = Geometry.Query.Centroid(element2D.IOutlineCurve());
-            Double area = Geometry.Query.Area(element2D.IOutlineCurve());
+            double area = Geometry.Query.Area(element2D.IOutlineCurve());
 
-            Double x = tmp.X * area;
-            Double y = tmp.Y * area;
-            Double z = tmp.Z * area;
+            double x = tmp.X * area;
+            double y = tmp.Y * area;
+            double z = tmp.Z * area;
 
 
             List<PolyCurve> openings = Geometry.Compute.BooleanUnion(element2D.IInternalOutlineCurves());
@@ -60,13 +60,13 @@ namespace BH.Engine.Common
             foreach (ICurve o in openings)
             {
                 Point oTmp = Geometry.Query.ICentroid(o);
-                Double oArea = o.IArea();
+                double oArea = o.IArea();
                 x -= oTmp.X * oArea;
                 y -= oTmp.Y * oArea;
                 z -= oTmp.Z * oArea;
                 area -= oArea;
             }
-            area = element2D.Area();
+            
             return new Point { X = x / area, Y = y / area, Z = z / area };
         }
 

--- a/Geometry_Engine/Compute/BooleanUnion.cs
+++ b/Geometry_Engine/Compute/BooleanUnion.cs
@@ -245,7 +245,8 @@ namespace BH.Engine.Geometry
                 throw new NotImplementedException("NurbsCurves and ellipses are not implemented yet.");
 
             List<PolyCurve> result = new List<PolyCurve>();
-
+            if (regionsList.Count == 0)
+                return result;
             if (regionsList.Count < 2)
             {
                 if (regionsList[0] is PolyCurve)
@@ -369,6 +370,14 @@ namespace BH.Engine.Geometry
                 }
 
                 result.AddRange(IJoin(tmpResult, tolerance));
+            }
+
+            foreach (ICurve curve in resultICurve)
+            {
+                if (curve is PolyCurve)
+                    result.Add(curve as PolyCurve);
+                else
+                    result.Add(new PolyCurve { Curves = curve.ISubParts().ToList() });
             }
 
             int res = 0;

--- a/Geometry_Engine/Compute/BooleanUnion.cs
+++ b/Geometry_Engine/Compute/BooleanUnion.cs
@@ -245,9 +245,10 @@ namespace BH.Engine.Geometry
                 throw new NotImplementedException("NurbsCurves and ellipses are not implemented yet.");
 
             List<PolyCurve> result = new List<PolyCurve>();
+
             if (regionsList.Count == 0)
                 return result;
-            if (regionsList.Count < 2)
+            else if (regionsList.Count == 1)
             {
                 if (regionsList[0] is PolyCurve)
                 {

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -132,6 +132,9 @@ namespace BH.Engine.Geometry
 
             List<ICurve> curveSubParts = curve.SubParts();
 
+            if (curveSubParts.Count == 1 && curveSubParts[0] is Circle)
+                return (curveSubParts[0] as Circle).Centroid();
+
             List<Point> pts = new List<Point> { curveSubParts[0].IStartPoint() };
             foreach (ICurve crv in curveSubParts)
             {

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -133,7 +133,7 @@ namespace BH.Engine.Geometry
             List<ICurve> curveSubParts = curve.SubParts();
 
             if (curveSubParts.Count == 1 && curveSubParts[0] is Circle)
-                return (curveSubParts[0] as Circle).Centroid();
+                return (curveSubParts[0] as Circle).Centre;
 
             List<Point> pts = new List<Point> { curveSubParts[0].IStartPoint() };
             foreach (ICurve crv in curveSubParts)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1016 

Updated `Area(IElement2D)` so now it operates on any ICurve.
Created `Centroid(IElement2D)`. It needed a small fix in Geometry_Engine Centroid.
Also found bug in `BooleanUnion(IEnumerable<ICurve>)` and fixed it.

### Test files
Area - regular test [file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Common_Engine/Query/Area.gh?csf=1&e=xBHseu)
Centroid - regular test [file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Common_Engine/Query/Centroid.gh?csf=1&e=D3MKCl)
BooleanUnion - regular test [file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Compute/BooleanUnionV3.gh?csf=1&e=mBTTjA)
BooleanUnion - issue specific test [file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Geometry_Engine-PullRequest1051-BooleanUnion%20bug/Geometry_Engine-PullRequest1051-BooleanUnion%20bug.gh?csf=1&e=WhN7m7)

### Changelog,
#### Changed:
- `Query.Area()` method changed in the `Common_Engine` for `IElement2D` interface
- `Query.Centroid()` method changed in the `Common_Engine` for `IElement2D` interface
- `Query.Centroid()` method changed in the `Geometry_Engine` for `PolyCurve` class
- `Compute.BooleanUnion()` method changed in the `Geometry_Engine` for `IEnumerable<ICurve>` class


### Additional comments
<!-- As required -->
I label Centroid as changed not added because it was already existing in code but was only throwing exceptions.