### PR TITLE
Physical_Engine: Query methods for topology workflows

### DIFF
--- a/BHoM_Engine/Query/FilterByType.cs
+++ b/BHoM_Engine/Query/FilterByType.cs
@@ -45,5 +45,14 @@ namespace BH.Engine.Base
         }
 
         /***************************************************/
+
+        [Description("Returns a collection of objects which are of the provided object type")]
+        [Input("objects", "A collection of generic BHoM objects")]
+        [Input("type", "The type of object to be queried and returned")]
+        [Output("bhomObjects", "A collection of generic BHoM objects matching the provided type")]
+        public static List<IBHoMObject> ObjectsByType(this List<IBHoMObject> objects, Type type)
+        {
+            return objects.Where(x => x.GetType() == type).ToList();
+        }
     }
 }

--- a/Environment_Engine/Environment_Engine.csproj
+++ b/Environment_Engine/Environment_Engine.csproj
@@ -130,7 +130,6 @@
     <Compile Include="Query\MatchPoint.cs" />
     <Compile Include="Query\FindMaterial.cs" />
     <Compile Include="Query\ObjectsByFragment.cs" />
-    <Compile Include="Query\ObjectsByType.cs" />
     <Compile Include="Query\Openings.cs" />
     <Compile Include="Query\Panels.cs" />
     <Compile Include="Query\RValue.cs" />
@@ -184,6 +183,10 @@
     <Compile Include="Query\Width.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj">
+      <Project>{1ad45c88-dd54-48e5-951f-55edfeb70e35}</Project>
+      <Name>BHoM_Engine</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Common_Engine\Common_Engine.csproj">
       <Project>{8d8cd66f-76f3-4750-936d-380d51bc67d6}</Project>
       <Name>Common_Engine</Name>

--- a/Environment_Engine/Modify/AddOpening.cs
+++ b/Environment_Engine/Modify/AddOpening.cs
@@ -43,6 +43,7 @@ namespace BH.Engine.Environment
         [Output("panel", "A modified Environment Panel with the provided opening added")]
         public static Panel AddOpening(this Panel panel, Opening opening)
         {
+            if (panel.Openings == null) panel.Openings = new List<Opening>();
             panel.Openings.Add(opening);
             return panel;
         }
@@ -59,8 +60,11 @@ namespace BH.Engine.Environment
                 if(centre != null)
                 {
                     Panel panel = panels.PanelsContainingPoint(centre).First();
-                    if(panel != null)
+                    if (panel != null)
+                    {
+                        if (panel.Openings == null) panel.Openings = new List<Opening>();
                         panel.Openings.Add(o);
+                    }
                 }
             }
 

