### PR TITLE
Reflection_Engine: Issue1081-RemoveLoggingForGetPropertyAndCustomObjects

### DIFF
--- a/Reflection_Engine/Query/PropertyValue.cs
+++ b/Reflection_Engine/Query/PropertyValue.cs
@@ -65,7 +65,8 @@ namespace BH.Engine.Reflection
                 IBHoMObject bhom = obj as IBHoMObject;
                 if (bhom.CustomData.ContainsKey(propName))
                 {
-                    Compute.RecordNote($"{propName} is stored in CustomData");
+                    if (!(bhom is CustomObject))
+                        Compute.RecordNote($"{propName} is stored in CustomData");
                     return bhom.CustomData[propName];
                 }
                 else


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1081 
<!-- Add short description of what has been fixed -->
In `Query.PropertyValue`, excluding `CustomObject`s from logging that the property is stored in the `CustomData` - as it is too verbose.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EpwKcoP9VTVGkssT71fhu7UBwMljIT4OTG1hmp96BH5MZw?e=HWJFe7
