### PR TITLE
Geometry_Engine - Grid is missing Geometry method

### DIFF
--- a/Geometry_Engine/Query/Geometry.cs
+++ b/Geometry_Engine/Query/Geometry.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Geometry.SettingOut;
 
 namespace BH.Engine.Geometry
 {
@@ -82,6 +83,13 @@ namespace BH.Engine.Geometry
         public static ICurve Geometry(this PolyCurve curve)
         {
             return curve;
+        }
+
+        /***************************************************/
+
+        public static ICurve Geometry(this Grid grid)
+        {
+            return grid.Curve;
         }
 
 


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1239 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1239%2DGridIsMissingGeometryMethod).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
`Geometry()` query method added to `BH.oM.Geometry.SettingOut.Grid`


### Additional comments
<!-- As required -->
Needs to be merged ASAP!