--- a/Environment_Engine/Modify/AddOpening.cs
+++ b/Environment_Engine/Modify/AddOpening.cs
@@ -59,7 +59,7 @@ namespace BH.Engine.Environment
                 Point centre = o.Polyline().Centre();
                 if(centre != null)
                 {
-                    Panel panel = panels.PanelsContainingPoint(centre).First();
+                    Panel panel = panels.PanelsContainingPoint(centre).FirstOrDefault();
                     if (panel != null)
                     {
                         if (panel.Openings == null) panel.Openings = new List<Opening>();

--- a/Environment_Engine/Query/Buildings.cs
+++ b/Environment_Engine/Query/Buildings.cs
@@ -41,13 +41,13 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Returns a collection of Environment Buildings from a list of generic BHoM objects")]
-        [Input("objects", "A collection of generic BHoM objects")]
+        [Input("bhomObjects", "A collection of generic BHoM objects")]
         [Output("buildings", "A collection of Environment Building objects")]
-        public static List<Building> Buildings(this List<IBHoMObject> objects)
+        public static List<Building> Buildings(this List<IBHoMObject> bhomObjects)
         {
-            objects = objects.ObjectsByType(typeof(Building));
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Building));
             List<Building> buildings = new List<Building>();
-            foreach (IBHoMObject o in objects)
+            foreach (IBHoMObject o in bhomObjects)
                 buildings.Add(o as Building);
 
             return buildings;

--- a/Environment_Engine/Query/Level.cs
+++ b/Environment_Engine/Query/Level.cs
@@ -34,6 +34,8 @@ using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 
+using BH.Engine.Base;
+
 namespace BH.Engine.Environment
 {
     public static partial class Query

--- a/Environment_Engine/Query/Level.cs
+++ b/Environment_Engine/Query/Level.cs
@@ -43,13 +43,13 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Returns a collection of Architecture Levels from a list of generic BHoM objects")]
-        [Input("objects", "A collection of generic BHoM objects")]
+        [Input("bhomObjects", "A collection of generic BHoM objects")]
         [Output("levels", "A collection of Architecture Level objects")]
-        public static List<Level> Levels(this List<IBHoMObject> objects)
+        public static List<Level> Levels(this List<IBHoMObject> bhomObjects)
         {
-            objects = objects.ObjectsByType(typeof(Level));
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Level));
             List<Level> levels = new List<Level>();
-            foreach (IBHoMObject o in objects)
+            foreach (IBHoMObject o in bhomObjects)
                 levels.Add(o as Level);
 
             return levels;

--- a/Environment_Engine/Query/Openings.cs
+++ b/Environment_Engine/Query/Openings.cs
@@ -43,13 +43,13 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Returns a collection of Environment Openings from a list of generic BHoM objects")]
-        [Input("objects", "A collection of generic BHoM objects")]
+        [Input("bhomObjects", "A collection of generic BHoM objects")]
         [Output("openings", "A collection of Environment Opening objects")]
-        public static List<Opening> Openings(this List<IBHoMObject> objects)
+        public static List<Opening> Openings(this List<IBHoMObject> bhomObjects)
         {
-            objects = objects.ObjectsByType(typeof(Opening));
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Opening));
             List<Opening> Openings = new List<Opening>();
-            foreach (IBHoMObject o in objects)
+            foreach (IBHoMObject o in bhomObjects)
                 Openings.Add(o as Opening);
 
             return Openings;

--- a/Environment_Engine/Query/Openings.cs
+++ b/Environment_Engine/Query/Openings.cs
@@ -140,6 +140,7 @@ namespace BH.Engine.Environment
                 Opening opening = new Opening();
                 opening.Name = o.Name;
                 opening.Edges = o.Location.IExternalEdges().ToEdges();
+                opening.Type = (o is Door ? OpeningType.Door : OpeningType.Window);
                 openings.Add(opening);
             }
 

--- a/Environment_Engine/Query/Openings.cs
+++ b/Environment_Engine/Query/Openings.cs
@@ -140,6 +140,7 @@ namespace BH.Engine.Environment
                 Opening opening = new Opening();
                 opening.Name = o.Name;
                 opening.Edges = o.Location.IExternalEdges().ToEdges();
+                opening.InnerEdges = o.Location.IInternalEdges().ToEdges();
                 opening.Type = (o is Door ? OpeningType.Door : OpeningType.Window);
                 openings.Add(opening);
             }

--- a/Environment_Engine/Query/Openings.cs
+++ b/Environment_Engine/Query/Openings.cs
@@ -36,6 +36,9 @@ using System.ComponentModel;
 
 using BH.Engine.Base;
 
+using BH.oM.Physical.Elements;
+using BH.Engine.Geometry;
+
 namespace BH.Engine.Environment
 {
     public static partial class Query
@@ -123,6 +126,24 @@ namespace BH.Engine.Environment
             }
 
             return returnOpenings;
+        }
+
+        [Description("Returns a collection of Environment Openings queried from a collection of Physical Objects (windows, doors, etc.)")]
+        [Input("physicalOpenings", "A collection of Physical Openings to query Environment Openings from")]
+        [Output("openings", "A collection of Environment Openings from Physical Objects")]
+        public static List<Opening> OpeningsFromPhysical(this List<IOpening> physicalOpenings)
+        {
+            List<Opening> openings = new List<Opening>();
+
+            foreach(IOpening o in physicalOpenings)
+            {
+                Opening opening = new Opening();
+                opening.Name = o.Name;
+                opening.Edges = o.Location.IExternalEdges().ToEdges();
+                openings.Add(opening);
+            }
+
+            return openings;
         }
     }
 }

