### PR TITLE
Geometry_Engine - Fix SplitAtPoints() bugs and change output type

### DIFF
--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -55,6 +55,9 @@ namespace BH.Engine.Geometry
             cPts = cPts.CullDuplicates(tolerance);
             cPts = cPts.SortAlongCurve(arc, tolerance);
 
+            if (arc.EndAngle - 2 * Math.PI < tolerance && arc.EndAngle - 2 * Math.PI > -tolerance)
+                cPts.Add(arc.EndPoint());
+
             if (cPts.Count > 2)
             {
                 Double startAng = arc.StartAngle;
@@ -77,17 +80,16 @@ namespace BH.Engine.Geometry
             }
             else
                 result.Add(arc.Clone());
-
             return result;
         }
 
         /***************************************************/
 
 
-        public static List<Arc> SplitAtPoints(this Circle circle, List<Point> points, double tolerance = Tolerance.Distance)
+        public static List<ICurve> SplitAtPoints(this Circle circle, List<Point> points, double tolerance = Tolerance.Distance)
         {
 
-            List<Arc> result = new List<Arc>();
+            List<ICurve> result = new List<ICurve>();
             List<Point> cPts = new List<Point>();
 
             foreach (Point point in points)
@@ -114,6 +116,11 @@ namespace BH.Engine.Geometry
             Vector enVec;
             Double enAng;
 
+            if (cPts.Count == 0)
+            {
+                result.Add(circle.Clone());
+                return result;
+            }
             if (cPts.Count == 1)
             {
                 tmpArc = mainArc;

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -85,7 +85,6 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-
         public static List<ICurve> SplitAtPoints(this Circle circle, List<Point> points, double tolerance = Tolerance.Distance)
         {
 
@@ -118,9 +117,10 @@ namespace BH.Engine.Geometry
 
             if (cPts.Count == 0)
             {
-                result.Add(circle.Clone());
+                result.Add(circle);
                 return result;
             }
+
             if (cPts.Count == 1)
             {
                 tmpArc = mainArc;


### PR DESCRIPTION
Fixed the bug of splitting 360 degree arc and circle having no split points. Also changed `SplitAtPoints(Circle)` output type from `List<Arc>` to `Liast<ICurve.` to allow returning Arcs or Circles. It does not affect any other method

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1057 
Closes #1058 

<!-- Add short description of what has been fixed -->


### Test files
[Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%20%231057%20%231058%20%2D%20SplitAtPoints%28%29%20bugs) is the issue specific test and [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FModify) is regular test (nothing changed in a second one).

### Changelog
 - `Modify.SplitAtPoints()` Modify method updated in the `Geometry_Engine` for `Arc` class
 - `Modify.SplitAtPoints()` Modify method updated in the `Geometry_Engine` for `Circle` class

### Additional comments
<!-- As required -->