### PR TITLE
Structure_Engine: Updating Geometry(this ISectionProperty section) to IGeometry(this ISectionProperty section)

### DIFF
--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -156,9 +156,18 @@ namespace BH.Engine.Structure
         /**** Public Methods - Interface                ****/
         /***************************************************/
 
-        public static IGeometry Geometry(this ISectionProperty section)
+        public static IGeometry IGeometry(this ISectionProperty section)
         {
             return Geometry(section as dynamic);
+        }
+
+        /***************************************************/
+        /**** Private Methods - Fallback                ****/
+        /***************************************************/
+
+        public static IGeometry Geometry(this object section)
+        {
+            return null;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1219 

<!-- Add short description of what has been fixed -->

Updating method name from Geometry to IGeometry for ISectionProperty
Adding fallback method returning null

This was for some cases before causing stack overflow exceptions when trying to get geometry for Sectionproeprties

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Grasshopper_Toolkit/Issue403-ExplodeBarsCrash?csf=1&e=wudePW