--- a/Environment_Engine/Query/Openings.cs
+++ b/Environment_Engine/Query/Openings.cs
@@ -34,6 +34,8 @@ using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 
+using BH.Engine.Base;
+
 namespace BH.Engine.Environment
 {
     public static partial class Query

--- a/Environment_Engine/Query/Panels.cs
+++ b/Environment_Engine/Query/Panels.cs
@@ -283,6 +283,7 @@ namespace BH.Engine.Environment
                 p.Construction = srf.Construction;
                 p.ExternalEdges = srf.Location.IExternalEdges().ToEdges();
                 p.Openings = srf.Openings.OpeningsFromPhysical();
+                p.Type = (srf is BH.oM.Physical.Elements.Wall ? PanelType.Wall : (srf is BH.oM.Physical.Elements.Roof ? PanelType.Roof : PanelType.Floor));
                 panels.Add(p);
             }
 

--- a/Environment_Engine/Query/Panels.cs
+++ b/Environment_Engine/Query/Panels.cs
@@ -40,6 +40,8 @@ using BH.oM.Architecture.Elements;
 
 using BH.Engine.Base;
 
+using BH.oM.Physical.Elements;
+
 namespace BH.Engine.Environment
 {
     public static partial class Query
@@ -265,6 +267,26 @@ namespace BH.Engine.Environment
             }
 
             return duplicates;
+        }
+
+        [Description("Returns a collection of Environment Panels queried from a collection of Physical Objects (walls, floors, etc.)")]
+        [Input("physicalObjects", "A collection of Physical Objects to query Environment Panels from")]
+        [Output("panels", "A collection of Environment Panels from Physical Objects")]
+        public static List<Panel> PanelsFromPhysical(this List<BH.oM.Physical.Elements.ISurface> physicalObjects)
+        {
+            List<Panel> panels = new List<Panel>();
+
+            foreach(BH.oM.Physical.Elements.ISurface srf in physicalObjects)
+            {
+                Panel p = new Panel();
+                p.Name = srf.Name;
+                p.Construction = srf.Construction;
+                p.ExternalEdges = srf.Location.IExternalEdges().ToEdges();
+                p.Openings = srf.Openings.OpeningsFromPhysical();
+                panels.Add(p);
+            }
+
+            return panels;
         }
     }
 }

--- a/Environment_Engine/Query/Panels.cs
+++ b/Environment_Engine/Query/Panels.cs
@@ -283,6 +283,7 @@ namespace BH.Engine.Environment
                 p.Construction = srf.Construction;
                 p.ExternalEdges = srf.Location.IExternalEdges().ToEdges();
                 p.Openings = srf.Openings.OpeningsFromPhysical();
+                if (p.Openings == null) p.Openings = new List<Opening>();
                 p.Type = (srf is BH.oM.Physical.Elements.Wall ? PanelType.Wall : (srf is BH.oM.Physical.Elements.Roof ? PanelType.Roof : PanelType.Floor));
                 panels.Add(p);
             }

--- a/Environment_Engine/Query/Panels.cs
+++ b/Environment_Engine/Query/Panels.cs
@@ -38,6 +38,8 @@ using System.ComponentModel;
 
 using BH.oM.Architecture.Elements;
 
+using BH.Engine.Base;
+
 namespace BH.Engine.Environment
 {
     public static partial class Query

--- a/Environment_Engine/Query/Panels.cs
+++ b/Environment_Engine/Query/Panels.cs
@@ -47,13 +47,13 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Returns a collection of Environment Panels from a list of generic BHoM objects")]
-        [Input("objects", "A collection of generic BHoM objects")]
+        [Input("bhomObjects", "A collection of generic BHoM objects")]
         [Output("panels", "A collection of Environment Panel objects")]
-        public static List<Panel> Panels(this List<IBHoMObject> objects)
+        public static List<Panel> Panels(this List<IBHoMObject> bhomObjects)
         {
-            objects = objects.ObjectsByType(typeof(Panel));
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Panel));
             List<Panel> spaces = new List<Panel>();
