### PR TITLE
Geometry_Engine #1096 - Fix BooleanUnion bug

### DIFF
--- a/Geometry_Engine/Compute/BooleanUnion.cs
+++ b/Geometry_Engine/Compute/BooleanUnion.cs
@@ -119,7 +119,11 @@ namespace BH.Engine.Geometry
                 for (int j = 0; j < regions.Count; j++)
                 {
                     if (i != j && regions[i].IsContaining(regions[j], true, tolerance))
+                    {
                         regions.RemoveAt(j);
+                        i = -1;
+                        break;
+                    }
                 }
             }
 
@@ -280,7 +284,11 @@ namespace BH.Engine.Geometry
                 for (int j = 0; j < regionsList.Count; j++)
                 {
                     if (i != j && regionsList[i].IIsContaining(regionsList[j], true, tolerance))
+                    {
                         regionsList.RemoveAt(j);
+                        i = -1;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
Didn't work in certain cases of regions inside regions. Now it does. It applies to both Polyline and ICurve methods.

### Issues addressed by this PR
#1096

Closes #1096

<!-- Add short description of what has been fixed -->


### Test files
Updated [file with bug](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1096%2DUnionBug) uploaded by @pawelbaran 

### Changelog
- `Compute.BooleanUnion()` Compute method updated in the `Geometry_Engine` for `Polyline` class
- `Compute.BooleanUnion()` Compute method updated in the `Geometry_Engine` for `ICurve` class
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->