### PR TITLE
Common_Engine-Issue1077-ChangeArgumentTypeFromBHoMObjectToIElement

### DIFF
--- a/Common_Engine/Query/ElementCurves.cs
+++ b/Common_Engine/Query/ElementCurves.cs
@@ -24,7 +24,9 @@ using BH.Engine.Geometry;
 using BH.oM.Base;
 using BH.oM.Common;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BH.Engine.Common
 {
@@ -70,7 +72,7 @@ namespace BH.Engine.Common
         /**** Public Methods - Interfaces      ****/
         /******************************************/
 
-        public static List<ICurve> IElementCurves(this BHoMObject element, bool recursive = true)
+        public static List<ICurve> IElementCurves(this IElement element, bool recursive = true)
         {
             return ElementCurves(element as dynamic, recursive);
         }
@@ -78,7 +80,7 @@ namespace BH.Engine.Common
 
         /******************************************/
 
-        public static List<ICurve> IElementCurves(this List<BHoMObject> elements, bool recursive = true)
+        public static List<ICurve> IElementCurves(this IEnumerable<IElement> elements, bool recursive = true)
         {
             List<ICurve> result = new List<ICurve>();
             foreach (BHoMObject element in elements)
@@ -86,6 +88,26 @@ namespace BH.Engine.Common
                 result.AddRange(element.IElementCurves(recursive));
             }
             return result;
+        }
+
+
+        /******************************************/
+        /****        Deprecated methods        ****/
+        /******************************************/
+
+        [DeprecatedAttribute("2.3", "Input type changed from BHoMObject to IElement", null, "IElementCurves")]
+        public static List<ICurve> IElementCurves(this BHoMObject element, bool recursive = true)
+        {
+            return IElementCurves(element as IElement, recursive);
+        }
+
+
+        /******************************************/
+
+        [DeprecatedAttribute("2.3", "Input type changed from List<BHoMObject> to IEnumerable<IElement>", null, "IElementCurves")]
+        public static List<ICurve> IElementCurves(this List<BHoMObject> elements, bool recursive = true)
+        {
+            return IElementCurves(elements.Cast<IElement>(), recursive);
         }
 
         /******************************************/

--- a/Common_Engine/Query/ElementVertices.cs
+++ b/Common_Engine/Query/ElementVertices.cs
@@ -24,7 +24,9 @@ using BH.Engine.Geometry;
 using BH.oM.Base;
 using BH.oM.Common;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BH.Engine.Common
 {
@@ -67,18 +69,40 @@ namespace BH.Engine.Common
         /**** Public Methods - Interfaces      ****/
         /******************************************/
 
-        public static List<Point> IElementVertices(this BHoMObject element)
+        public static List<Point> IElementVertices(this IElement element)
         {
             return ElementVertices(element as dynamic);
         }
 
         /******************************************/
 
-        public static List<Point> IElementVertices(this List<BHoMObject> elements)
+        public static List<Point> IElementVertices(this IEnumerable<IElement> elements)
         {
             List<Point> result = new List<Point>();
-            elements.ForEach(e => result.AddRange(e.IElementVertices()));
+            foreach(IElement element in elements)
+            {
+                result.AddRange(element.IElementVertices());
+            }
             return result;
+        }
+
+
+        /******************************************/
+        /****        Deprecated methods        ****/
+        /******************************************/
+
+        [DeprecatedAttribute("2.3", "Input type changed from BHoMObject to IElement", null, "IElementVertices")]
+        public static List<Point> IElementVertices(this BHoMObject element)
+        {
+            return IElementVertices(element as IElement);
+        }
+
+        /******************************************/
+
+        [DeprecatedAttribute("2.3", "Input type changed from List<BHoMObject> to IEnumerable<IElement>", null, "IElementVertices")]
+        public static List<Point> IElementVertices(this List<BHoMObject> elements)
+        {
+            return IElementVertices(elements.Cast<IElement>());
         }
 
         /******************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1077 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not liking myself, but no test file added - it did not exist and I have not created one. The methods are used in dependent projects and everything seems to be fine.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Added:
- `Query.ElementCurves()` method added in the `Common_Engine` for `IElement` interface
- `Query.ElementVertices()` method added in the `Common_Engine` for `IElement` interface
#### Deprecated: 
- `Query.ElementCurves()` method deprecated in the `Common_Engine` for `BHoMObject` interface
- `Query.ElementVertices()` method deprecated in the `Common_Engine` for `BHoMObject` interface
