### PR TITLE
Migrating grids and levels from Architecture to Geometry.SettingOut

### DIFF
--- a/Architecture_Engine/Architecture_Engine.csproj
+++ b/Architecture_Engine/Architecture_Engine.csproj
@@ -59,6 +59,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Create\SettingOut\Grid.cs" />
+    <Compile Include="Create\SettingOut\Level.cs" />
     <Compile Include="Create\Theatron\CircularStadiaPlan.cs" />
     <Compile Include="Create\Theatron\EightArcStadiaPlan.cs" />
     <Compile Include="Create\Theatron\FourArcStadiaPlan.cs" />

--- a/Architecture_Engine/Architecture_Engine.csproj
+++ b/Architecture_Engine/Architecture_Engine.csproj
@@ -59,8 +59,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Create\SettingOut\Grid.cs" />
-    <Compile Include="Create\SettingOut\Level.cs" />
     <Compile Include="Create\Theatron\CircularStadiaPlan.cs" />
     <Compile Include="Create\Theatron\EightArcStadiaPlan.cs" />
     <Compile Include="Create\Theatron\FourArcStadiaPlan.cs" />
@@ -102,6 +100,7 @@
   <ItemGroup>
     <Folder Include="Compute\" />
     <Folder Include="Convert\" />
+    <Folder Include="Create\SettingOut\" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Architecture_Engine/Create/Grid.cs
+++ b/Architecture_Engine/Create/Grid.cs
@@ -19,8 +19,8 @@
  * You should have received a copy of the GNU Lesser General Public License     
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
-
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using BH.oM.Architecture.Elements;
 using System.Collections.Generic;
 using BH.Engine.Geometry;
