### PR TITLE
Geometry_Engine - Add an Offset method

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -205,6 +205,10 @@
     <Compile Include="Query\Side.cs" />
     <Compile Include="Query\IsSameSide.cs" />
     <Compile Include="Query\IsValid.cs" />
+	<Compile Include="Modify\Offset.cs" />
+	<Compile Include="Modify\ExtendTangent.cs" />
+	<Compile Include="Modify\Trim.cs" />
+	<Compile Include="Modify\TrimExtend.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Geometry_Engine/Modify/Extend.cs
+++ b/Geometry_Engine/Modify/Extend.cs
@@ -77,7 +77,7 @@ namespace BH.Engine.Geometry
 
         private static Circle Extend(this Circle curve, Point startPoint, Point endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            Reflection.Compute.RecordNote("Can't Extend closed curves.");
             return curve;
         }
 
@@ -85,7 +85,7 @@ namespace BH.Engine.Geometry
 
         private static Circle Extend(this Circle curve, double startPoint, double endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            Reflection.Compute.RecordNote("Can't Extend closed curves.");
             return curve;
         }
 
@@ -93,7 +93,7 @@ namespace BH.Engine.Geometry
 
         private static Ellipse Extend(this Ellipse curve, Point startPoint, Point endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            Reflection.Compute.RecordNote("Can't Extend closed curves.");
             return curve;
         }
 
@@ -101,7 +101,7 @@ namespace BH.Engine.Geometry
 
         private static Ellipse Extend(this Ellipse curve, double startPoint, double endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            Reflection.Compute.RecordNote("Can't Extend closed curves.");
             return curve;
         }
 
@@ -127,17 +127,14 @@ namespace BH.Engine.Geometry
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                Reflection.Compute.RecordNote("Can't Extend closed curves.");
                 return curve;
             }
             List<Point> result = new List<Point>();
             result = curve.ControlPoints;
             result[0] = startPoint;
             result[result.Count - 1] = endPoint;
-            return new Polyline
-            {
-                ControlPoints = result
-            };
+            return new Polyline { ControlPoints = result };
         }
 
         /***************************************************/
@@ -146,7 +143,7 @@ namespace BH.Engine.Geometry
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                Reflection.Compute.RecordNote("Can't Extend closed curves.");
                 return curve;
             }
             Line first = new Line { Start = curve.ControlPoints[0], End = curve.ControlPoints[1] };
@@ -157,10 +154,7 @@ namespace BH.Engine.Geometry
             result = curve.ControlPoints;
             result[0] = first.Start;
             result[result.Count - 1] = last.End;
-            return new Polyline
-            {
-                ControlPoints = result
-            };
+            return new Polyline { ControlPoints = result };
         }
 
         /***************************************************/
@@ -169,18 +163,14 @@ namespace BH.Engine.Geometry
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                Reflection.Compute.RecordNote("Can't Extend closed curves.");
                 return curve;
             }
             List<ICurve> result = new List<ICurve>();
             result = curve.Curves;
             result[0] = result[0].IExtend(startPoint, result[0].IEndPoint());
             result[result.Count - 1] = result[result.Count - 1].IExtend(result[result.Count - 1].IStartPoint(), endPoint);
-            return new PolyCurve
-            {
-                Curves = result
-            };
-
+            return new PolyCurve { Curves = result };
         }
 
         /***************************************************/
@@ -189,18 +179,14 @@ namespace BH.Engine.Geometry
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                Reflection.Compute.RecordNote("Can't Extend closed curves.");
                 return curve;
             }
             List<ICurve> result = new List<ICurve>();
             result = curve.Curves;
             result[0] = result[0].IExtend(start, 0);
             result[result.Count - 1] = result[result.Count - 1].IExtend(0, end);
-            return new PolyCurve
-            {
-                Curves = result
-            };
-
+            return new PolyCurve { Curves = result };
         }
 
 

--- a/Geometry_Engine/Modify/Extend.cs
+++ b/Geometry_Engine/Modify/Extend.cs
@@ -32,10 +32,10 @@ namespace BH.Engine.Geometry
     public static partial class Modify
     {
         /***************************************************/
-        /**** Private Methods - Curves                  ****/
+        /**** Public Methods - Curves                  ****/
         /***************************************************/
 
-        private static Line Extend(this Line curve, double start = 0.0, double end = 0.0)
+        public static Line Extend(this Line curve, double start = 0.0, double end = 0.0)
         {
             Vector dir = curve.Direction();
             return new Line { Start = curve.Start - dir * start, End = curve.End + dir * end };

--- a/Geometry_Engine/Modify/ExtendTangent.cs
+++ b/Geometry_Engine/Modify/ExtendTangent.cs
@@ -41,26 +41,9 @@ namespace BH.Engine.Geometry
 
         private static PolyCurve ExtendTangent(this Line curve, Point startPoint, Point endPoint)
         {
-            List<ICurve> result = new List<ICurve>();
-            //if(curve.ClosestPoint(startPoint)==curve.ClosestPoint(endPoint))
-            //{
-            //    result.Add(new Line { Start = startPoint, End = endPoint });
-            //    return new PolyCurve
-            //    {
-            //        Curves=result
-            //    };
-            //}
-            //if(!startPoint.IsOnCurve(curve))
-            //    result.Add(new Line { Start = startPoint, End = curve.Start });
-            //result.Add(curve);
-            //if(!endPoint.IsOnCurve(curve))
-            //    result.Add(new Line { Start = curve.End, End = endPoint});
+            List<ICurve> result = new List<ICurve>();            
             result.Add(curve.Extend(startPoint, endPoint));
-            return new PolyCurve
-            {
-                Curves = result
-            }
-            ;
+            return new PolyCurve { Curves = result };
         }
 
         /***************************************************/
@@ -68,15 +51,16 @@ namespace BH.Engine.Geometry
         private static PolyCurve ExtendTangent(this Arc curve, Point startPoint, Point endPoint)
         {
             List<ICurve> result = new List<ICurve>();
+
             if(!startPoint.IsOnCurve(curve))
                 result.Add(new Line { Start = startPoint, End = curve.StartPoint() });
+
             result.Add(curve);
+
             if (!endPoint.IsOnCurve(curve))
                 result.Add(new Line { Start = curve.EndPoint(), End = endPoint });
-            return new PolyCurve
-            {
-                Curves = result
-            };
+
+            return new PolyCurve { Curves = result };
         }
         
         /***************************************************/
@@ -113,20 +97,19 @@ namespace BH.Engine.Geometry
                 return curve;
             }
             List<Point> result = new List<Point>();
+
             if(curve.ControlPoints[0]!=startPoint)
                 result.Add(startPoint);
-            foreach(Point a in curve.ControlPoints)
-            {
+
+            foreach (Point a in curve.ControlPoints)
                 result.Add(a);
-            }
+
             if (result[result.Count - 1] != endPoint)
                 result.Add(endPoint);
-            return new Polyline
-            {
-                ControlPoints = result
-            };
+
+            return new Polyline { ControlPoints = result };
         }
