### PR TITLE
Geometry_Engine-Issue1053-ClosestPointToCircleBugWhenPointInCenter

### DIFF
--- a/Geometry_Engine/Query/ClosestPoint.cs
+++ b/Geometry_Engine/Query/ClosestPoint.cs
@@ -102,10 +102,22 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [DeprecatedAttribute("2.3", "Replaced with method that takes tolerance input", null, "ClosestPoint")]
         public static Point ClosestPoint(this Circle circle, Point point)
         {
+            return circle.ClosestPoint(point, Tolerance.Distance);
+        }
+
+        /***************************************************/
+        
+        public static Point ClosestPoint(this Circle circle, Point point, double tolerance = Tolerance.Distance)
+        {
             Plane p = new Plane { Origin = circle.Centre, Normal = circle.Normal };
-            return circle.Centre + (point.Project(p) - circle.Centre).Normalise() * circle.Radius;
+            Vector closestDir = point.Project(p) - circle.Centre;
+            if (closestDir.SquareLength() <= tolerance * tolerance)
+                return circle.StartPoint();
+            else
+                return circle.Centre + (point.Project(p) - circle.Centre).Normalise() * circle.Radius;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1053 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Issue specific test file is [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1053%2DClosestPointToCircleBugWhenPointInCenter).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added:
- `Query.ClosestPoint()` method with distance tolerance added in the Geometry_Engine for `Circle` class

#### Deprecated:
- `Query.ClosestPoint()` method without distance tolerance deprecated in the Geometry_Engine for `Circle` class, replaced with similar method taking the distance tolerance