### PR TITLE
Geometry_Engine Protection if ICentroid returns null

### DIFF
--- a/Geometry_Engine/Query/PointInRegion.cs
+++ b/Geometry_Engine/Query/PointInRegion.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Geometry
         public static Point PointInRegion(this ICurve curve, bool acceptOnEdge = false, double tolerance = Tolerance.Distance)
         {
             Point point = curve.ICentroid(tolerance);
-            if (curve.IIsContaining(new List<Point> { point }, acceptOnEdge, tolerance))
+            if (point != null && curve.IIsContaining(new List<Point> { point }, acceptOnEdge, tolerance))
                 return point;
 
             List<Point> controlPoints = curve.IControlPoints();


### PR DESCRIPTION
Closes #1242 

Added a protection for when the ICentroid returns null so that PointInRegion can find another PointInRegion 

[Test file](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&e=UuLrGh&cid=13698a4a%2Dabca%2D4608%2Db33f%2D5e33f66d98f1&RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FXML%5FToolkit%2FXML%5FToolkit%2DIssue355%5FPushError&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)