-        
+
         /***************************************************/
 
         private static PolyCurve ExtendTangent(this PolyCurve curve, Point startPoint, Point endPoint)
@@ -137,17 +120,17 @@ namespace BH.Engine.Geometry
                 return curve;
             }
             List<ICurve> result = new List<ICurve>();
+
             if (curve.Curves[0].IStartPoint() != startPoint)
                 result.Add(new Line { Start = startPoint, End = curve.Curves[0].IStartPoint() });
+
             foreach (ICurve a in curve.Curves)
                 result.Add(a);
-            if (result[result.Count - 1].IEndPoint() != endPoint)
-                result.Add(new Line { Start=result[result.Count - 1].IEndPoint(), End = endPoint });
-            return new PolyCurve
-            {
-                Curves = result
-            };
 
+            if (result[result.Count - 1].IEndPoint() != endPoint)
+                result.Add(new Line { Start = result[result.Count - 1].IEndPoint(), End = endPoint });
+
+            return new PolyCurve { Curves = result };
         }
 
 
@@ -158,8 +141,8 @@ namespace BH.Engine.Geometry
         private static ICurve IExtendTangent(this ICurve curve, Point startPoint, Point endPoint)
         {
             return ExtendTangent(curve as dynamic, startPoint, endPoint);
-
         }
+
         /***************************************************/
 
     }

--- a/Geometry_Engine/Modify/ExtendTangent.cs
+++ b/Geometry_Engine/Modify/ExtendTangent.cs
@@ -1,0 +1,166 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+using BH.oM.Geometry;
+using BH.oM.Geometry.CoordinateSystem;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Modify
+    {
+        /******************************************************************/
+        /*** Those methods were written to work with offset method only ***/
+        /***        They were not tested with anything else!            ***/
+        /******************************************************************/
+
+        /***************************************************/
+        /**** private Methods - Curves                   ****/
+        /***************************************************/
+
+        private static PolyCurve ExtendTangent(this Line curve, Point startPoint, Point endPoint)
+        {
+            List<ICurve> result = new List<ICurve>();
+            //if(curve.ClosestPoint(startPoint)==curve.ClosestPoint(endPoint))
+            //{
+            //    result.Add(new Line { Start = startPoint, End = endPoint });
+            //    return new PolyCurve
+            //    {
+            //        Curves=result
+            //    };
+            //}
+            //if(!startPoint.IsOnCurve(curve))
+            //    result.Add(new Line { Start = startPoint, End = curve.Start });
+            //result.Add(curve);
+            //if(!endPoint.IsOnCurve(curve))
+            //    result.Add(new Line { Start = curve.End, End = endPoint});
+            result.Add(curve.Extend(startPoint, endPoint));
+            return new PolyCurve
+            {
+                Curves = result
+            }
+            ;
+        }
+
+        /***************************************************/
+
+        private static PolyCurve ExtendTangent(this Arc curve, Point startPoint, Point endPoint)
+        {
+            List<ICurve> result = new List<ICurve>();
+            if(!startPoint.IsOnCurve(curve))
+                result.Add(new Line { Start = startPoint, End = curve.StartPoint() });
+            result.Add(curve);
+            if (!endPoint.IsOnCurve(curve))
+                result.Add(new Line { Start = curve.EndPoint(), End = endPoint });
+            return new PolyCurve
+            {
+                Curves = result
+            };
+        }
+        
+        /***************************************************/
+
+        private static Circle ExtendTangent(this Circle curve, Point startPoint, Point endPoint)
+        {
+            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            return curve;
+        }
+        
+        /***************************************************/
+
+        private static Ellipse ExtendTangent(this Ellipse curve, Point startPoint, Point endPoint)
+        {
+            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            return curve;
+        }
+        
+        /***************************************************/
+
+        [NotImplemented]
+        private static NurbsCurve ExtendTangent(this NurbsCurve curve, Point startPoint, Point endPoint)
+        {
+            throw new NotImplementedException();
+        }
+        
+        /***************************************************/
+
+        private static Polyline ExtendTangent(this Polyline curve, Point startPoint, Point endPoint)
+        {
+            if (curve.IsClosed())
+            {
+                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                return curve;
+            }
+            List<Point> result = new List<Point>();
+            if(curve.ControlPoints[0]!=startPoint)
+                result.Add(startPoint);
+            foreach(Point a in curve.ControlPoints)
+            {
+                result.Add(a);
+            }
+            if (result[result.Count - 1] != endPoint)
+                result.Add(endPoint);
+            return new Polyline
+            {
+                ControlPoints = result
+            };
+        }
+        
+        /***************************************************/
+
+        private static PolyCurve ExtendTangent(this PolyCurve curve, Point startPoint, Point endPoint)
+        {
+            if (curve.IsClosed())
+            {
+                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                return curve;
+            }
+            List<ICurve> result = new List<ICurve>();
+            if (curve.Curves[0].IStartPoint() != startPoint)
+                result.Add(new Line { Start = startPoint, End = curve.Curves[0].IStartPoint() });
+            foreach (ICurve a in curve.Curves)
+                result.Add(a);
+            if (result[result.Count - 1].IEndPoint() != endPoint)
+                result.Add(new Line { Start=result[result.Count - 1].IEndPoint(), End = endPoint });
+            return new PolyCurve
+            {
+                Curves = result
+            };
+
+        }
+
+
+        /***************************************************/
+        /**** private Methods - Interfaces               ****/
+        /***************************************************/
+
+        private static ICurve IExtendTangent(this ICurve curve, Point startPoint, Point endPoint)
+        {
+            return ExtendTangent(curve as dynamic, startPoint, endPoint);
+
+        }
+        /***************************************************/
+
+    }
+}

