### PR TITLE
Reflection_Engine: CreateType throws exeptions that stop the data flow in visual programming if in a loop

### DIFF
--- a/Reflection_Engine/Create/Type.cs
+++ b/Reflection_Engine/Create/Type.cs
@@ -38,16 +38,20 @@ namespace BH.Engine.Reflection
 
             List<Type> types = null;
             if (!typeDictionary.TryGetValue(name, out types))
-                throw new KeyNotFoundException("A type corresponding to " + name + " cannot be found.");
+            {
+                Compute.RecordError($"A type corresponding to {name} cannot be found.");
+                return null;
+            }
             else if (types.Count == 1)
                 return types[0];
             else
             {
-                string message = "Multiple types correspond the the name provided: \n";
+                string message = "Ambiguous match: Multiple types correspond the the name provided: \n";
                 foreach (Type type in types)
                     message += "- " + type.FullName + "\n";
 
-                throw new AmbiguousMatchException(message);
+                Compute.RecordError(message);
+                return null;
             }  
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Closes #1193
<!-- Add short description of what has been fixed -->

### Test files
<!-- Link to test files to validate the proposed changes -->
You can find two test files at https://burohappold.sharepoint.com/:f:/s/BHoM/ErItJgi3dcJGuWF4ewszSdYB_vmDJaNuib6ZILMPdx_xOQ?e=APCMLW
I suggest using the one with the suffix "Loop" which actually reproduces the error.
