### PR TITLE
Geometry_Engine: Change variable name to minimumSegmentLength

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -104,6 +104,8 @@
     <Compile Include="Create\IntegrationSlice.cs" />
     <Compile Include="Modify\CleanPolyline.cs" />
     <Compile Include="Modify\CollapseToPolyline.cs" />
+    <Compile Include="Modify\RemoveLeastSignificantVertices.cs" />
+    <Compile Include="Modify\RemoveShortSegments.cs" />
     <Compile Include="Modify\SetGeometry.cs" />
     <Compile Include="Modify\Simplify.cs" />
     <Compile Include="Modify\Extend.cs" />

--- a/Geometry_Engine/Modify/CleanPolyline.cs
+++ b/Geometry_Engine/Modify/CleanPolyline.cs
@@ -36,17 +36,26 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Returns a polyline that is cleaned by removing least significant vertices and short segments. This is designed for closed polylines only")]
+        [Input("polyline", "The polyline you wish to clean by removing unnecessary points")]
+        [Input("angleTolerance", "The tolerance of the angle that defines a straight line. Default is set to the value defined by BH.oM.Geometry.Tolerance.Angle")]
+        [Input("minimumSegmentLength", "The length of the smallest allowed segment. Segments smaller than this will be removed. Default is set to the value defined by BH.oM.Geometry.Tolerance.Distance")]
+        [Output("polyline", "The cleaned polyline")]
+        public static Polyline CleanPolyline(this Polyline polyline, double angleTolerance = Tolerance.Angle, double minimumSegmentLength = Tolerance.Distance)
+        {
+            return polyline.RemoveLeastSignificantVertices().RemoveShortSegments();
+        }
+
         [Description("Returns a polyline defined by the points which result in deviations from a straight line only. For example, if a polyline has 3 points in a straight line, the middle point is removed as part of this cleaning process. This is designed for closed polylines only")]
         [Input("polyline", "The polyline you wish to clean by removing unnecessary points")]
         [Input("angleTolerance", "The tolerance of the angle that defines a straight line. Default is set to the value defined by BH.oM.Geometry.Tolerance.Angle")]
-        [Input("distanceTolerance", "The distance between two point that should be removed. Default is set to the value defined by BH.oM.Geometry.Tolerance.Distance")]
         [Output("polyline", "The cleaned polyline")]
-        public static Polyline CleanPolyline(this Polyline polyline, double angleTolerance = Tolerance.Angle, double distanceTolerance = Tolerance.Distance)
+        public static Polyline RemoveLeastSignificantVertices(this Polyline polyline, double angleTolerance = Tolerance.Angle)
         {
             //This method is for closed polylines only at the moment
             if (!polyline.IsClosed())
             {
-                BH.Engine.Reflection.Compute.RecordError("The CleanPolyline method is only for closed polylines and the input polyline is not closed.");
+                BH.Engine.Reflection.Compute.RecordError("The RemoveLeastSignificantVertices method is only for closed polylines and the input polyline is not closed.");
                 return polyline;
             }
 
@@ -66,7 +75,46 @@ namespace BH.Engine.Geometry
                     //Delete the second point from the list, it's not necessary
                     pnts.RemoveAt((startIndex + 1) % pnts.Count);
                 }
-                else if (first.Distance(second) <= distanceTolerance)
+                else
+                    startIndex++; //Move onto the next point
+            }
+
+            if (pnts.First() != pnts.Last())
+                pnts.Add(pnts.First()); //Reclose polyline
+
+            Polyline pLine = new Polyline()
+            {
+                ControlPoints = pnts,
+            };
+
+            return pLine;
+        }
+
+        [Description("Returns a polyline that has short segments removed. For example, if the polyline has 2 points less than the minimumSegmentLength apart, then only one point will be retained and the short segment will be merged with the next segment")]
+        [Input("polyline", "The polyline you wish to clean by removing short segments")]
+        [Input("minimumSegmentLength", "The tolerance of what a short segment is. Segments greater than this length will be kept, segments shorter will be cleaned (removed). Default is set to the value defined by BH.oM.Geometry.Tolerance.Distance")]
+        [Output("polyline", "The cleaned polyline")]
+        public static Polyline RemoveShortSegments(this Polyline polyline, double minimumSegmentLength = Tolerance.Distance)
+        {
+            //This method is for closed polylines only at the moment
+            if (!polyline.IsClosed())
+            {
+                BH.Engine.Reflection.Compute.RecordError("The RemoveShortSegments method is only for closed polylines and the input polyline is not closed.");
+                return polyline;
+            }
+
+            List<Point> pnts = polyline.DiscontinuityPoints();
+
+            if (pnts.Count < 3) return polyline; //If there's only two points here then this method isn't necessary
+
+            int startIndex = 0;
+            while (startIndex < pnts.Count)
+            {
+                Point first = pnts[startIndex];
+                Point second = pnts[(startIndex + 1) % pnts.Count];
+                Point third = pnts[(startIndex + 2) % pnts.Count];
+
+                if (first.Distance(second) <= minimumSegmentLength)
                 {
                     //Delete the second point as it is too close to the first to produce any meaningful change...
                     pnts.RemoveAt((startIndex + 1) % pnts.Count);
@@ -84,6 +132,6 @@ namespace BH.Engine.Geometry
             };
 
             return pLine;
-        }
+        }            
     }
 }