--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -33,11 +33,18 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
+        public static Line Offset(this Line curve, double offset, Vector normal)
+        {
+            return curve.Translate(normal.CrossProduct(curve.Start - curve.End).Normalise() * offset);
+        }
+
+        /***************************************************/
+
         public static Arc Offset(this Arc curve, double offset, Vector normal)
         {
             if (!curve.IsPlanar())
             {
-                BH.Engine.Reflection.Compute.RecordError("Offset works only on planar curves");
+                Reflection.Compute.RecordError("Offset works only on planar curves");
                 return null;
             }
 

--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -1,0 +1,572 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods - Curves                   ****/
+        /***************************************************/
+
+        public static Arc Offset(this Arc curve, double offset, Vector normal)
+        {
+            if (!curve.IsPlanar())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset works only on planar curves");
+                return null;
+            }
+
+            if (offset == 0)
+                return curve.Clone();
+
+            double radius = curve.Radius;
+            Arc result = curve.Clone();
+
+            if (normal.DotProduct(curve.Normal()) > 0)
+                radius += offset;
+            else
+                radius -= offset;
+
+            if (radius > 0)
+            {
+                result.Radius = radius;
+                return result;
+            }
+            else
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset value is greater than arc radius");
+                return null;
+            }
+        }
+
+        /***************************************************/
+
+        public static Circle Offset(this Circle curve, double offset, Vector normal)
+        {
+            if (offset == 0)
+                return curve.Clone();
+
+            double radius = curve.Radius;
+            Circle result = curve.Clone();
+
+            if (normal.DotProduct(curve.Normal()) > 0)
+                radius += offset;
+            else
+                radius -= offset;
+
+            if (radius > 0)
+            {
+                result.Radius = radius;
+                return result;
+            }
+            else
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset value is greater than circle radius");
+                return null;
+            }
+
+        }
+
+        /***************************************************/
+
+        public static Polyline Offset(this Polyline curve, double offset, Vector normal = null, double tolerance = Tolerance.Distance)
+        {
+            if (!curve.IsPlanar())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset works only on planar curves");
+                return null;
+            }
+            Boolean isClosed = curve.IsClosed(tolerance);
+            if (normal == null)
+                if (!isClosed)
+                    BH.Engine.Reflection.Compute.RecordError("Normal is missing. Normal vector is not needed only for closed curves");
+                else
+                    normal = curve.Normal();
+
+            if (offset == 0)
+                return curve.Clone();
+
+            List<Point> cPts = new List<Point>(curve.ControlPoints);
+            List<Point> tmp = new List<Point>(curve.ControlPoints);
+
+            if (!isClosed)
+            {
+                for (int i = 0; i < cPts.Count - 1; i++) //moving every vertex perpendicularly to each of it's edgses. At this point only direction of move is good.
+                {
+                    Vector trans = (cPts[i + 1] - cPts[i]).CrossProduct(normal);
+                    trans = trans.Normalise() * offset;
+                    tmp[i] += trans;
+                    tmp[i + 1] += trans;
+                }
+
+                for (int i = 1; i < cPts.Count - 1; i++) //adjusting move distance
+                {
+                    Vector trans = (tmp[i] - cPts[i]);
+                    trans = trans.Normalise() * Math.Abs(offset) / Math.Sin(Math.Abs((cPts[i] - cPts[i - 1]).Angle(cPts[i] - cPts[i + 1])) / 2);
+                    tmp[i] = cPts[i] + trans;
+                }
+                //return new Polyline { ControlPoints = tmp };
+            }
+            else
+            {
+                cPts.RemoveAt(cPts.Count - 1);
+                tmp.RemoveAt(tmp.Count - 1);
+                for (int i = 0; i < cPts.Count; i++) //moving every vertex perpendicularly to each of it's edgses. At this point only direction of move is good.
+                {
+                    Vector trans = (cPts[(i + 1) % cPts.Count] - cPts[i]).CrossProduct(normal);
+                    trans = trans.Normalise() * offset;
+                    tmp[i] += trans;
+                    tmp[(i + 1) % cPts.Count] += trans;
+                }
+
+                for (int i = 0; i < cPts.Count; i++)  // adjusting move distance
+                {
+                    if (!(Math.Abs(Math.Sin((cPts[i] - cPts[(i + cPts.Count - 1) % cPts.Count]).Angle(cPts[i] - cPts[(i + 1) % cPts.Count]))) < Tolerance.Angle))
+                    {
+                        Vector trans = (tmp[i] - cPts[i]);
+                        trans = trans.Normalise() * Math.Abs(offset) / Math.Sin(Math.Abs((cPts[i] - cPts[(i + cPts.Count - 1) % cPts.Count]).Angle(cPts[i] - cPts[(i + 1) % cPts.Count])) / 2);
+                        tmp[i] = cPts[i] + trans;
+                    }
+                }
+                tmp.Add(tmp[0]);
+            }
+            Polyline result = new Polyline { ControlPoints = tmp };
+            List<Line> Lines = result.SubParts();
+            if (isClosed)
+                tmp.RemoveAt(tmp.Count - 1);
+            int counter = 0;
+            for (int i = 0; i < Lines.Count; i++)
+            {
+                if (Lines[i].PointAtParameter(0.5).Distance(curve) + tolerance < Math.Abs(offset) &&
+                   (Lines[i].Start.Distance(curve) + tolerance < Math.Abs(offset) ||
+                    Lines[i].End.Distance(curve) + tolerance < Math.Abs(offset)))
+                {
+                    Line line1 = new Line { Start = tmp[i], End = tmp[(i + tmp.Count - 1) % tmp.Count], Infinite = true };
+                    Line line2 = new Line { Start = tmp[(i + 1) % tmp.Count], End = tmp[(i + 2) % tmp.Count], Infinite = true };
+                    if(!(line1.LineIntersection(line2) == null))
+                        tmp[i] = line1.LineIntersection(line2);
+                    tmp.RemoveAt((i + 1) % tmp.Count);
+                    if(tmp.Count == 0)
+                    {
+                        Reflection.Compute.RecordError("Method failed to produce corretct offset. Null has been returned.");
+                        return null;
+                    }
+                    tmp.Add(tmp[0]);
+                    Lines = result.SubParts();
+                    tmp.RemoveAt(tmp.Count - 1);
+                    i--;
+                    counter++;
+                }
+            }
+            if (isClosed)
+                tmp.Add(tmp[0]);
+            if (tmp.Count < 3 || (isClosed && tmp.Count < 4))
+            {
+                Reflection.Compute.RecordError("Method failed to produce corretct offset. Null has been returned.");
+                return null;
+            }
+            if (counter > 0)
+                Reflection.Compute.RecordWarning("Reduced " + counter as string + " lines. Offset may be wrong. Please inspect the results.");
+            if (result.IsSelfIntersecting(tolerance) || result.LineIntersections(curve).Count != 0)
+                Reflection.Compute.RecordWarning("Intersections occured. Offset may be wrong. Please inspect the results.");
+            return result;
+        }
+    
+
+        /***************************************************/
+
+        public static PolyCurve Offset(this PolyCurve curve, double offset, Vector normal = null, bool extend = false, double tolerance = Tolerance.Distance)
+        {
+            if (!curve.IsPlanar(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset works only on planar curves");
+                return null;
+            }
+
+            if (curve.IsSelfIntersecting())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset works only on non-self intersecting curves");
+                return null;
+            }
+
+            if (offset == 0)
+                return curve.Clone();
+
+            List<ICurve> resultList = new List<ICurve>();
+            List<ICurve> ICrvs = new List<ICurve>(curve.Curves);
+            PolyCurve result = new PolyCurve();
+
+            if (ICrvs[0] is Circle)
+            {
+                result.Curves.Add(Offset((Circle)ICrvs[0], offset, normal));
+                return result;
+            }
+
+            //First - offseting each individual element
+
+            List<ICurve> crvs = new List<ICurve>();
+            foreach (ICurve crv in curve.Curves)
+            {
+                if (crv is Arc)
+                {
+                    Arc arc = new Arc();
+                    arc = ((Arc)crv).Clone();
+                    crvs.Add(arc.Offset(offset, normal));
+                }
+                else
+                {
+                    Line ln = new Line();
+                    ln = ((Line)crv).Clone();
+                    Vector mv = new Vector();
+                    mv = ln.TangentAtPoint(ln.Start).CrossProduct(normal);
+                    double mvScale = 0;
+                    mvScale = offset / mv.Length();
+                    mv *= mvScale;
+                    ln.Start = ln.Start + mv;
+                    ln.End += mv;
+                    crvs.Add(ln);
+                }
+            }
+
+            // Looking for an index of a longest curve - most offsets maintain this longest curve all the time
+            int lngstIndex = 0;
+            for (int i = 1; i < crvs.Count; i++)
+            {
+                if (crvs[i].ILength() > crvs[lngstIndex].ILength())
+                {
+                    lngstIndex = i;
+                }
+            }
+
+            // Searching for intersections - if 2 curves intersect, trim them to the point of intersection
+            Line tmpLn = null;
+            bool omitWarning = false;
+            // intersecting lines
+            for (int i = 0; i < crvs.Count - 1; i++)
+            {
+                if (crvs[i] is Line && crvs[(i + 1) % crvs.Count] is Line)
+                {
+                    tmpLn = Create.Line(crvs[i].IStartPoint(), -crvs[i].IStartDir() / crvs[i].IStartDir().Length() * Math.Abs(offset * offset * 5));
+                    tmpLn.Infinite = false;
+                    if (!((Line)crvs[i]).LineIntersection((Line)crvs[(i + 1) % crvs.Count], true).IsOnCurve(tmpLn))
+                    {
+                        crvs[i]=crvs[i].IExtend(crvs[i].IStartPoint(), ((Line)crvs[i]).LineIntersection((Line)crvs[(i + 1) % crvs.Count], true));
+                        crvs[i + 1] = crvs[i + 1].IExtend(crvs[i].IEndPoint(), crvs[i + 1].IEndPoint());
+                    }
+                    else
+                    {
+                        crvs[i] = crvs[i].IExtend(((Line)crvs[i]).LineIntersection((Line)crvs[(i + 1) % crvs.Count], true), crvs[i].IEndPoint());
+                        crvs[i + 1] = crvs[i + 1].IExtend(crvs[i + 1].IStartPoint(), ((Line)crvs[i]).LineIntersection((Line)crvs[(i + 1) % crvs.Count], true));
+                        crvs.Reverse(i, 2);
+                        omitWarning = true;
+                    }
+                }
+            }
+
+            List<Point> Pts = new List<Point>();
+            List<Point[]> intersections = new List<Point[]>();
+
+            for (int i = 0; i < crvs.Count; i++)
+            {
+                intersections.Add(new Point[2]);
+                intersections[i][0] = crvs[i].IStartPoint();
+                intersections[i][1] = crvs[i].IEndPoint();
+            }
+            //intersecting arcs with arcs and lines
+
+            for (int i = lngstIndex; i <lngstIndex+ crvs.Count; i++)
+            {
+                for (int j = i + 1; j < i + Math.Min(crvs.Count / 2+2, crvs.Count-1); j++)
+                {
+
+                    if ((Pts = crvs[i % crvs.Count].ICurveIntersections(crvs[j % crvs.Count])).Count > 0)
+                    {
+                        if (Pts.Count == 2)
+                        {
+                            if (Pts[0].Distance(crvs[i % crvs.Count].IStartPoint()) < Pts[1].Distance(crvs[i % crvs.Count].IStartPoint()))
+                            {
+                                intersections[i%crvs.Count][0] = Pts[0];
+                                intersections[i % crvs.Count][1] = Pts[1];
+                                intersections[j % crvs.Count][0] = Pts[1];
+                                intersections[j % crvs.Count][1] = Pts[0];
+                            }
+                            else
+                            {
+                                intersections[i % crvs.Count][0] = Pts[1];
+                                intersections[i % crvs.Count][1] = Pts[0];
+                                intersections[j % crvs.Count][0] = Pts[0];
+                                intersections[j % crvs.Count][1] = Pts[1];
+                            }
+
+                            if (curve.IsClosed())
+                            {
+                                //this will happen only in making a curve smaller - if 2 curves intersect creating a closed Pcurve, we can return it
+                                resultList.Add(crvs[i % crvs.Count].ITrim(intersections[i % crvs.Count][0], intersections[i % crvs.Count][1]));
+                                resultList.Add(crvs[j % crvs.Count].ITrim(intersections[j % crvs.Count][0], intersections[j % crvs.Count][1]));
+                                return new PolyCurve { Curves = resultList };
+                            }
+                            break;
+                        }
+                        else
+                        {
+                            if (i % crvs.Count == lngstIndex)
+                            {
+                                if (intersections[i % crvs.Count][0].Distance(Pts[0]) > intersections[i % crvs.Count][1].Distance(Pts[0])&&intersections[i % crvs.Count][0].Distance(crvs[i % crvs.Count].IStartPoint())==0)
+                                    intersections[i % crvs.Count][1] = Pts[0];
+                                else
+                                    intersections[i % crvs.Count][0] = Pts[0];
+
+                                if (intersections[j % crvs.Count][1].Distance(Pts[0]) > 0)
+                                    intersections[j % crvs.Count][0] = Pts[0];
+                            }
+                            else
+                            {
+                                if (intersections[i % crvs.Count][0].Distance(Pts[0]) > 0)
+                                    intersections[i % crvs.Count][1] = Pts[0];
+
+                                if (intersections[j % crvs.Count][1].Distance(Pts[0]) > 0)
+                                    intersections[j % crvs.Count][0] = Pts[0];
+                            }
+                        }
+
+                        if (j % crvs.Count == lngstIndex)
+                            break;
+                    }
+                }
+
+            }
+
+            for (int i = 0; i < crvs.Count; i++)
+            {
+                if (intersections[i][0].Distance(crvs[i].IStartPoint()) < intersections[i][1].Distance(crvs[i].IStartPoint()))
+                    crvs[i] = crvs[i].ITrim(intersections[i][0], intersections[i][1]);
+            }
+
+            result.Curves = crvs;
+            //if this operation was enough to create a curve matching the last one - only appropriate on closed curves - return the result
+            if (result.IsClosed()&&curve.IsClosed())
+                return result;
+
+            resultList.Add(crvs[lngstIndex]);
+            Point lastPoint = resultList[resultList.Count - 1].IEndPoint();
+            bool changed = false;
+            List<ICurve> tmp = new List<ICurve>();
+            List<Point> tmpPts = new List<Point>();
+
+            //if the original curve is open, it is better to start offseting from the beginning, rather than from longest curve
+            if(!curve.IsClosed())
+            {
+                resultList.Clear();
+                lngstIndex = 0;
+                resultList.Add(crvs[0]);
+            }
+
+            int lastIndexUsed = lngstIndex;
+            bool flip = false;
+
+            //this loop finds us the proper offset - trims/extends the curves to create one joint polycurve
+            for (int i = lngstIndex + 1; i < lngstIndex + crvs.Count; i++)
+            {
+                changed = false;
+                flip = false;
+                Line ln1 = Create.Line(resultList[resultList.Count - 1].IEndPoint(), resultList[resultList.Count - 1].IEndDir() / resultList[resultList.Count - 1].IEndDir().Length() * Math.Max(Math.Abs(offset * offset * 3), 5));
+                ln1.Infinite = false;
+                Line ln2 = Create.Line(crvs[i % crvs.Count].IStartPoint(), -crvs[i % crvs.Count].IStartDir() / crvs[i % crvs.Count].IStartDir().Length() * Math.Max(Math.Abs(offset * offset * 3), 5));
+                ln2.Infinite = false;
+
+                if (crvs[i % crvs.Count] is Line && resultList[resultList.Count - 1] is Arc)
+                {
+                    if (((Arc)resultList[resultList.Count - 1]).Centre().Distance((Line)crvs[i % crvs.Count]) < ((Arc)resultList[resultList.Count - 1]).Radius)
+                    {
+                        flip = true;
+                        ln2.Infinite = true;
+                    }
+                }
+
+                Pts.Clear();
+
+                if ((tmpPts = crvs[i % crvs.Count].ICurveIntersections(resultList[resultList.Count - 1])).Count > 0)
+                {
+                    foreach (Point point in tmpPts)
+                        Pts.Add(point);
+                    changed = true;
+                }
+                else
+                {
+                    if ((tmpPts = ln1.ICurveIntersections(crvs[i % crvs.Count])).Count > 0)
+                    {
+                        foreach (Point point in tmpPts)
+                            Pts.Add(point);
+                        changed = true;
+                    }
+
+                    if ((tmpPts = ln1.ICurveIntersections(ln2)).Count > 0)
+                    {
+                        foreach (Point point in tmpPts)
+                            Pts.Add(point);
+                        changed = true;
+                    }
+
+                    if ((tmpPts = ln2.ICurveIntersections(resultList[resultList.Count - 1])).Count > 0)
+                    {
+                        foreach (Point point in tmpPts)
+                            Pts.Add(point);
+                        changed = true;
+                    }
+                }
+
+                if (changed)
+                {
+                    if (Pts.Count >= 2)
+                    {
+                        for (int a = 0; a < Pts.Count; a++)
+                        {
+                            if ((Pts[a].IDistance(crvs[i % crvs.Count]) + Pts[a].IDistance(resultList[resultList.Count - 1]) <= Pts[0].IDistance(crvs[i % crvs.Count]) + Pts[0].IDistance(resultList[resultList.Count - 1])))
+                                Pts[0] = Pts[a];
+                        }
+                    }
+
+                    int oldResNmbr = resultList.Count - 1;
+                    tmp = resultList[resultList.Count - 1].TrimExtend(resultList[resultList.Count - 1].IStartPoint(), Pts[0], extend);
+                    resultList.RemoveAt(resultList.Count - 1);
+                    foreach (ICurve x in tmp)
+                    {
+                        resultList.Add(x);
+                    }
+                    tmp = crvs[i % crvs.Count].TrimExtend(Pts[0], crvs[i % crvs.Count].IEndPoint(), extend);
+
+                    foreach (ICurve x in tmp)
+                    {
+                        resultList.Add(x);
+                    }
+
+                    if (flip)
+                    {
+                        if (resultList[resultList.Count - 1].IStartPoint().Distance(resultList[oldResNmbr].IEndPoint()) > resultList[resultList.Count - 1].IEndPoint().Distance(resultList[oldResNmbr].IEndPoint()))
+                            resultList[resultList.Count - 1] = resultList[resultList.Count - 1].IFlip();
+                    }
+
+                    lastPoint = resultList[resultList.Count - 1].IEndPoint();
+                    lastIndexUsed = i;
+                }
+                else
+                    omitWarning = true;
+            }
+
+            result.Curves = resultList;
+            //here, we try to close the curve and get rid of "unnecessary" curves - creating self-intersections
+            if (!result.IsClosed() && curve.IsClosed())
+            {
+                if ((lastIndexUsed + 1) % crvs.Count == lngstIndex)
+                {
+                    Line ln1 = null;
+                    Line ln2 = null;
+                    ln1 = Create.Line(resultList[resultList.Count - 1].IEndPoint(), resultList[resultList.Count - 1].IEndDir() / resultList[resultList.Count - 1].IEndDir().Length() * Math.Abs(offset * offset * 5));
+                    ln2 = Create.Line(resultList[0].IStartPoint(), -resultList[0].IStartDir() / resultList[0].IStartDir().Length() * Math.Abs(offset * offset * 5));
+                    Pts.Clear();
+
+                    if ((tmpPts = ln1.ICurveIntersections(resultList[0])).Count > 0)
+                    {
+                        foreach (Point point in tmpPts)
+                            Pts.Add(point);
+                    }
+
+                    if ((tmpPts = ln1.ICurveIntersections(ln2)).Count > 0)
+                    {
+                        foreach (Point point in tmpPts)
+                            Pts.Add(point);
+                    }
+
+                    if ((tmpPts = ln2.ICurveIntersections(resultList[resultList.Count - 1])).Count > 0)
+                    {
+                        foreach (Point point in tmpPts)
+                            Pts.Add(point);
+                    }
+
+                    if (Pts.Count >= 2)
+                    {
+                        for (int a = 0; a < Pts.Count; a++)
+                        {
+                            if ((Pts[a].IDistance(resultList[0]) <= Pts[0].IDistance(resultList[0]) || Pts[a].IDistance(resultList[resultList.Count - 1]) <= Pts[0].IDistance(resultList[resultList.Count - 1])))
+                                Pts[0] = Pts[a];
+                        }
+                    }
+
+                    tmp = resultList[resultList.Count - 1].TrimExtend(resultList[resultList.Count - 1].IStartPoint(), Pts[0], extend);
+                    resultList.RemoveAt(resultList.Count - 1);
+                    foreach (ICurve x in tmp)
+                    {
+                        resultList.Add(x);
+                    }
+
+                    tmp = resultList[0].TrimExtend(Pts[0], resultList[0].IEndPoint(), extend);
+                    if (tmp.Count == 1)
+                        resultList[0] = tmp[0];
+                    else
+                    {
+                        resultList.Add(tmp[0]);
+                        resultList[0] = tmp[1];
+                    }
+                }
+
+                else
+                {
+                    Line ln2 = Create.Line(resultList[0].IStartPoint(), -resultList[0].IStartDir() / resultList[0].IStartDir().Length() * Math.Abs(offset * offset * 3));
+                    ln2.Infinite = false;
+                    for (int i = 0; i < resultList.Count; i++)
+                    {
+                        if ((Pts = ln2.ICurveIntersections(resultList[i])).Count > 0)
+                        {
+                            resultList[i] = resultList[i].ITrim(resultList[i].IStartPoint(), Pts[0]);
+                            for (int j = i + 1; j < resultList.Count; j++)
+                                resultList.RemoveAt(j);
+                            resultList.Add(new Line { Start = Pts[0], End = resultList[0].IStartPoint() });
+                            omitWarning = true;
+                            break;
+                        }
+                    }
+                }
+
+            }
+
+
+            if (!result.IsClosed(tolerance) && curve.IsClosed(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset is incorrect.");
+                return null;
+            }
+
+            if (omitWarning||result.CurveIntersections(curve).Count > 0|| result.IsSelfIntersecting())
+            {
+                BH.Engine.Reflection.Compute.RecordWarning("Offset may be wrong. Please inspect the results.");
+            }
+
+            return result;
+        }
+    }
+}