-            foreach (IBHoMObject o in objects)
+            foreach (IBHoMObject o in bhomObjects)
                 spaces.Add(o as Panel);
 
             return spaces;

--- a/Environment_Engine/Query/Spaces.cs
+++ b/Environment_Engine/Query/Spaces.cs
@@ -43,13 +43,13 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Returns a collection of Environment Spaces from a list of generic BHoM objects")]
-        [Input("objects", "A collection of generic BHoM objects")]
+        [Input("bhomObjects", "A collection of generic BHoM objects")]
         [Output("spaces", "A collection of Environment Space objects")]
-        public static List<Space> Spaces(this List<IBHoMObject> objects)
+        public static List<Space> Spaces(this List<IBHoMObject> bhomObjects)
         {
-            objects = objects.ObjectsByType(typeof(Space));
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Space));
             List<Space> spaces = new List<Space>();
-            foreach (IBHoMObject o in objects)
+            foreach (IBHoMObject o in bhomObjects)
                 spaces.Add(o as Space);
 
             return spaces;

--- a/Environment_Engine/Query/Spaces.cs
+++ b/Environment_Engine/Query/Spaces.cs
@@ -34,6 +34,8 @@ using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 
+using BH.Engine.Base;
+
 namespace BH.Engine.Environment
 {
     public static partial class Query

--- a/Physical_Engine/Physical_Engine.csproj
+++ b/Physical_Engine/Physical_Engine.csproj
@@ -64,15 +64,24 @@
     <Compile Include="Modify\AddMaterialProperties.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\Construction.cs" />
+    <Compile Include="Query\Doors.cs" />
+    <Compile Include="Query\Floors.cs" />
     <Compile Include="Query\Geometry.cs" />
     <Compile Include="Query\Polyline.cs" />
+    <Compile Include="Query\Roofs.cs" />
     <Compile Include="Query\Thickness.cs" />
+    <Compile Include="Query\Walls.cs" />
+    <Compile Include="Query\Windows.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Compute\" />
     <Folder Include="Convert\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj">
+      <Project>{1ad45c88-dd54-48e5-951f-55edfeb70e35}</Project>
+      <Name>BHoM_Engine</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Geometry_Engine\Geometry_Engine.csproj">
       <Project>{89ab2dcb-ef87-4cba-b59c-c16a8a71d333}</Project>
       <Name>Geometry_Engine</Name>

--- a/Physical_Engine/Physical_Engine.csproj
+++ b/Physical_Engine/Physical_Engine.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\Construction.cs" />
     <Compile Include="Query\Geometry.cs" />
+    <Compile Include="Query\Polyline.cs" />
     <Compile Include="Query\Thickness.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Physical_Engine/Query/Doors.cs
+++ b/Physical_Engine/Query/Doors.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Physical
         [Output("doors", "A collection of Physical Door objects")]
         public static List<Door> Doors(this List<IBHoMObject> bhomObjects)
         {
-            bhomObjects = bhomObjects.ObjectsByType(typeof(Window));
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Door));
             List<Door> doors = new List<Door>();
             foreach (IBHoMObject o in bhomObjects)
                 doors.Add(o as Door);

--- a/Physical_Engine/Query/Doors.cs
+++ b/Physical_Engine/Query/Doors.cs
@@ -20,21 +20,15 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BH.oM.Environment.Elements;
-using BH.oM.Base;
-
-using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Physical.Elements;
+using BH.oM.Base;
 
 using BH.Engine.Base;
 