--- a/Geometry_Engine/Modify/RemoveLeastSignificantVertices.cs
+++ b/Geometry_Engine/Modify/RemoveLeastSignificantVertices.cs
@@ -51,7 +51,8 @@ namespace BH.Engine.Geometry
 
             List<Point> pnts = polyline.DiscontinuityPoints();
 
-            if (pnts.Count < 3) return polyline; //If there's only two points here then this method isn't necessary
+            if (pnts.Count < 3)
+                return polyline; //If there's only two points here then this method isn't necessary
 
             int startIndex = 0;
             while (startIndex < pnts.Count)
@@ -61,10 +62,7 @@ namespace BH.Engine.Geometry
                 Point third = pnts[(startIndex + 2) % pnts.Count];
 
                 if (first.Angle(second, third) <= angleTolerance)
-                {
-                    //Delete the second point from the list, it's not necessary
-                    pnts.RemoveAt((startIndex + 1) % pnts.Count);
-                }
+                    pnts.RemoveAt((startIndex + 1) % pnts.Count);  //Delete the second point from the list, it's not necessary
                 else
                     startIndex++; //Move onto the next point
             }
@@ -79,5 +77,7 @@ namespace BH.Engine.Geometry
 
             return pLine;
         }
+
+        /***************************************************/
     }
 }

--- a/Geometry_Engine/Modify/RemoveLeastSignificantVertices.cs
+++ b/Geometry_Engine/Modify/RemoveLeastSignificantVertices.cs
@@ -36,14 +36,48 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns a polyline that is cleaned by removing least significant vertices and short segments. This is designed for closed polylines only")]
+        [Description("Returns a polyline defined by the points which result in deviations from a straight line only. For example, if a polyline has 3 points in a straight line, the middle point is removed as part of this cleaning process. This is designed for closed polylines only")]
         [Input("polyline", "The polyline you wish to clean by removing unnecessary points")]
         [Input("angleTolerance", "The tolerance of the angle that defines a straight line. Default is set to the value defined by BH.oM.Geometry.Tolerance.Angle")]
-        [Input("minimumSegmentLength", "The length of the smallest allowed segment. Segments smaller than this will be removed. Default is set to the value defined by BH.oM.Geometry.Tolerance.Distance")]
         [Output("polyline", "The cleaned polyline")]
-        public static Polyline CleanPolyline(this Polyline polyline, double angleTolerance = Tolerance.Angle, double minimumSegmentLength = Tolerance.Distance)
+        public static Polyline RemoveLeastSignificantVertices(this Polyline polyline, double angleTolerance = Tolerance.Angle)
         {
-            return polyline.RemoveLeastSignificantVertices().RemoveShortSegments();
-        }  
+            //This method is for closed polylines only at the moment
+            if (!polyline.IsClosed())
+            {
+                BH.Engine.Reflection.Compute.RecordError("The RemoveLeastSignificantVertices method is only for closed polylines and the input polyline is not closed.");
+                return polyline;
+            }
+
+            List<Point> pnts = polyline.DiscontinuityPoints();
+
+            if (pnts.Count < 3) return polyline; //If there's only two points here then this method isn't necessary
+
+            int startIndex = 0;
+            while (startIndex < pnts.Count)
+            {
+                Point first = pnts[startIndex];
+                Point second = pnts[(startIndex + 1) % pnts.Count];
+                Point third = pnts[(startIndex + 2) % pnts.Count];
+
+                if (first.Angle(second, third) <= angleTolerance)
+                {
+                    //Delete the second point from the list, it's not necessary
+                    pnts.RemoveAt((startIndex + 1) % pnts.Count);
+                }
+                else
+                    startIndex++; //Move onto the next point
+            }
+
+            if (pnts.First() != pnts.Last())
+                pnts.Add(pnts.First()); //Reclose polyline
+
+            Polyline pLine = new Polyline()
+            {
+                ControlPoints = pnts,
+            };
+
+            return pLine;
+        }
     }
 }