--- a/Geometry_Engine/Modify/Trim.cs
+++ b/Geometry_Engine/Modify/Trim.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
@@ -31,31 +31,30 @@ namespace BH.Engine.Geometry
 {
     public static partial class Modify
     {
+        /******************************************************************/
+        /*** Those methods were written to work with offset method only ***/
+        /***        They were not tested with anything else!            ***/
+        /******************************************************************/
+
         /***************************************************/
         /**** Private Methods - Curves                  ****/
         /***************************************************/
 
-        private static Line Extend(this Line curve, double start = 0.0, double end = 0.0)
+        private static Line Trim(this Line curve, double start = 0.0, double end = 0.0)
         {
-            Vector dir = curve.Direction();
-            return new Line { Start = curve.Start - dir * start, End = curve.End + dir * end };
+            return curve.Extend(-start, -end);
         }
 
         /***************************************************/
 
-        /*****************************************************************/
-        /*** Next methods were written to work with offset method only ***/
-        /***        They were not tested with anything else!           ***/
-        /*****************************************************************/
-
-        private static Line Extend(this Line curve, Point startPoint, Point endPoint)
+        private static Line Trim(this Line curve, Point startPoint, Point endPoint)
         {
             return new Line { Start = startPoint, End = endPoint };
         }
 
         /***************************************************/
 
-        private static Arc Extend(this Arc curve, Point startPoint, Point endPoint)
+        private static Arc Trim(this Arc curve, Point startPoint, Point endPoint)
         {
             Cartesian coordinateSystem = new Cartesian(curve.CoordinateSystem.Origin,
                 (startPoint - curve.CoordinateSystem.Origin).Normalise(),
@@ -75,40 +74,40 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        private static Circle Extend(this Circle curve, Point startPoint, Point endPoint)
+        private static Circle Trim(this Circle curve, Point startPoint, Point endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            Reflection.Compute.RecordNote("Can't Trim closed models.");
             return curve;
         }
 
         /***************************************************/
 
-        private static Circle Extend(this Circle curve, double startPoint, double endPoint)
+        private static Circle Trim(this Circle curve, double startPoint, double endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            Reflection.Compute.RecordNote("Can't Trim closed models.");
             return curve;
         }
 
         /***************************************************/
 
-        private static Ellipse Extend(this Ellipse curve, Point startPoint, Point endPoint)
+        private static Ellipse Trim(this Ellipse curve, Point startPoint, Point endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            Reflection.Compute.RecordNote("Can't Trim closed models.");
             return curve;
         }
 
         /***************************************************/
 
-        private static Ellipse Extend(this Ellipse curve, double startPoint, double endPoint)
+        private static Ellipse Trim(this Ellipse curve, double startPoint, double endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Extend closed models.");
+            Reflection.Compute.RecordNote("Can't Trim closed models.");
             return curve;
         }
 
         /***************************************************/
 
         [NotImplemented]
-        private static NurbsCurve Extend(this NurbsCurve curve, Point startPoint, Point endPoint)
+        private static NurbsCurve Trim(this NurbsCurve curve, Point startPoint, Point endPoint)
         {
             throw new NotImplementedException();
         }
@@ -116,18 +115,18 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [NotImplemented]
-        private static NurbsCurve Extend(this NurbsCurve curve, double startPoint, double endPoint)
+        private static NurbsCurve Trim(this NurbsCurve curve, double startPoint, double endPoint)
         {
             throw new NotImplementedException();
         }
 
         /***************************************************/
 
-        private static Polyline Extend(this Polyline curve, Point startPoint, Point endPoint)
+        private static Polyline Trim(this Polyline curve, Point startPoint, Point endPoint)
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                Reflection.Compute.RecordNote("Can't Trim closed models.");
                 return curve;
             }
             List<Point> result = new List<Point>();
@@ -142,11 +141,11 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        private static Polyline Extend(this Polyline curve, double start, double end)
+        private static Polyline Trim(this Polyline curve, double start, double end)
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                Reflection.Compute.RecordNote("Can't Trim closed models.");
                 return curve;
             }
             Line first = new Line { Start = curve.ControlPoints[0], End = curve.ControlPoints[1] };
@@ -165,17 +164,17 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        private static PolyCurve Extend(this PolyCurve curve, Point startPoint, Point endPoint)
+        private static PolyCurve Trim(this PolyCurve curve, Point startPoint, Point endPoint)
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                Reflection.Compute.RecordNote("Can't Trim closed models.");
                 return curve;
             }
             List<ICurve> result = new List<ICurve>();
             result = curve.Curves;
-            result[0] = result[0].IExtend(startPoint, result[0].IEndPoint());
-            result[result.Count - 1] = result[result.Count - 1].IExtend(result[result.Count - 1].IStartPoint(), endPoint);
+            result[0] = result[0].ITrim(startPoint, result[0].IEndPoint());
+            result[result.Count - 1] = result[result.Count - 1].ITrim(result[result.Count - 1].IStartPoint(), endPoint);
             return new PolyCurve
             {
                 Curves = result
@@ -185,17 +184,17 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        private static PolyCurve Extend(this PolyCurve curve, double start, double end)
+        private static PolyCurve Trim(this PolyCurve curve, double start, double end)
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Extend closed models.");
+                Reflection.Compute.RecordNote("Can't Trim closed models.");
                 return curve;
             }
             List<ICurve> result = new List<ICurve>();
             result = curve.Curves;
-            result[0] = result[0].IExtend(start, 0);
-            result[result.Count - 1] = result[result.Count - 1].IExtend(0, end);
+            result[0] = result[0].ITrim(start, 0);
+            result[result.Count - 1] = result[result.Count - 1].ITrim(0, end);
             return new PolyCurve
             {
                 Curves = result
@@ -205,24 +204,22 @@ namespace BH.Engine.Geometry
 
 
         /***************************************************/
-        /**** Private Methods - Interfaces              ****/
+        /**** private Methods - Interfaces               ****/
         /***************************************************/
 
-        private static ICurve IExtend(this ICurve curve, Point startPoint, Point endPoint, bool isExtend = true)
+        private static ICurve ITrim(this ICurve curve, Point startPoint, Point endPoint)
         {
-            if (isExtend)
-                return Extend(curve as dynamic, startPoint, endPoint);
-            else
-                return ExtendTangent(curve as dynamic, startPoint, endPoint);
+            return Trim(curve as dynamic, startPoint, endPoint);
         }
 
         /***************************************************/
 
-        private static ICurve IExtend(this ICurve curve, double start, double end)
+        private static ICurve ITrim(this ICurve curve, double start, double end)
         {
-            return Extend(curve as dynamic, start, end);
+            return Trim(curve as dynamic, start, end);
         }
-
+     
         /***************************************************/
+
     }
 }

