### PR TITLE
Environment_Engine: Add ability to Set Opening Type

### DIFF
--- a/Environment_Engine/Environment_Engine.csproj
+++ b/Environment_Engine/Environment_Engine.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Create\SpaceTime.cs" />
     <Compile Include="Modify\FixNormal.cs" />
     <Compile Include="Modify\Remove.cs" />
+    <Compile Include="Modify\SetOpeningType.cs" />
     <Compile Include="Query\Absorptance.cs" />
     <Compile Include="Query\DateTime.cs" />
     <Compile Include="Query\DateTimeList.cs" />

--- a/Environment_Engine/Modify/SetOpeningType.cs
+++ b/Environment_Engine/Modify/SetOpeningType.cs
@@ -39,13 +39,13 @@ namespace BH.Engine.Environment
         /***************************************************/
 
         [Description("Set the opening type based on the provided type")]
-        [Input("openings", "A collection of Environment Openings to set the type off")]
-        [Input("type", "The opening type to assign to the openings")]
+        [Input("openings", "A collection of Environment Openings to set the type of")]
+        [Input("openingType", "The opening type to assign to the openings")]
         [Output("openings", "A collection of Environment Openings with their type set")]
-        public static List<Opening> SetOpeningType(this List<Opening> openings, OpeningType type)
+        public static List<Opening> SetOpeningType(this List<Opening> openings, OpeningType openingType)
         {
             foreach (Opening o in openings)
-                o.Type = type;
+                o.Type = openingType;
 
             return openings;
         }

--- a/Environment_Engine/Modify/SetOpeningType.cs
+++ b/Environment_Engine/Modify/SetOpeningType.cs
@@ -29,6 +29,7 @@ using BH.oM.Environment.Fragments;
 using System;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
+using BH.Engine.Base;
 
 namespace BH.Engine.Environment
 {
@@ -44,10 +45,10 @@ namespace BH.Engine.Environment
         [Output("openings", "A collection of Environment Openings with their type set")]
         public static List<Opening> SetOpeningType(this List<Opening> openings, OpeningType openingType)
         {
-            foreach (Opening o in openings)
+            List<Opening> cloned = openings.DeepClone<List<Opening>>();
+            foreach (Opening o in cloned)
                 o.Type = openingType;
-
-            return openings;
+            return cloned;
         }
-    } 
-}
+    }
+} 

--- a/Environment_Engine/Modify/SetOpeningType.cs
+++ b/Environment_Engine/Modify/SetOpeningType.cs
@@ -30,7 +30,6 @@ using System;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 
-
 namespace BH.Engine.Environment
 {
     public static partial class Modify
@@ -43,15 +42,12 @@ namespace BH.Engine.Environment
         [Input("openings", "A collection of Environment Openings to set the type off")]
         [Input("type", "The opening type to assign to the openings")]
         [Output("openings", "A collection of Environment Openings with their type set")]
-
-        public static List<Opening> SetOpeningType (this List<Opening> openings, OpeningType type)
+        public static List<Opening> SetOpeningType(this List<Opening> openings, OpeningType type)
         {
             foreach (Opening o in openings)
                 o.Type = type;
 
             return openings;
-                
         }
-    }
-    
+    } 
 }

--- a/Environment_Engine/Modify/SetOpeningType.cs
+++ b/Environment_Engine/Modify/SetOpeningType.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Linq;
+using System.Collections.Generic;
+using BH.oM.Environment.Elements;
+using BH.oM.Geometry;
+using BH.Engine.Geometry;
+using BH.oM.Environment.Fragments;
+using System;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
+
+namespace BH.Engine.Environment
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /****               Public Methods              ****/
+        /***************************************************/
+
+        [Description("Set the opening type based on the provided type")]
+        [Input("openings", "A collection of Environment Openings to set the type off")]
+        [Input("type", "The opening type to assign to the openings")]
+        [Output("openings", "A collection of Environment Openings with their type set")]
+
+        public static List<Opening> SetOpeningType (this List<Opening> openings, OpeningType type)
+        {
+            foreach (Opening o in openings)
+                o.Type = type;
+
+            return openings;
+                
+        }
+    }
+    
+}


### PR DESCRIPTION
Added SetOpeningType to the Environment_Engine modify. 

Makes it possible to assign a specific opening type to a list of openings.

Closes #1176 

[Test file](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&e=HbjegC&cid=2fb09dcd%2D74bf%2D4ca8%2D8984%2Db0b2830f78c0&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FEnvironment%5FEngine%2FEnvironment%5FEngine%2DIssue%2D1176%2DSetOpeningType)