--- a/Geometry_Engine/Modify/RemoveShortSegments.cs
+++ b/Geometry_Engine/Modify/RemoveShortSegments.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+
+using System.Collections.Generic;
+using System.Linq;
+
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Returns a polyline that has short segments removed. For example, if the polyline has 2 points less than the minimumSegmentLength apart, then only one point will be retained and the short segment will be merged with the next segment")]
+        [Input("polyline", "The polyline you wish to clean by removing short segments")]
+        [Input("minimumSegmentLength", "The tolerance of what a short segment is. Segments greater than this length will be kept, segments shorter will be cleaned (removed). Default is set to the value defined by BH.oM.Geometry.Tolerance.Distance")]
+        [Output("polyline", "The cleaned polyline")]
+        public static Polyline RemoveShortSegments(this Polyline polyline, double minimumSegmentLength = Tolerance.Distance)
+        {
+            //This method is for closed polylines only at the moment
+            if (!polyline.IsClosed())
+            {
+                BH.Engine.Reflection.Compute.RecordError("The RemoveShortSegments method is only for closed polylines and the input polyline is not closed.");
+                return polyline;
+            }
+
+            List<Point> pnts = polyline.DiscontinuityPoints();
+
+            if (pnts.Count < 3) return polyline; //If there's only two points here then this method isn't necessary
+
+            int startIndex = 0;
+            while (startIndex < pnts.Count)
+            {
+                Point first = pnts[startIndex];
+                Point second = pnts[(startIndex + 1) % pnts.Count];
+                Point third = pnts[(startIndex + 2) % pnts.Count];
+
+                if (first.Distance(second) <= minimumSegmentLength)
+                {
+                    //Delete the second point as it is too close to the first to produce any meaningful change...
+                    pnts.RemoveAt((startIndex + 1) % pnts.Count);
+                }
+                else
+                    startIndex++; //Move onto the next point
+            }
+
+            if (pnts.First() != pnts.Last())
+                pnts.Add(pnts.First()); //Reclose polyline
+
+            Polyline pLine = new Polyline()
+            {
+                ControlPoints = pnts,
+            };
+
+            return pLine;
+        }
+    }
+}

--- a/Geometry_Engine/Modify/RemoveShortSegments.cs
+++ b/Geometry_Engine/Modify/RemoveShortSegments.cs
@@ -51,7 +51,8 @@ namespace BH.Engine.Geometry
 
             List<Point> pnts = polyline.DiscontinuityPoints();
 
-            if (pnts.Count < 3) return polyline; //If there's only two points here then this method isn't necessary
+            if (pnts.Count < 3)
+                return polyline; //If there's only two points here then this method isn't necessary
 
             int startIndex = 0;
             while (startIndex < pnts.Count)
@@ -61,10 +62,7 @@ namespace BH.Engine.Geometry
                 Point third = pnts[(startIndex + 2) % pnts.Count];
 
                 if (first.Distance(second) <= minimumSegmentLength)
-                {
-                    //Delete the second point as it is too close to the first to produce any meaningful change...
-                    pnts.RemoveAt((startIndex + 1) % pnts.Count);
-                }
+                    pnts.RemoveAt((startIndex + 1) % pnts.Count); //Delete the second point as it is too close to the first to produce any meaningful change...
                 else
                     startIndex++; //Move onto the next point
             }
@@ -79,5 +77,7 @@ namespace BH.Engine.Geometry
 
             return pLine;
         }
