### PR TITLE
Geometry_Engine: Expose tolerances

### DIFF
--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -35,20 +35,31 @@ namespace BH.Engine.Geometry
         /***************************************************/
         /**** Public Methods - Curves                   ****/
         /***************************************************/
-
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Polyline curve, double tolerance = Tolerance.Distance)")]
         public static Point Centroid(this Polyline curve)
         {
-            if (!curve.IsPlanar())
+            return curve.Centroid(Tolerance.Distance);
+        }
+
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this PolyCurve curve, double tolerance = Tolerance.Distance)")]
+        public static Point Centroid(this PolyCurve curve)
+        {
+            return curve.Centroid(Tolerance.Distance);
+        }
+
+        public static Point Centroid(this Polyline curve, double tolerance = Tolerance.Distance)
+        {
+            if (!curve.IsPlanar(tolerance))
             {
                 Reflection.Compute.RecordError("Input must be planar.");
                 return null;
             }
-            else if (!curve.IsClosed())
+            else if (!curve.IsClosed(tolerance))
             {
                 Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
                 return null;
             }
-            else if (curve.IsSelfIntersecting())
+            else if (curve.IsSelfIntersecting(tolerance))
             {
                 Reflection.Compute.RecordWarning("Curve is self intersecting");
                 return null;
@@ -112,19 +123,19 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static Point Centroid(this PolyCurve curve)
+        public static Point Centroid(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
-            if (!curve.IsPlanar())
+            if (!curve.IsPlanar(tolerance))
             {
                 Reflection.Compute.RecordError("Input must be planar.");
                 return null;
             }
-            else if (!curve.IsClosed())
+            else if (!curve.IsClosed(tolerance))
             {
                 Reflection.Compute.RecordError("Curve is not closed.");
                 return null;
             }
-            else if (curve.IsSelfIntersecting())
+            else if (curve.IsSelfIntersecting(tolerance))
             {
                 Reflection.Compute.RecordWarning("Curve is self intersecting");
                 return null;
@@ -288,9 +299,9 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         public static Point ICentroid(this ICurve curve)
-            {
-                return Centroid(curve as dynamic);
-            }
+        {
+            return Centroid(curve as dynamic);
+        }
 
         /***************************************************/
     }

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -88,21 +88,33 @@ namespace BH.Engine.Geometry
         /***************************************************/
         /**** Public Methods - Curves                   ****/
         /***************************************************/
-        
+
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Normal(this Polyline curve, double tolerance = Tolerance.Distance)")]
         public static Vector Normal(this Polyline curve)
         {
+            return curve.Normal(Tolerance.Distance);
+        }
 
-            if (!curve.IsPlanar())
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Normal(this PolyCurve curve, double tolerance = Tolerance.Distance)")]
+        public static Vector Normal(this PolyCurve curve)
+        {
+            return curve.Normal(Tolerance.Distance);
+        }
+
+        public static Vector Normal(this Polyline curve, double tolerance = Tolerance.Distance)
+        {
+
+            if (!curve.IsPlanar(tolerance))
             {
                 Reflection.Compute.RecordError("Input must be planar.");
                 return null;
             }
-            else if (!curve.IsClosed())
+            else if (!curve.IsClosed(tolerance))
             {
                 Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
                 return null;
             }
-            else if (curve.IsSelfIntersecting())
+            else if (curve.IsSelfIntersecting(tolerance))
             {
                 Reflection.Compute.RecordWarning("Curve is self intersecting");
                 return null;
@@ -124,20 +136,20 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static Vector Normal(this PolyCurve curve)
+        public static Vector Normal(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
 
-            if (!curve.IsPlanar())
+            if (!curve.IsPlanar(tolerance))
             {
                 Reflection.Compute.RecordError("Input must be planar.");
                 return null;
             }
-            else if (!curve.IsClosed())
+            else if (!curve.IsClosed(tolerance))
             {
                 Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
                 return null;
             }
-            else if (curve.IsSelfIntersecting())
+            else if (curve.IsSelfIntersecting(tolerance))
             {
                 Reflection.Compute.RecordWarning("Curve is self intersecting");
                 return null;


### PR DESCRIPTION
 ### Issues addressed by this PR
Fixes #1156 
Fixes #1157 


### Test files
N/A


### Changelog
 - Expose tolerance parameter on `Normal` query for `Curve` inputs
 - Expose tolerance parameter on `Centroid` query for `Curve` inputs
 - Deprecate existing `Normal` and `Centroid` queries as a result of the above


### Additional comments
This exposes tolerances for methods which can utilise tolerances to provide greater control when utilising these geometry methods within code and visual programming.