### PR TITLE
Geometry_Engine: re-implement UVCount() and Degrees()

### DIFF
--- a/Geometry_Engine/Query/Bounds.cs
+++ b/Geometry_Engine/Query/Bounds.cs
@@ -255,10 +255,9 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static BoundingBox Bounds(this NurbsCurve curve)
         {
-            throw new NotImplementedException();
+            return curve.ControlPoints.Bounds(); // TODO: Bounds(NurbsCurve) incorrect
         }
 
         /***************************************************/
@@ -313,10 +312,9 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static BoundingBox Bounds(this NurbsSurface surface)
         {
-            throw new NotImplementedException();
+            return surface.ControlPoints.Bounds(); // TODO: Bounds(NurbsSurface) incorrect
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Bounds.cs
+++ b/Geometry_Engine/Query/Bounds.cs
@@ -257,7 +257,7 @@ namespace BH.Engine.Geometry
 
         public static BoundingBox Bounds(this NurbsCurve curve)
         {
-            return curve.ControlPoints.Bounds(); // TODO: Bounds(NurbsCurve) incorrect
+            return curve.ControlPoints.Bounds();
         }
 
         /***************************************************/
@@ -314,7 +314,7 @@ namespace BH.Engine.Geometry
 
         public static BoundingBox Bounds(this NurbsSurface surface)
         {
-            return surface.ControlPoints.Bounds(); // TODO: Bounds(NurbsSurface) incorrect
+            return surface.ControlPoints.Bounds();
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Degree.cs
+++ b/Geometry_Engine/Query/Degree.cs
@@ -22,8 +22,6 @@
 
 using System.Collections.Generic;
 using BH.oM.Geometry;
-using BH.oM.Reflection.Attributes;
-using System;
 
 namespace BH.Engine.Geometry
 {
@@ -40,10 +38,15 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static List<int> Degrees(this NurbsSurface surf)
         {
-            throw new NotImplementedException();
+            int uDegree = 1;
+            int vDegree = 1;
+            while (surf.UKnots[uDegree - 1] == surf.UKnots[uDegree])
+                uDegree++;
+            while (surf.VKnots[vDegree - 1] == surf.VKnots[vDegree])
+                vDegree++;
+            return new List<int>() { uDegree, vDegree };
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/UVCount.cs
+++ b/Geometry_Engine/Query/UVCount.cs
@@ -21,8 +21,6 @@
  */
 
 using BH.oM.Geometry;
-using BH.oM.Reflection.Attributes;
-using System;
 using System.Collections.Generic;
 
 namespace BH.Engine.Geometry
@@ -33,10 +31,10 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [NotImplemented]
         public static List<int> UVCount(this NurbsSurface surf)
         {
-            throw new NotImplementedException();
+            List<int> degrees = surf.Degrees();
+            return new List<int> { surf.UKnots.Count - degrees[0] + 1, surf.VKnots.Count - degrees[1] + 1 };
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
 
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1094 
<!-- Add short description of what has been fixed -->
In order to reinstate the ability to convert `NurbsSurface` to and from Rhinoceros.
See the issue for more.

### Test files
<!-- Link to test files to validate the proposed changes -->
I simply reinstated the code that was in these commits, which, for the sake of celerity, I assume it is correct. The test file will come with the associated Grasshopper pull request.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Add `BH.Engine.Geometry.Query.UVCount()`
- Add `BH.Engine.Geometry.Query.Degrees()`
- Add `BH.Engine.Geometry.Query.Bounds(NurbsSurface)`

### Additional comments
<!-- As required -->