### PR TITLE
Environment_Engine: Add defaults for gain computes to allow gains to be returned

### DIFF
--- a/Environment_Engine/Compute/EquipmentGain.cs
+++ b/Environment_Engine/Compute/EquipmentGain.cs
@@ -40,11 +40,11 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Compute the sensible or latent equipment gain from the watts per meter squared and the area of the space")]
-        [Input("sensibleWattsPerMeterSquared", "The sensible watts per meter squared from building code")]
-        [Input("latentWattsPerMeterSquared", "The latent watts per meter squared from building code")]
-        [Input("area", "The area of the space")]
+        [Input("sensibleWattsPerMeterSquared", "The sensible watts per meter squared from building code, default 0.0")]
+        [Input("latentWattsPerMeterSquared", "The latent watts per meter squared from building code, default 0.0")]
+        [Input("area", "The area of the space, default 0.0")]
         [Output("equipmentGain", "The calculated sensible or latent equipment gain with the sensible or latent watts for the space")]
-        public static Equipment EquipmentGain(double sensibleWattsPerSquareMeter, double latentWattsPerSquareMeter, double area)
+        public static Equipment EquipmentGain(double sensibleWattsPerSquareMeter = 0.0, double latentWattsPerSquareMeter = 0.0, double area = 0.0)
         {
             return Create.Equipment(sensibleWattsPerSquareMeter * area, latentWattsPerSquareMeter * area);
         }

--- a/Environment_Engine/Compute/LightingGain.cs
+++ b/Environment_Engine/Compute/LightingGain.cs
@@ -40,10 +40,10 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Compute a lighting gain from the watts per square meter and floor area of the space")]
-        [Input("wattsPerMeterSquared", "The watts per meter squared from a standard or set of lights")]
-        [Input("area", "The floor area (in square meters) of the space")]
+        [Input("wattsPerMeterSquared", "The watts per meter squared from a standard or set of lights, default 0.0")]
+        [Input("area", "The floor area (in square meters) of the space, default 0.0")]
         [Output("lightingGain", "The calculated lighting gain with the sensible watts for the space")]
-        public static Lighting LightingGain(double wattsPerMeterSquared, double area)
+        public static Lighting LightingGain(double wattsPerMeterSquared = 0.0, double area = 0.0)
         {
             return Create.Lighting(wattsPerMeterSquared * area);
         }

--- a/Environment_Engine/Compute/PeopleGain.cs
+++ b/Environment_Engine/Compute/PeopleGain.cs
@@ -40,11 +40,11 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Compute the sensible or latent people gain from the watts per person and occupancy of the space")]
-        [Input("sensibleWattsPerPerson", "The sensible watts per person from building code")]
-        [Input("latentWattsPerPerson", "The latent watts per person from building code")]
-        [Input("occupancy", "The occupancy of the space")]
+        [Input("sensibleWattsPerPerson", "The sensible watts per person from building code, default 0.0")]
+        [Input("latentWattsPerPerson", "The latent watts per person from building code, default 0.0")]
+        [Input("occupancy", "The occupancy of the space, default 0.0")]
         [Output("peopleGain", "The calculated sensible or latent people gain with the sensible or latent watts for the space")]
-        public static People PeopleGain(double sensibleWattsPerPerson, double latentWattsPerPerson, double occupancy)
+        public static People PeopleGain(double sensibleWattsPerPerson = 0.0, double latentWattsPerPerson = 0.0, double occupancy = 0.0)
         {
             return Create.People(sensibleWattsPerPerson * occupancy, latentWattsPerPerson * occupancy);
         }

--- a/Environment_Engine/Compute/PlugGain.cs
+++ b/Environment_Engine/Compute/PlugGain.cs
@@ -40,10 +40,10 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Compute a plug gain from the watts per square meter and floor area of the space")]
-        [Input("wattsPerMeterSquared", "The watts per meter squared from plugs/receptacles/outlets")]
-        [Input("area", "The floor area (in square meters) of the space")]
+        [Input("wattsPerMeterSquared", "The watts per meter squared from plugs/receptacles/outlets, default 0.0")]
+        [Input("area", "The floor area (in square meters) of the space, default 0.0")]
         [Output("plugGain", "The calculated plug gain with the sensible watts for the space")]
-        public static Plug PlugGain(double wattsPerMeterSquared, double area)
+        public static Plug PlugGain(double wattsPerMeterSquared = 0.0, double area = 0.0)
         {
             return Create.Plug(wattsPerMeterSquared * area);
         }


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #1112 


### Test files
Existing scripts


### Changelog
 - Added default inputs to gain computes to return gains even if not all gains are required (e.g. sensible/latent)


### Additional comments
This addresses item 1 of the issue referenced. The other items are being ignored for now while gain refactoring is done between @michaldengusiak and @kayleighhoude 