-namespace BH.Engine.Environment
+namespace BH.Engine.Physical
 {
     public static partial class Query
     {
@@ -42,17 +36,17 @@ namespace BH.Engine.Environment
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns a collection of Environment Buildings from a list of generic BHoM objects")]
+        [Description("Returns a collection of Physical Doors from a list of generic BHoM objects")]
         [Input("bhomObjects", "A collection of generic BHoM objects")]
-        [Output("buildings", "A collection of Environment Building objects")]
-        public static List<Building> Buildings(this List<IBHoMObject> bhomObjects)
+        [Output("doors", "A collection of Physical Door objects")]
+        public static List<Door> Doors(this List<IBHoMObject> bhomObjects)
         {
-            bhomObjects = bhomObjects.ObjectsByType(typeof(Building));
-            List<Building> buildings = new List<Building>();
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Window));
+            List<Door> doors = new List<Door>();
             foreach (IBHoMObject o in bhomObjects)
-                buildings.Add(o as Building);
+                doors.Add(o as Door);
 
-            return buildings;
+            return doors;
         }
     }
 }

--- a/Physical_Engine/Query/Floors.cs
+++ b/Physical_Engine/Query/Floors.cs
@@ -21,20 +21,18 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BH.oM.Environment.Elements;
-using BH.oM.Base;
-
-using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
 using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Physical.Elements;
+using BH.oM.Geometry;
+using BH.oM.Physical;
+using BH.oM.Base;
 
 using BH.Engine.Base;
 
-namespace BH.Engine.Environment
+namespace BH.Engine.Physical
 {
     public static partial class Query
     {
@@ -42,17 +40,17 @@ namespace BH.Engine.Environment
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns a collection of Environment Buildings from a list of generic BHoM objects")]
+        [Description("Returns a collection of Physical Floors from a list of generic BHoM objects")]
         [Input("bhomObjects", "A collection of generic BHoM objects")]
-        [Output("buildings", "A collection of Environment Building objects")]
-        public static List<Building> Buildings(this List<IBHoMObject> bhomObjects)
+        [Output("floors", "A collection of Physical Floor objects")]
+        public static List<Floor> Floors(this List<IBHoMObject> bhomObjects)
         {
-            bhomObjects = bhomObjects.ObjectsByType(typeof(Building));
-            List<Building> buildings = new List<Building>();
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Floor));
+            List<Floor> floors = new List<Floor>();
             foreach (IBHoMObject o in bhomObjects)
-                buildings.Add(o as Building);
+                floors.Add(o as Floor);
 
-            return buildings;
+            return floors;
         }
     }
 }

