### PR TITLE
Reflection_Engine  - Issue 703 - Fix Depth of Arrays in UnderlyingType

### DIFF
--- a/Reflection_Engine/Query/UnderlyingType.cs
+++ b/Reflection_Engine/Query/UnderlyingType.cs
@@ -39,10 +39,10 @@ namespace BH.Engine.Reflection
         public static UnderlyingType UnderlyingType(this Type type)
         {
             int depth = 0;
-            while (type.GetGenericArguments().Count() == 1 && typeof(IEnumerable).IsAssignableFrom(type))
+            while ((type.GetGenericArguments().Count() == 1 || type.GetElementType() != null) && typeof(IEnumerable).IsAssignableFrom(type))
             {
                 depth++;
-                type = type.GetGenericArguments().First();
+                type = type.GetElementType() ?? type.GetGenericArguments().First();
             }
 
             return new UnderlyingType { Type = type, Depth = depth };


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #703
`Engine.Reflection.Query.UnderlyingType` currently returns the wrong depth for array types, this pr solves it.

Note: a multidimensional array (`int[,]`) has depth of 1. A jagged array (`int[][]`) has depth equals to its nesting levels (2 in this case).

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EjmxIfvj4WNBvi9qWzVvunoBwjYJX03lohJTTu8WHAxAhA?e=5F10sa

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Update the `Engine.Reflection.Query.UnderlyingType` to return the correct depth for the `Array`  type.