--- a/Geometry_Engine/Modify/Trim.cs
+++ b/Geometry_Engine/Modify/Trim.cs
@@ -76,7 +76,7 @@ namespace BH.Engine.Geometry
 
         private static Circle Trim(this Circle curve, Point startPoint, Point endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Trim closed models.");
+            Reflection.Compute.RecordNote("Can't Trim closed curves.");
             return curve;
         }
 
@@ -84,7 +84,7 @@ namespace BH.Engine.Geometry
 
         private static Circle Trim(this Circle curve, double startPoint, double endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Trim closed models.");
+            Reflection.Compute.RecordNote("Can't Trim closed curves.");
             return curve;
         }
 
@@ -92,7 +92,7 @@ namespace BH.Engine.Geometry
 
         private static Ellipse Trim(this Ellipse curve, Point startPoint, Point endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Trim closed models.");
+            Reflection.Compute.RecordNote("Can't Trim closed curves.");
             return curve;
         }
 
@@ -100,7 +100,7 @@ namespace BH.Engine.Geometry
 
         private static Ellipse Trim(this Ellipse curve, double startPoint, double endPoint)
         {
-            Reflection.Compute.RecordNote("Can't Trim closed models.");
+            Reflection.Compute.RecordNote("Can't Trim closed curves.");
             return curve;
         }
 
