### PR TITLE
Geometry_Engine: issue 947 Merge Flip and Reverse

### DIFF
--- a/Geometry_Engine/Modify/Flip.cs
+++ b/Geometry_Engine/Modify/Flip.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -32,6 +32,15 @@ namespace BH.Engine.Geometry
     public static partial class Modify
     {
         /***************************************************/
+        /**** Public Methods - Vectors                  ****/
+        /***************************************************/
+
+        public static Vector Flip(this Vector vector)
+        {
+            return new Vector { X = -vector.X, Y = -vector.Y, Z = -vector.Z };
+        }
+
+        /***************************************************/
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
@@ -53,7 +62,7 @@ namespace BH.Engine.Geometry
 
         public static Line Flip(this Line curve)
         {
-            return new Line { Start = curve.End, End = curve.Start };
+            return new Line { Start = curve.End, End = curve.Start, Infinite = curve.Infinite };
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Reverse.cs
+++ b/Geometry_Engine/Modify/Reverse.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Linq;
 
@@ -32,9 +33,10 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Vectors                  ****/
         /***************************************************/
 
+        [DeprecatedAttribute("2.3", "Merged Reverse with Flip", null, "Flip")]
         public static Vector Reverse(this Vector vector)
         {
-            return new Vector { X = -vector.X, Y = -vector.Y, Z = -vector.Z };
+            return vector.Flip();
         }
 
 
@@ -42,9 +44,10 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
+        [DeprecatedAttribute("2.3", "Merged Reverse with Flip", null, "Flip")]
         public static Line Reverse(this Line line)
         {
-            return new Line { Start = line.End, End = line.Start, Infinite = line.Infinite };
+            return line.Flip();
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #947 

Reverse had only two methods for Vector and Line. Flip has methods for all IGeometry. Moved Vector to Flip, and updated `Flip(Line)` so now it passes line's infinity.
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Added tests for Line and Vector at the end of regular [file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/Modify/Flip.gh?csf=1&e=Wx44fu).

### Changelog

#### Added:
- `Modify.Flip()` method added in the `Geometry_Engine` for `Vector` class
#### Changed:
- `Modify.Flip()` method changed in the `Geometry_Engine` for `Line` class
#### Deprecated: 
- `Modify.Reverse()` method deprecated in the `Geometry_Engine` for `Vector` class
- `Modify.Reverse()` method deprecated in the `Geometry_Engine` for `Line` class

 ### Additional comments
<!-- As required -->
This should me merged simultaneously with PR [#134](https://github.com/BuroHappoldEngineering/StructuralEngineering_Toolkit/pull/134) and [#160](https://github.com/BuroHappoldEngineering/ModelLaundry_Toolkit/pull/160)