### PR TITLE
Add embodied carbon to material fragments

### DIFF
--- a/Structure_Engine/Create/Bar.cs
+++ b/Structure_Engine/Create/Bar.cs
@@ -54,7 +54,8 @@ namespace BH.Engine.Structure
                 SectionProperty = property,
                 Release = release == null ? BarReleaseFixFix() : release,
                 FEAType = feaType,
-                OrientationAngle = orientationAngle
+                OrientationAngle = orientationAngle,
+                EmbodiedCarbon = property.Material.EmbodiedCarbon * property.Area * startNode.Position.Distance(endNode.Position),
             };
         }
 
@@ -76,7 +77,7 @@ namespace BH.Engine.Structure
 
                 if (Math.Abs(1 - dot) < oM.Geometry.Tolerance.Angle)
                 {
-                    Reflection.Compute.RecordError("The normal is parallell to the centreline of the bar");
+                    Reflection.Compute.RecordError("The normal is parallel to the centreline of the bar");
                     return null;
                 }
                 else if (Math.Abs(dot) > oM.Geometry.Tolerance.Angle)

--- a/Structure_Engine/Create/Bar.cs
+++ b/Structure_Engine/Create/Bar.cs
@@ -54,8 +54,7 @@ namespace BH.Engine.Structure
                 SectionProperty = property,
                 Release = release == null ? BarReleaseFixFix() : release,
                 FEAType = feaType,
-                OrientationAngle = orientationAngle,
-                EmbodiedCarbon = property.Material.EmbodiedCarbon * property.Area * startNode.Position.Distance(endNode.Position),
+                OrientationAngle = orientationAngle
             };
         }
 
@@ -77,7 +76,7 @@ namespace BH.Engine.Structure
 
                 if (Math.Abs(1 - dot) < oM.Geometry.Tolerance.Angle)
                 {
-                    Reflection.Compute.RecordError("The normal is parallel to the centreline of the bar");
+                    Reflection.Compute.RecordError("The normal is parallell to the centreline of the bar");
                     return null;
                 }
                 else if (Math.Abs(dot) > oM.Geometry.Tolerance.Angle)

--- a/Structure_Engine/Create/MaterialFragment.cs
+++ b/Structure_Engine/Create/MaterialFragment.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Structure
         [Input("dampingRatio", "Dynamic damping ratio of the material. Will be stored on the material fragment")]
         [Input("embodiedCarbon", "Embodied carbon for the material. Will be stored on the material fragment")]
         [Output("Material", "The created material with a aluminium fragment")]