@@ -126,17 +126,14 @@ namespace BH.Engine.Geometry
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Trim closed models.");
+                Reflection.Compute.RecordNote("Can't Trim closed curves.");
                 return curve;
             }
             List<Point> result = new List<Point>();
             result = curve.ControlPoints;
             result[0] = startPoint;
             result[result.Count - 1] = endPoint;
-            return new Polyline
-            {
-                ControlPoints = result
-            };
+            return new Polyline { ControlPoints = result };
         }
 
         /***************************************************/
@@ -145,7 +142,7 @@ namespace BH.Engine.Geometry
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Trim closed models.");
+                Reflection.Compute.RecordNote("Can't Trim closed curves.");
                 return curve;
             }
             Line first = new Line { Start = curve.ControlPoints[0], End = curve.ControlPoints[1] };
@@ -156,10 +153,7 @@ namespace BH.Engine.Geometry
             result = curve.ControlPoints;
             result[0] = first.Start;
             result[result.Count - 1] = last.End;
-            return new Polyline
-            {
-                ControlPoints = result
-            };
+            return new Polyline { ControlPoints = result };
         }
 
         /***************************************************/
@@ -168,18 +162,14 @@ namespace BH.Engine.Geometry
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Trim closed models.");
+                Reflection.Compute.RecordNote("Can't Trim closed curves.");
                 return curve;
             }
             List<ICurve> result = new List<ICurve>();
             result = curve.Curves;
             result[0] = result[0].ITrim(startPoint, result[0].IEndPoint());
             result[result.Count - 1] = result[result.Count - 1].ITrim(result[result.Count - 1].IStartPoint(), endPoint);