@@ -33,6 +33,7 @@ namespace BH.Engine.Architecture.Elements
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Deprecated("2.4", "BH.Engine.Architecture.Elements.Grid superseded by BH.oM.Geometry.SettingOut.Grid")]
         public static Grid Grid(ICurve curve)
         {
             return new Grid
@@ -43,6 +44,7 @@ namespace BH.Engine.Architecture.Elements
 
         /***************************************************/
 
+        [Deprecated("2.4", "BH.Engine.Architecture.Elements.Grid superseded by BH.oM.Geometry.SettingOut.Grid")]
         public static Grid Grid(Point origin, Vector direction, double length = 20)
         {
             Line line = new Line { Start = new Point { X = origin.X, Y = origin.Y, Z = 0 }, End = origin + new Vector { X = direction.X, Y = direction.Y, Z = 0 }.Normalise() * length };
@@ -51,6 +53,7 @@ namespace BH.Engine.Architecture.Elements
 
         /***************************************************/
 
+        [Deprecated("2.4", "BH.Engine.Architecture.Elements.Grid superseded by BH.oM.Geometry.SettingOut.Grid")]
         public static Grid Grid(ICurve curve, string name)
         {
             return new Grid
@@ -62,6 +65,7 @@ namespace BH.Engine.Architecture.Elements
 
         /***************************************************/
 
+        [Deprecated("2.4", "BH.Engine.Architecture.Elements.Grid superseded by BH.oM.Geometry.SettingOut.Grid")]
         public static Grid Grid(Point origin, Vector direction, string name, double length = 20)
         {
             Line line = new Line { Start = new Point { X = origin.X, Y = origin.Y, Z = 0 }, End = origin + new Vector { X = direction.X, Y = direction.Y, Z = 0 }.Normalise() * length };

--- a/Architecture_Engine/Create/Level.cs
+++ b/Architecture_Engine/Create/Level.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Architecture.Elements;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Architecture.Elements
 {
@@ -30,6 +31,7 @@ namespace BH.Engine.Architecture.Elements
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Deprecated("2.4", "BH.Engine.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
         public static Level Level(double elevation)
         {
             return new Level
@@ -40,6 +42,7 @@ namespace BH.Engine.Architecture.Elements
 
         /***************************************************/
 
+        [Deprecated("2.4", "BH.Engine.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
         public static Level Level(double elevation, string name)
         {
             return new Level

--- a/Architecture_Engine/Modify/SetGeometry.cs
+++ b/Architecture_Engine/Modify/SetGeometry.cs
@@ -23,6 +23,7 @@
 using BH.Engine.Geometry;
 using BH.oM.Architecture.Elements;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Architecture
 {
@@ -31,7 +32,8 @@ namespace BH.Engine.Architecture
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
-
+   
+        [Deprecated("2.4", "BH.Engine.Architecture.Elements.Grid superseded by BH.oM.Geometry.SettingOut.Grid")]
         public static Grid SetGeometry(this Grid grid, ICurve curve)
         {
             Grid clone = grid.GetShallowClone() as Grid;

--- a/Environment_Engine/Query/Level.cs
+++ b/Environment_Engine/Query/Level.cs
@@ -28,7 +28,7 @@ using System.Linq;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
 
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 using BH.oM.Base;
 
 using BH.oM.Reflection.Attributes;
@@ -44,9 +44,9 @@ namespace BH.Engine.Environment
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns a collection of Architecture Levels from a list of generic BHoM objects")]
+        [Description("Returns a collection of Setting Out Levels from a list of generic BHoM objects")]
         [Input("bhomObjects", "A collection of generic BHoM objects")]
-        [Output("levels", "A collection of Architecture Level objects")]
+        [Output("levels", "A collection of Setting Out Level objects")]
         public static List<Level> Levels(this List<IBHoMObject> bhomObjects)
         {
             bhomObjects = bhomObjects.ObjectsByType(typeof(Level));
@@ -85,10 +85,10 @@ namespace BH.Engine.Environment
             return Math.Round(max, 3);
         }
 
-        [Description("Returns the Architecture Level that the Environment Panel resides on")]
+        [Description("Returns the Setting Out Level that the Environment Panel resides on")]
         [Input("panel", "An Environment Panel to find the level from")]
-        [Input("levels", "A collection of Architecture Levels to search from")]
-        [Output("level", "The Architecture Level of the panel")]
+        [Input("levels", "A collection of Setting Out Levels to search from")]
+        [Output("level", "The Setting Out Level of the panel")]
         public static Level Level(this Panel panel, IEnumerable<Level> levels)
         {
             double min = panel.MinimumLevel();
@@ -97,10 +97,10 @@ namespace BH.Engine.Environment
             return levels.Where(x => x.Elevation >= min && x.Elevation <= max).FirstOrDefault();
         }
 
-        [Description("Returns the Architecture Level that the space (represented by a collection of Environment Panels) resides on")]
+        [Description("Returns the Setting Out Level that the space (represented by a collection of Environment Panels) resides on")]
         [Input("panelsAsSpace", "A collection of Environment Panels that represent a single space to find the level from")]
-        [Input("level", "The Architecture Level to check against")]
-        [Output("level", "The Architecture Level of the space if the space resides on this level, otherwise returns null if the space does not reside on this level")]
+        [Input("level", "The Setting Out Level to check against")]
+        [Output("level", "The Setting Out Level of the space if the space resides on this level, otherwise returns null if the space does not reside on this level")]
         public static Level Level(this List<Panel> panelsAsSpace, Level level)
         {
             Polyline floor = panelsAsSpace.FloorGeometry();
@@ -116,10 +116,10 @@ namespace BH.Engine.Environment
             return level;
         }
 
-        [Description("Returns the Architecture Level that the space (represented by a collection of Environment Panels) resides on")]
+        [Description("Returns the Setting Out Level that the space (represented by a collection of Environment Panels) resides on")]
         [Input("panelsAsSpace", "A collection of Environment Panels that represent a single space to find the level from")]
-        [Input("levels", "A collection of Architecture Levels to search from")]
-        [Output("level", "The Architecture Level of the space")]
+        [Input("levels", "A collection of Setting Out Levels to search from")]
+        [Output("level", "The Setting Out Level of the space")]
         public static Level Level(this List<Panel> panelsAsSpace, List<Level> levels)
         {
             foreach(Level l in levels)
@@ -130,5 +130,65 @@ namespace BH.Engine.Environment
 
             return null;
         }
+
+
+        /***************************************************/
+        /**** Deprecated Methods                        ****/
+        /***************************************************/
+
+        [Description("Returns the Architecture Level that the Environment Panel resides on")]
+        [Input("panel", "An Environment Panel to find the level from")]
+        [Input("levels", "A collection of Architecture Levels to search from")]
+        [Output("level", "The Architecture Level of the panel")]
+        [Deprecated("2.4", "BH.oM.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
+        public static BH.oM.Architecture.Elements.Level Level(this Panel panel, IEnumerable<BH.oM.Architecture.Elements.Level> levels)
+        {
+            double min = panel.MinimumLevel();
+            double max = panel.MaximumLevel();
+
+            return levels.Where(x => x.Elevation >= min && x.Elevation <= max).FirstOrDefault();
+        }
+
+        /***************************************************/
+
+        [Description("Returns the Architecture Level that the space (represented by a collection of Environment Panels) resides on")]
+        [Input("panelsAsSpace", "A collection of Environment Panels that represent a single space to find the level from")]
+        [Input("level", "The Architecture Level to check against")]
+        [Output("level", "The Architecture Level of the space if the space resides on this level, otherwise returns null if the space does not reside on this level")]
+        [Deprecated("2.4", "BH.oM.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
+        public static BH.oM.Architecture.Elements.Level Level(this List<Panel> panelsAsSpace, BH.oM.Architecture.Elements.Level level)
+        {
+            Polyline floor = panelsAsSpace.FloorGeometry();
+            if (floor == null) return null;
+
+            List<Point> floorPts = floor.IControlPoints();
+
+            bool allPointsOnLevel = true;
+            foreach (Point pt in floorPts)
+                allPointsOnLevel &= (pt.Z > (level.Elevation - BH.oM.Geometry.Tolerance.Distance) && pt.Z < (level.Elevation + BH.oM.Geometry.Tolerance.Distance));
+
+            if (!allPointsOnLevel) return null;
+            return level;
+        }
+
+        /***************************************************/
+
+        [Description("Returns the Architecture Level that the space (represented by a collection of Environment Panels) resides on")]
+        [Input("panelsAsSpace", "A collection of Environment Panels that represent a single space to find the level from")]
+        [Input("levels", "A collection of Architecture Levels to search from")]
+        [Output("level", "The Architecture Level of the space")]
+        [Deprecated("2.4", "BH.oM.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
+        public static BH.oM.Architecture.Elements.Level Level(this List<Panel> panelsAsSpace, List<BH.oM.Architecture.Elements.Level> levels)
+        {
+            foreach (BH.oM.Architecture.Elements.Level l in levels)
+            {
+                BH.oM.Architecture.Elements.Level match = panelsAsSpace.Level(l);
+                if (match != null) return match;
+            }
+
+            return null;
+        }
+
+        /***************************************************/
     }
 }

--- a/Environment_Engine/Query/Panels.cs
+++ b/Environment_Engine/Query/Panels.cs
@@ -36,7 +36,7 @@ using BH.Engine.Geometry;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 
 using BH.Engine.Base;
 
@@ -208,7 +208,7 @@ namespace BH.Engine.Environment
 
         [Description("Returns a collection of Environment Panels that sit entirely on a given levels elevation")]
         [Input("panels", "A collection of Environment Panels to filter")]
-        [Input("searchLevel", "The Architecture level to search by")]
+        [Input("searchLevel", "The Setting Out Level to search by")]
         [Output("panels", "A collection of Environment Panels which match the given level")]
         public static List<Panel> PanelsByLevel(this List<Panel> panels, Level searchLevel)
         {
@@ -226,7 +226,7 @@ namespace BH.Engine.Environment
 
         [Description("Returns a collection of Environment Panels where the minimum level of the panel matches the elevation of the given search level")]
         [Input("panels", "A collection of Environment Panels to filter")]
-        [Input("searchLevel", "The Architecture level to search by")]
+        [Input("searchLevel", "The Setting Out Level to search by")]
         [Output("panels", "A collection of Environment Panels where the minimum level meets the search level")]
         public static List<Panel> PanelsByMinimumLevel(this List<Panel> panels, Level searchLevel)
         {
@@ -244,7 +244,7 @@ namespace BH.Engine.Environment
 
         [Description("Returns a collection of Environment Panels where the maximum level of the panel matches the elevation of the given search level")]
         [Input("panels", "A collection of Environment Panels to filter")]
-        [Input("searchLevel", "The Architecture level to search by")]
+        [Input("searchLevel", "The Setting Level to search by")]
         [Output("panels", "A collection of Environment Panels where the maximum level meets the search level")]
         public static List<Panel> PanelsByMaximumLevel(this List<Panel> panels, Level searchLevel)
         {
@@ -300,5 +300,44 @@ namespace BH.Engine.Environment
         }
 
 
+        /***************************************************/
+        /**** Deprecated Methods                        ****/
+        /***************************************************/
+
+        [Description("Returns a collection of Environment Panels that sit entirely on a given levels elevation")]
+        [Input("panels", "A collection of Environment Panels to filter")]
+        [Input("searchLevel", "The Architecture level to search by")]
+        [Output("panels", "A collection of Environment Panels which match the given level")]
+        [Deprecated("2.4", "BH.oM.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
+        public static List<Panel> PanelsByLevel(this List<Panel> panels, BH.oM.Architecture.Elements.Level searchLevel)
+        {
+            return panels.PanelsByLevel(searchLevel.Elevation);
+        }
+
+        /***************************************************/
+
+        [Description("Returns a collection of Environment Panels where the minimum level of the panel matches the elevation of the given search level")]
+        [Input("panels", "A collection of Environment Panels to filter")]
+        [Input("searchLevel", "The Architecture level to search by")]
+        [Output("panels", "A collection of Environment Panels where the minimum level meets the search level")]
+        [Deprecated("2.4", "BH.oM.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
+        public static List<Panel> PanelsByMinimumLevel(this List<Panel> panels, BH.oM.Architecture.Elements.Level searchLevel)
+        {
+            return panels.PanelsByMinimumLevel(searchLevel.Elevation);
+        }
+
+        /***************************************************/
+
+        [Description("Returns a collection of Environment Panels where the maximum level of the panel matches the elevation of the given search level")]
+        [Input("panels", "A collection of Environment Panels to filter")]
+        [Input("searchLevel", "The Architecture level to search by")]
+        [Output("panels", "A collection of Environment Panels where the maximum level meets the search level")]
+        [Deprecated("2.4", "BH.oM.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
+        public static List<Panel> PanelsByMaximumLevel(this List<Panel> panels, BH.oM.Architecture.Elements.Level searchLevel)
+        {
+            return panels.PanelsByMaximumLevel(searchLevel.Elevation);
+        }
+
+        /***************************************************/
     }
 }

--- a/Environment_Engine/Query/StoreyGeometry.cs
+++ b/Environment_Engine/Query/StoreyGeometry.cs
@@ -27,7 +27,7 @@ using System.Linq;
 
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
-using BH.oM.Architecture.Elements;
+using BH.oM.Geometry.SettingOut;
 
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -41,7 +41,7 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Returns the storey geometry for a given level")]
-        [Input("level", "An Architecture Level to get the geometry for")]
+        [Input("level", "An Setting Out Level to get the geometry for")]
         [Input("panelsAsSpaces", "A nested collection of Environment Panels representing spaces")]
         [Output("polyline", "A BHoM Geometry Polyline outlining the geometry of the level")]
         public static Polyline StoreyGeometry(this Level level, List<List<Panel>> panelsAsSpaces)
@@ -66,5 +66,41 @@ namespace BH.Engine.Environment
 
             return BH.Engine.Geometry.Create.ConvexHull(ctrlPoints.CullDuplicates());
         }
+
+
+        /***************************************************/
+        /**** Deprecated Methods                        ****/
+        /***************************************************/
+
+        [Description("Returns the storey geometry for a given level")]
+        [Input("level", "An Architecture Level to get the geometry for")]
+        [Input("panelsAsSpaces", "A nested collection of Environment Panels representing spaces")]
+        [Output("polyline", "A BHoM Geometry Polyline outlining the geometry of the level")]
+        [Deprecated("2.4", "BH.oM.Architecture.Elements.Level superseded by BH.oM.Geometry.SettingOut.Level")]
+        public static Polyline StoreyGeometry(this BH.oM.Architecture.Elements.Level level, List<List<Panel>> panelsAsSpaces)
+        {
+            List<List<Panel>> spacesAtLevel = panelsAsSpaces.FindAll(x => x.Level(level) != null).ToList();
+
+            if (spacesAtLevel.Count == 0) return null;
+
+            List<Point> ctrlPoints = new List<Point>();
+
+            foreach (List<Panel> space in spacesAtLevel)
+            {
+                foreach (Panel element in space)
+                {
+                    foreach (Point pt in element.Polyline().IControlPoints())
+                    {
+                        if (pt.Z > (level.Elevation - BH.oM.Geometry.Tolerance.Distance) && pt.Z < (level.Elevation + BH.oM.Geometry.Tolerance.Distance))
+                            ctrlPoints.Add(pt);
+                    }
+                }
+            }
+
+            return BH.Engine.Geometry.Create.ConvexHull(ctrlPoints.CullDuplicates());
+        }
+
+        /***************************************************/
+
     }
 }

--- a/Geometry_Engine/Create/SettingOut/Grid.cs
+++ b/Geometry_Engine/Create/SettingOut/Grid.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Geometry.SettingOut;
+
+namespace BH.Engine.Geometry.SettingOut
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Grid Grid(ICurve curve)
+        {
+            return new Grid
+            {
+                Curve = Geometry.Modify.IProject(curve, BH.oM.Geometry.Plane.XY)
+            };
+        }
+
+        /***************************************************/
+
+        public static Grid Grid(Point origin, Vector direction, double length = 20)
+        {
+            Line line = new Line { Start = new Point { X = origin.X, Y = origin.Y, Z = 0 }, End = origin + new Vector { X = direction.X, Y = direction.Y, Z = 0 }.Normalise() * length };
+            return new Grid { Curve = line };
+        }
+
+        /***************************************************/
+
+        public static Grid Grid(ICurve curve, string name)
+        {
+            return new Grid
+            {
+                Curve = Geometry.Modify.IProject(curve, BH.oM.Geometry.Plane.XY),
+                Name = name,
+            };
+        }
+
+        /***************************************************/
+
+        public static Grid Grid(Point origin, Vector direction, string name, double length = 20)
+        {
+            Line line = new Line { Start = new Point { X = origin.X, Y = origin.Y, Z = 0 }, End = origin + new Vector { X = direction.X, Y = direction.Y, Z = 0 }.Normalise() * length };
+            return new Grid { Curve = line, Name = name };
+        }
+
+        /***************************************************/
+    }
+}

--- a/Geometry_Engine/Create/SettingOut/Level.cs
+++ b/Geometry_Engine/Create/SettingOut/Level.cs
@@ -1,0 +1,54 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry.SettingOut;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Level Level(double elevation)
+        {
+            return new Level
+            {
+                Elevation = elevation
+            };
+        }
+
+        /***************************************************/
+
+        public static Level Level(double elevation, string name)
+        {
+            return new Level
+            {
+                Elevation = elevation,
+                Name = name,
+            };
+        }
+
+        /***************************************************/
+    }
+}

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -78,6 +78,8 @@
     <Compile Include="Create\Cuboid.cs" />
     <Compile Include="Create\Cylinder.cs" />
     <Compile Include="Create\Geometry.cs" />
+    <Compile Include="Create\SettingOut\Grid.cs" />
+    <Compile Include="Create\SettingOut\Level.cs" />
     <Compile Include="Create\PlanarSurface.cs" />
     <Compile Include="Create\ShapeProfileCurves.cs" />
     <Compile Include="Create\ShapeProfile.cs" />

--- a/Geometry_Engine/Modify/SetGeometry.cs
+++ b/Geometry_Engine/Modify/SetGeometry.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Geometry.SettingOut;
 
 namespace BH.Engine.Geometry
 {
@@ -84,6 +85,14 @@ namespace BH.Engine.Geometry
             return newCurve.IClone();
         }
 
+        /***************************************************/
+
+        public static Grid SetGeometry(this Grid grid, ICurve curve)
+        {
+            Grid clone = grid.GetShallowClone() as Grid;
+            clone.Curve = curve.IClone();
+            return clone;
+        }
 
         /***************************************************/
         /****              Interface Methods            ****/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/554

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1203

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FArchitecture%5FoM%2F%23536%20%2D%20migration%20of%20grid%20and%20level&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.oM.Architecture.Elements.Grid` and `Level` Creates deprecated.
- `Grid` and `Level` added to `BH.oM.Geometry.SettingOut`
- Environment methods based on `Level` deprecated and updated to utilise `BH.oM.Geometry.SettingOut.Level`