-        public static Aluminium Aluminium(string name, double E = 70000000000, double v = 0.34, double tC = 0.000023, double density = 2710, double dampingRatio = 0, double embodiedCarbon = 100)
+        public static Aluminium Aluminium(string name, double E = 70000000000, double v = 0.34, double tC = 0.000023, double density = 2710, double dampingRatio = 0, double embodiedCarbon = 7.9)
         {
             return new Aluminium()
             {
@@ -71,7 +71,7 @@ namespace BH.Engine.Structure
         [Input("cylinderStrength", "Cylinder strength of the concrete material. Given in [Pa] or [N/m].Will be stored on the material fragment")]
         [Input("embodiedCarbon", "Embodied carbon for the material. Will be stored on the material fragment")]
         [Output("Material", "The created material with a concrete fragment")]
-        public static Concrete Concrete(string name, double E = 33000000000, double v = 0.2, double tC = 0.00001, double density = 2550, double dampingRatio = 0, double cubeStrength = 0, double cylinderStrength = 0, double embodiedCarbon = 200)
+        public static Concrete Concrete(string name, double E = 33000000000, double v = 0.2, double tC = 0.00001, double density = 2550, double dampingRatio = 0, double cubeStrength = 0, double cylinderStrength = 0, double embodiedCarbon = 0.12)
         {
             return new Concrete()
             {
@@ -99,7 +99,7 @@ namespace BH.Engine.Structure
         [Input("ultimateStress", "Stress level at break for the material. Given in [Pa] or [N/m]. Will be stored on the material fragment")]
         [Input("embodiedCarbon", "Embodied carbon for the material. Will be stored on the material fragment")]
         [Output("Material", "The created material with a steel fragment")]
-        public static Steel Steel(string name, double E = 210000000000, double v = 0.3, double tC = 0.000012, double density = 7850, double dampingRatio = 0, double yieldStress = 0, double ultimateStress = 0, double embodiedCarbon = 300)
+        public static Steel Steel(string name, double E = 210000000000, double v = 0.3, double tC = 0.000012, double density = 7850, double dampingRatio = 0, double yieldStress = 0, double ultimateStress = 0, double embodiedCarbon = 1.3)
         {
             return new Steel()
             {
@@ -126,7 +126,7 @@ namespace BH.Engine.Structure
         [Input("dampingRatio", "Dynamic damping ratio of the material. Will be stored on the material fragment")]
         [Input("embodiedCarbon", "Embodied carbon for the material. Will be stored on the material fragment")]
         [Output("Material", "The created material with a timber fragment")]
-        public static Timber Timber(string name, Vector E, Vector v, Vector G, Vector tC, double density, double dampingRatio, double embodiedCarbon = 0)
+        public static Timber Timber(string name, Vector E, Vector v, Vector G, Vector tC, double density, double dampingRatio, double embodiedCarbon = 0.4)
         {
             return new Timber()
             {

--- a/Structure_Engine/Create/MaterialFragment.cs
+++ b/Structure_Engine/Create/MaterialFragment.cs
@@ -43,8 +43,9 @@ namespace BH.Engine.Structure
         [Input("tC", "Modulus of thermal expansion. Given in [1/°C] or [1/K]. Will be stored on the material fragment")]
         [Input("density", "Given as [kg/m3]. Will be stored on the base material")]
         [Input("dampingRatio", "Dynamic damping ratio of the material. Will be stored on the material fragment")]
+        [Input("embodiedCarbon", "Embodied carbon for the material. Will be stored on the material fragment")]
         [Output("Material", "The created material with a aluminium fragment")]
-        public static Aluminium Aluminium(string name, double E = 70000000000, double v = 0.34, double tC = 0.000023, double density = 2710, double dampingRatio = 0)
+        public static Aluminium Aluminium(string name, double E = 70000000000, double v = 0.34, double tC = 0.000023, double density = 2710, double dampingRatio = 0, double embodiedCarbon = 100)
         {
             return new Aluminium()
             {
@@ -54,6 +55,7 @@ namespace BH.Engine.Structure
                 PoissonsRatio = v,
                 ThermalExpansionCoeff = tC,
                 DampingRatio = dampingRatio,
+                EmbodiedCarbon = embodiedCarbon,
             };
         }
 
@@ -67,8 +69,9 @@ namespace BH.Engine.Structure
         [Input("dampingRatio", "Dynamic damping ratio of the material. Will be stored on the material fragment")]
         [Input("cubeStrength", "Cube strength of the concrete material. Given in [Pa] or [N/m]. Will be stored on the material fragment")]
         [Input("cylinderStrength", "Cylinder strength of the concrete material. Given in [Pa] or [N/m].Will be stored on the material fragment")]
+        [Input("embodiedCarbon", "Embodied carbon for the material. Will be stored on the material fragment")]
         [Output("Material", "The created material with a concrete fragment")]
-        public static Concrete Concrete(string name, double E = 33000000000, double v = 0.2, double tC = 0.00001, double density = 2550, double dampingRatio = 0, double cubeStrength = 0, double cylinderStrength = 0)
+        public static Concrete Concrete(string name, double E = 33000000000, double v = 0.2, double tC = 0.00001, double density = 2550, double dampingRatio = 0, double cubeStrength = 0, double cylinderStrength = 0, double embodiedCarbon = 200)
         {
             return new Concrete()
             {
@@ -79,7 +82,8 @@ namespace BH.Engine.Structure
                 ThermalExpansionCoeff = tC,
                 CubeStrength = cubeStrength,
                 DampingRatio = dampingRatio,
-                CylinderStrength = cylinderStrength
+                CylinderStrength = cylinderStrength,
+                EmbodiedCarbon = embodiedCarbon,
             };
         }
 
@@ -93,8 +97,9 @@ namespace BH.Engine.Structure
         [Input("dampingRatio", "Dynamic damping ratio of the material. Will be stored on the material fragment")]
         [Input("yieldStress", "Stress level at yield for the material. Given in [Pa] or [N/m]. Will be stored on the material fragment")]
         [Input("ultimateStress", "Stress level at break for the material. Given in [Pa] or [N/m]. Will be stored on the material fragment")]
+        [Input("embodiedCarbon", "Embodied carbon for the material. Will be stored on the material fragment")]
         [Output("Material", "The created material with a steel fragment")]
-        public static Steel Steel(string name, double E = 210000000000, double v = 0.3, double tC = 0.000012, double density = 7850, double dampingRatio = 0, double yieldStress = 0, double ultimateStress = 0)
+        public static Steel Steel(string name, double E = 210000000000, double v = 0.3, double tC = 0.000012, double density = 7850, double dampingRatio = 0, double yieldStress = 0, double ultimateStress = 0, double embodiedCarbon = 300)
         {
             return new Steel()
             {
@@ -105,7 +110,8 @@ namespace BH.Engine.Structure
                 ThermalExpansionCoeff = tC,
                 DampingRatio = dampingRatio,
                 YieldStress = yieldStress,
-                UltimateStress = ultimateStress
+                UltimateStress = ultimateStress,
+                EmbodiedCarbon = embodiedCarbon,
             };
         }
 
@@ -118,8 +124,9 @@ namespace BH.Engine.Structure
         [Input("tC", "Modulus of thermal expansion as Vector. Given in [1/°C] or [1/K]. Will be stored on the material fragment")]
         [Input("density", "Given as [kg/m3]. Will be stored on the base material")]
         [Input("dampingRatio", "Dynamic damping ratio of the material. Will be stored on the material fragment")]
+        [Input("embodiedCarbon", "Embodied carbon for the material. Will be stored on the material fragment")]
         [Output("Material", "The created material with a timber fragment")]
-        public static Timber Timber(string name, Vector E, Vector v, Vector G, Vector tC, double density, double dampingRatio)
+        public static Timber Timber(string name, Vector E, Vector v, Vector G, Vector tC, double density, double dampingRatio, double embodiedCarbon = 0)
         {
             return new Timber()
             {
@@ -130,6 +137,7 @@ namespace BH.Engine.Structure
                 ShearModulus = G,
                 ThermalExpansionCoeff = tC,
                 DampingRatio = dampingRatio,
+                EmbodiedCarbon = embodiedCarbon,
             };
 
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
Adapting to [BHoM PR 560](https://github.com/BHoM/BHoM/pull/560)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1230

<!-- Add short description of what has been fixed -->

Added default value for embodied carbon for each material class

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->