--- a/Physical_Engine/Query/Polyline.cs
+++ b/Physical_Engine/Query/Polyline.cs
@@ -39,6 +39,54 @@ namespace BH.Engine.Physical
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Returns the External Polyline representation of a physical object (e.g. wall or window)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
+        public static List<Polyline> ExternalPolyline(IPhysical physicalObject)
+        {
+            return ExternalPolyline(physicalObject as dynamic);
+        }
+
+        [Description("Returns the External Polyline representation of a physical object that represents a solid impassable object (e.g. wall or roof)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
+        public static List<Polyline> ExternalPolyline(BH.oM.Physical.Elements.ISurface physicalObject)
+        {
+            return physicalObject.Location.IExternalEdges().Select(x => x.ICollapseToPolyline(Tolerance.Angle)).ToList();
+        }
+
+        [Description("Returns the External Polyline representation of a physical object that represents an opening (e.g. window or door)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
+        public static List<Polyline> ExternalPolyline(IOpening physicalOpening)
+        {
+            return physicalOpening.Location.IExternalEdges().Select(x => x.ICollapseToPolyline(Tolerance.Angle)).ToList();
+        }
+
+        [Description("Returns the Internal Polyline representation of a physical object (e.g. wall or window)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
+        public static List<Polyline> InternalPolyline(IPhysical physicalObject)
+        {
+            return InternalPolyline(physicalObject as dynamic);
+        }
+
+        [Description("Returns the Internal Polyline representation of a physical object that represents a solid impassable object (e.g. wall or roof)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
+        public static List<Polyline> InternalPolyline(BH.oM.Physical.Elements.ISurface physicalObject)
+        {
+            return physicalObject.Location.IInternalEdges().Select(x => x.ICollapseToPolyline(Tolerance.Angle)).ToList();
+        }
+
+        [Description("Returns the Internal Polyline representation of a physical object that represents an opening (e.g. window or door)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
+        public static List<Polyline> InternalPolyline(IOpening physicalOpening)
+        {
+            return physicalOpening.Location.IInternalEdges().Select(x => x.ICollapseToPolyline(Tolerance.Angle)).ToList();
+        }
+
         [Description("Returns a Polyline representation of a physical object (e.g. wall or window)")]
         [Input("physicalObject", "A physical object to query the polyline representation of")]
         [Output("polyline", "BHoM Geometry Polyline")]

--- a/Physical_Engine/Query/Polyline.cs
+++ b/Physical_Engine/Query/Polyline.cs
@@ -1,0 +1,58 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Physical.Elements;
+using BH.oM.Geometry;
+using BH.oM.Physical;
+
+using BH.Engine.Geometry;
+
+namespace BH.Engine.Physical
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+       
+        public static List<Polyline> Polyline(IPhysical physicalObject)
+        {
+            return Polyline(physicalObject as dynamic);
+        }
+
+        public static List<Polyline> Polyline(BH.oM.Physical.Elements.ISurface physicalObject)
+        {
+            return physicalObject.Location.Edges().Select(x => x.ICollapseToPolyline(Tolerance.Angle)).ToList();
+        }
+
+        public static List<Polyline> Polyline(IOpening physicalOpening)
+        {
+            return physicalOpening.Location.Edges().Select(x => x.ICollapseToPolyline(Tolerance.Angle)).ToList();
+        }
+    }
+}

--- a/Physical_Engine/Query/Polyline.cs
+++ b/Physical_Engine/Query/Polyline.cs
@@ -39,17 +39,25 @@ namespace BH.Engine.Physical
         /**** Public Methods                            ****/
         /***************************************************/
 
-       
+        [Description("Returns a Polyline representation of a physical object (e.g. wall or window)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
         public static List<Polyline> Polyline(IPhysical physicalObject)
         {
             return Polyline(physicalObject as dynamic);
         }
 
+        [Description("Returns a Polyline representation of a physical object that represents a solid impassable object (e.g. wall or roof)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
         public static List<Polyline> Polyline(BH.oM.Physical.Elements.ISurface physicalObject)
         {
             return physicalObject.Location.Edges().Select(x => x.ICollapseToPolyline(Tolerance.Angle)).ToList();
         }
 
+        [Description("Returns a Polyline representation of a physical object that represents an opening (e.g. window or door)")]
+        [Input("physicalObject", "A physical object to query the polyline representation of")]
+        [Output("polyline", "BHoM Geometry Polyline")]
         public static List<Polyline> Polyline(IOpening physicalOpening)
         {
             return physicalOpening.Location.Edges().Select(x => x.ICollapseToPolyline(Tolerance.Angle)).ToList();

--- a/Physical_Engine/Query/Roofs.cs
+++ b/Physical_Engine/Query/Roofs.cs
@@ -21,18 +21,18 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BH.oM.Environment.Elements;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Physical.Elements;
+using BH.oM.Geometry;
+using BH.oM.Physical;
 using BH.oM.Base;
 
-using BH.oM.Reflection.Attributes;
-using System.ComponentModel;
+using BH.Engine.Base;
 
-namespace BH.Engine.Environment
+namespace BH.Engine.Physical
 {
     public static partial class Query
     {
@@ -40,13 +40,17 @@ namespace BH.Engine.Environment
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns a collection of objects which are of the provided object type")]
-        [Input("objects", "A collection of generic BHoM objects")]
-        [Input("type", "The type of object to be queried and returned")]
-        [Output("bhomObjects", "A collection of generic BHoM objects matching the provided type")]
-        public static List<IBHoMObject> ObjectsByType(this List<IBHoMObject> objects, Type type)
+        [Description("Returns a collection of Physical Roofs from a list of generic BHoM objects")]
+        [Input("bhomObjects", "A collection of generic BHoM objects")]
+        [Output("roofs", "A collection of Physical Roof objects")]
+        public static List<Roof> Roofs(this List<IBHoMObject> bhomObjects)
         {
-            return objects.Where(x => x.GetType() == type).ToList();
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Roof));
+            List<Roof> roofs = new List<Roof>();
+            foreach (IBHoMObject o in bhomObjects)
+                roofs.Add(o as Roof);
+
+            return roofs;
         }
     }
 }

--- a/Physical_Engine/Query/Walls.cs
+++ b/Physical_Engine/Query/Walls.cs
@@ -21,20 +21,18 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BH.oM.Environment.Elements;
-using BH.oM.Base;
-
-using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
 using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Physical.Elements;
+using BH.oM.Geometry;
+using BH.oM.Physical;
+using BH.oM.Base;
 
 using BH.Engine.Base;
 
-namespace BH.Engine.Environment
+namespace BH.Engine.Physical
 {
     public static partial class Query
     {
@@ -42,17 +40,17 @@ namespace BH.Engine.Environment
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns a collection of Environment Buildings from a list of generic BHoM objects")]
+        [Description("Returns a collection of Physical Walls from a list of generic BHoM objects")]
         [Input("bhomObjects", "A collection of generic BHoM objects")]
-        [Output("buildings", "A collection of Environment Building objects")]
-        public static List<Building> Buildings(this List<IBHoMObject> bhomObjects)
+        [Output("walls", "A collection of Physical Wall objects")]
+        public static List<Wall> Walls(this List<IBHoMObject> bhomObjects)
         {
-            bhomObjects = bhomObjects.ObjectsByType(typeof(Building));
-            List<Building> buildings = new List<Building>();
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Wall));
+            List<Wall> walls = new List<Wall>();
             foreach (IBHoMObject o in bhomObjects)
-                buildings.Add(o as Building);
+                walls.Add(o as Wall);
 
-            return buildings;
+            return walls;
         }
     }
 }

--- a/Physical_Engine/Query/Windows.cs
+++ b/Physical_Engine/Query/Windows.cs
@@ -21,20 +21,18 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BH.oM.Environment.Elements;
-using BH.oM.Base;
-
-using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
 using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Physical.Elements;
+using BH.oM.Geometry;
+using BH.oM.Physical;
+using BH.oM.Base;
 
 using BH.Engine.Base;
 
-namespace BH.Engine.Environment
+namespace BH.Engine.Physical
 {
     public static partial class Query
     {
@@ -42,17 +40,17 @@ namespace BH.Engine.Environment
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns a collection of Environment Buildings from a list of generic BHoM objects")]
+        [Description("Returns a collection of Physical Windows from a list of generic BHoM objects")]
         [Input("bhomObjects", "A collection of generic BHoM objects")]
-        [Output("buildings", "A collection of Environment Building objects")]
-        public static List<Building> Buildings(this List<IBHoMObject> bhomObjects)
+        [Output("windows", "A collection of Physical Window objects")]
+        public static List<Window> Windows(this List<IBHoMObject> bhomObjects)
         {
-            bhomObjects = bhomObjects.ObjectsByType(typeof(Building));
-            List<Building> buildings = new List<Building>();
+            bhomObjects = bhomObjects.ObjectsByType(typeof(Window));
+            List<Window> windows = new List<Window>();
             foreach (IBHoMObject o in bhomObjects)
-                buildings.Add(o as Building);
+                windows.Add(o as Window);
 
-            return buildings;
+            return windows;
         }
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #1114 
Fixes #1115 
Fixes #1116 

### Test files
Existing test scripts for physical workflow from Revit


### Changelog
 - Add query methods to extract physical objects from collections of BHoM objects to the Physical Engine
 - Add query methods to obtain polyline representations of Physical objects to the Physical Engine
 - Add query methods to obtain Environment representations of Physical objects to the Environment Engine
 - Move method from Environment Engine to BHoM Engine to query objects by type for use by multiple engines


### Additional comments
<!-- As required -->