+
+        /***************************************************/
     }
 }

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -50,33 +50,33 @@ namespace BH.Engine.Geometry
         [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Ellipse ellipse, double tolerance = Tolerance.Distance)")]
         public static Point Centroid(this Ellipse ellipse)
         {
-            return ellipse.Centre;
+            return ellipse.Centroid(Tolerance.Distance);
         }
 
         [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Circle circle, double tolerance = Tolerance.Distance)")]
         public static Point Centroid(this Circle circle)
         {
-            return circle.Centre;
+            return circle.Centroid(Tolerance.Distance);
         }
 
         [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Line line, double tolerance = Tolerance.Distance)")]
         public static Point Centroid(this Line line)
         {
-            return line.PointAtParameter(0.5);
+            return line.Centroid(Tolerance.Distance);
         }
 
         [NotImplemented]
         [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Arc arc, double tolerance = Tolerance.Distance)")]
         public static Point Centroid(this Arc arc)
         {
-            throw new NotImplementedException();
+            return arc.Centroid(Tolerance.Distance);
         }
 
         [NotImplemented]
         [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this NurbsCurve nurbsCurve, double tolerance = Tolerance.Distance)")]
         public static Point Centroid(this NurbsCurve nurbsCurve)
         {
-            throw new NotImplementedException();
+            return nurbsCurve.Centroid(Tolerance.Distance);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -47,6 +47,40 @@ namespace BH.Engine.Geometry
             return curve.Centroid(Tolerance.Distance);
         }
 
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Ellipse ellipse, double tolerance = Tolerance.Distance)")]
+        public static Point Centroid(this Ellipse ellipse)
+        {
+            return ellipse.Centre;
+        }
+
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Circle circle, double tolerance = Tolerance.Distance)")]
+        public static Point Centroid(this Circle circle)
+        {
+            return circle.Centre;
+        }
+
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Line line, double tolerance = Tolerance.Distance)")]
+        public static Point Centroid(this Line line)
+        {
+            return line.PointAtParameter(0.5);
+        }
+
+        [NotImplemented]
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this Arc arc, double tolerance = Tolerance.Distance)")]
+        public static Point Centroid(this Arc arc)
+        {
+            throw new NotImplementedException();
+        }
+
+        [NotImplemented]
+        [Deprecated("2.4", "Deprecated to expose tolerance as optional parameter for greater control", null, "Centroid(this NurbsCurve nurbsCurve, double tolerance = Tolerance.Distance)")]
+        public static Point Centroid(this NurbsCurve nurbsCurve)
+        {
+            throw new NotImplementedException();
+        }
+
+        /***************************************************/
+
         public static Point Centroid(this Polyline curve, double tolerance = Tolerance.Distance)
         {
             if (!curve.IsPlanar(tolerance))
@@ -242,21 +276,21 @@ namespace BH.Engine.Geometry
         
         /***************************************************/
 
-        public static Point Centroid(this Ellipse ellipse)
+        public static Point Centroid(this Ellipse ellipse, double tolerance = Tolerance.Distance)
         {
             return ellipse.Centre;
         }
                 
         /***************************************************/
 
-        public static Point Centroid(this Circle circle)
+        public static Point Centroid(this Circle circle, double tolerance = Tolerance.Distance)
         {
             return circle.Centre;
         }
         
         /***************************************************/
 
-        public static Point Centroid(this Line line)
+        public static Point Centroid(this Line line, double tolerance = Tolerance.Distance)
         {
             return line.PointAtParameter(0.5);
         }
@@ -264,7 +298,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [NotImplemented]
-        public static Point Centroid(this Arc arc)
+        public static Point Centroid(this Arc arc, double tolerance = Tolerance.Distance)
         {
             throw new NotImplementedException();
         }
@@ -272,7 +306,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [NotImplemented]
-        public static Point Centroid(this NurbsCurve nurbsCurve)
+        public static Point Centroid(this NurbsCurve nurbsCurve, double tolerance = Tolerance.Distance)
         {
             throw new NotImplementedException();
         }
@@ -298,9 +332,9 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 
-        public static Point ICentroid(this ICurve curve)
+        public static Point ICentroid(this ICurve curve, double tolerance = Tolerance.Distance)
         {
-            return Centroid(curve as dynamic);
+            return Centroid(curve as dynamic, tolerance);
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #1173 


### Test files
[Existing](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Geometry_Engine/CleanPolyline.gh?csf=1&e=mpq5Kw)


### Changelog
 - Rename `distanceTolerance` to `minmumSegmentLength` in `CleanPolyline`
 - Add `RemoveLeastSignificantVertices` method separately from `CleanPolyline` for greater user control
 - Add `RemoveShortSegments` method separately from `CleanPolyline` for greater user control
 - Modify `CleanPolyline` to use the two separate methods
 - Add `tolerance` to all `centroid` methods

### Additional comments
Tolerance added to all Centroid methods per PR comment https://github.com/BHoM/BHoM_Engine/pull/1170#issuecomment-529340030