-            return new PolyCurve
-            {
-                Curves = result
-            };
-
+            return new PolyCurve { Curves = result };
         }
 
         /***************************************************/
@@ -188,18 +178,14 @@ namespace BH.Engine.Geometry
         {
             if (curve.IsClosed())
             {
-                Reflection.Compute.RecordNote("Can't Trim closed models.");
+                Reflection.Compute.RecordNote("Can't Trim closed curves.");
                 return curve;
             }
             List<ICurve> result = new List<ICurve>();
             result = curve.Curves;
             result[0] = result[0].ITrim(start, 0);
             result[result.Count - 1] = result[result.Count - 1].ITrim(0, end);
-            return new PolyCurve
-            {
-                Curves = result
-            };
-
+            return new PolyCurve { Curves = result };
         }
 
 
@@ -220,6 +206,5 @@ namespace BH.Engine.Geometry
         }
      
         /***************************************************/
-
     }
 }

--- a/Geometry_Engine/Modify/TrimExtend.cs
+++ b/Geometry_Engine/Modify/TrimExtend.cs
@@ -41,32 +41,32 @@ namespace BH.Engine.Geometry
         /**** Private Methods - Curves                  ****/
         /***************************************************/
 
-        private static List<ICurve> TrimExtend(this ICurve curve,Point startPoint, Point endPoint,bool isExtend)
+        private static List<ICurve> TrimExtend(this ICurve curve, Point startPoint, Point endPoint, bool isExtend)
         {
             List<ICurve> result = new List<ICurve>();
             bool sP = false;
             bool eP = false;
             if(startPoint.IsOnCurve(curve))
             {
-                curve=curve.ITrim(startPoint, curve.IEndPoint());
+                curve = curve.ITrim(startPoint, curve.IEndPoint());
                 sP = true;
             }
             if(endPoint.IsOnCurve(curve))
             {
-                curve=curve.ITrim(curve.IStartPoint(), endPoint);
+                curve = curve.ITrim(curve.IStartPoint(), endPoint);
                 eP = true;
             }
-            if(sP&&eP)
+            if(sP && eP)
             {
                 result.Add(curve);
                 return result;
             }
-            if(sP&&!eP)
+            if(sP && !eP)
             {
                 if (isExtend)
                     result.Add(curve.IExtend(curve.IStartPoint(), endPoint, isExtend));
                 else
-                    result =((PolyCurve) curve.IExtend(curve.IStartPoint(), endPoint, isExtend)).Curves;
+                    result = ((PolyCurve) curve.IExtend(curve.IStartPoint(), endPoint, isExtend)).Curves;
                 return result;
             }
             if (!sP && !eP)
@@ -87,5 +87,7 @@ namespace BH.Engine.Geometry
             }
             return result;
         }
