### PR TITLE
Structure_Engine: Fix crash when integrating empty FreeFormProfiles

### DIFF
--- a/Geometry_Engine/Create/IntegrationSlice.cs
+++ b/Geometry_Engine/Create/IntegrationSlice.cs
@@ -49,6 +49,9 @@ namespace BH.Engine.Geometry
         {
             List<IntegrationSlice> slices = new List<IntegrationSlice>();
 
+            if (edges.Count == 0)
+                return slices;
+
             List<double> cutAt = new List<double>();
             List<double> sliceSegments = new List<double>();
             Plane p = new Plane { Origin = oM.Geometry.Point.Origin, Normal = direction };

--- a/Structure_Engine/Create/ConcreteSection.cs
+++ b/Structure_Engine/Create/ConcreteSection.cs
@@ -69,6 +69,17 @@ namespace BH.Engine.Structure
 
         public static ConcreteSection ConcreteSectionFromProfile(IProfile profile, Concrete material = null, string name = "", List<Reinforcement> reinforcement = null)
         {
+
+            //Check name
+            if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
+                name = profile.Name;
+
+            //Check profile and raise warnings
+            if (profile.Edges.Count == 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
+            }
+
             Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
 
             profile = result.Item1;
@@ -91,11 +102,7 @@ namespace BH.Engine.Structure
             }
 
             section.Material = material;
-
-            if (!string.IsNullOrWhiteSpace(name))
-                section.Name = name;
-            else if (!string.IsNullOrWhiteSpace(profile.Name))
-                section.Name = profile.Name;
+            section.Name = name;
 
             if (reinforcement != null)
                 section.Reinforcement = reinforcement;

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -113,6 +113,16 @@ namespace BH.Engine.Structure
 
         public static SteelSection SteelSectionFromProfile(IProfile profile, Steel material = null, string name = "")
         {
+            //Check name
+            if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
+                name = profile.Name;
+
+            //Check profile and raise warnings
+            if (profile.Edges.Count == 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
+            }
+
             Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
 
             profile = result.Item1;
@@ -135,11 +145,8 @@ namespace BH.Engine.Structure
             }
 
             section.Material = material;
+            section.Name = name;
 
-            if (!string.IsNullOrWhiteSpace(name))
-                section.Name = name;
-            else if (!string.IsNullOrWhiteSpace(profile.Name))
-                section.Name = profile.Name;
 
             return section;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1160 

<!-- Add short description of what has been fixed -->

Fixing issue with Integrate method crashing for empty `FreeFormProfile`s. 
This has caused the AnalyticalBars method to crash when used on profiles that failed to pull correctly from Revit.

### Test files
<!-- Link to test files to validate the proposed changes -->

[Test file using analytical bars](https://burohappold.sharepoint.com/:f:/s/BHoM/Eqqz9K_SKOpDu0r41tlnwsoBUS2Ba92z4qamTBZt01ludA?e=df0tNn)