+
+        /***************************************************/
     }
 }

--- a/Geometry_Engine/Modify/TrimExtend.cs
+++ b/Geometry_Engine/Modify/TrimExtend.cs
@@ -1,0 +1,91 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.oM.Geometry;
+using BH.oM.Geometry.CoordinateSystem;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Modify
+    {
+        /******************************************************************/
+        /*** Those methods were written to work with offset method only ***/
+        /***        They were not tested with anything else!            ***/
+        /******************************************************************/
+
+        /***************************************************/
+        /**** Private Methods - Curves                  ****/
+        /***************************************************/
+
+        private static List<ICurve> TrimExtend(this ICurve curve,Point startPoint, Point endPoint,bool isExtend)
+        {
+            List<ICurve> result = new List<ICurve>();
+            bool sP = false;
+            bool eP = false;
+            if(startPoint.IsOnCurve(curve))
+            {
+                curve=curve.ITrim(startPoint, curve.IEndPoint());
+                sP = true;
+            }
+            if(endPoint.IsOnCurve(curve))
+            {
+                curve=curve.ITrim(curve.IStartPoint(), endPoint);
+                eP = true;
+            }
+            if(sP&&eP)
+            {
+                result.Add(curve);
+                return result;
+            }
+            if(sP&&!eP)
+            {
+                if (isExtend)
+                    result.Add(curve.IExtend(curve.IStartPoint(), endPoint, isExtend));
+                else
+                    result =((PolyCurve) curve.IExtend(curve.IStartPoint(), endPoint, isExtend)).Curves;
+                return result;
+            }
+            if (!sP && !eP)
+            {
+                if (isExtend)
+                    result.Add(curve.IExtend(startPoint, endPoint, isExtend));
+                else
+                    result = ((PolyCurve)curve.IExtend(startPoint, endPoint, isExtend)).Curves;
+                return result;
+            }
+            if (!sP && eP)
+            {
+                if (isExtend)
+                    result.Add(curve.IExtend(startPoint, curve.IEndPoint(), isExtend));
+                else
+                    result = ((PolyCurve)curve.IExtend(startPoint, curve.IEndPoint(), isExtend)).Curves;
+                return result;
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
Closes #1066 

Adding offset methods. `Offset(Arc)`, `Offset(Line)`, `Offset(Circle)` and `Offset(Polyline)` are mine. `Offset(Polycurve)` was made by @KonradStolarski.
Offset is hard to implement because of it's ambiguous nature. In more complicated cases there is no one proper way how it should work. Our methods work well on simple forms and polygons but get messy in more complicated shapes. In my opinion for now it is enough for most of engineering applications.
To avoid mistakes we added warnings about occurring unwanted intersections and changes in shapes of curves. 
<!-- Add short description of what has been fixed -->


### Test files
<s>[Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1066%2DOffset) is test file of offset method. In this case default random tests at the top of the file are less important. They are working for the small values of offset only. </s> [Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FModify) is updated test. In the first section are generic test for simple curves. In the second there are some tests of complex curves. In the third there are generic tests of Polyline and PolyCurve which in this case are kinda useless. I invite to take a look at edge cases and make some tests of your own to see how this version of offset works and suggest any changes.


### Changelog
- `Modify.Offset()` Modify methods added in the `Geometry_Engine` for `Line`, `Arc`, `Circle`, `Polyline` and `PolyCurve` classes
- `Modify.Extend()` private Modify methods added in the `Geometry_Engine` for `Line`, `Arc`, `Circle`, `Ellipse`, `NurbsCurve`, `Polyline`, `PolyCurve` and `ICurve` classes
- `Modify.ExtendTangent()` private Modify methods added in the `Geometry_Engine` for `Line`, `Arc`, `Circle`, `Ellipse`, `NurbsCurve`, `Polyline`, `PolyCurve` and `ICurve` classes
- `Modify.Trim()` private Modify methods added in the `Geometry_Engine` for `Line`, `Arc`, `Circle`, `Ellipse`, `NurbsCurve`, `Polyline`, `PolyCurve` and `ICurve` classes
- `Modify.TrimExtend()` private Modify method added in the `Geometry_Engine` for `List<ICurve>` class



### Additional comments
<!-- As required -->
Methods  `Modify.Extend()`,  `Modify.ExtendTangent()`,  `Modify.Trim()` and  `Modify.TrimExtend()` are all made by Konrad and are used only in `Modify.Offset()`. They haven't been properly tested as they are not a matter of this issue. It'd take a solid amount of time to step into Konrad's shoes and match them with the rest of the code. I think it'll be better to push Offset now with rest of methods marked as private and labelled with appropriate comment. Then raise another issue about finishing them properly.

#### TL;DR
Offset is much more complicated than it seems to be 😉 