### PR TITLE
Geometry engine - Adding an Orient method and Translate, Scale and Rotate methods for Arcs, Circles and Ellipses

### DIFF
--- a/Geometry_Engine/Create/TransformMatrix.cs
+++ b/Geometry_Engine/Create/TransformMatrix.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Geometry.CoordinateSystem;
 using System;
 
 namespace BH.Engine.Geometry
@@ -129,6 +130,46 @@ namespace BH.Engine.Geometry
             matrix[3, 3] = 1;
 
             return new TransformMatrix { Matrix = matrix };
+        }
+
+        /***************************************************/
+
+        public static TransformMatrix OrientationMatrixGlobalToLocal(Cartesian csTo)
+        {
+            Vector XWorld = new Vector { X = 1, Y = 0, Z = 0 };
+            Vector YWorld = new Vector { X = 0, Y = 1, Z = 0 };
+            Vector ZWorld = new Vector { X = 0, Y = 0, Z = 1 };
+
+            Vector XTo = csTo.X.Normalise();
+            Vector YTo = csTo.Y.Normalise();
+            Vector ZTo = csTo.Z.Normalise();
+
+            TransformMatrix globalToLocal = new TransformMatrix
+            {
+                Matrix = new double[,]
+                {
+                    { XWorld.DotProduct(XTo), XWorld.DotProduct(YTo), XWorld.DotProduct(ZTo), csTo.Origin.X },
+                    { YWorld.DotProduct(XTo), YWorld.DotProduct(YTo), YWorld.DotProduct(ZTo), csTo.Origin.Y },
+                    { ZWorld.DotProduct(XTo), ZWorld.DotProduct(YTo), ZWorld.DotProduct(ZTo), csTo.Origin.Z },
+                    { 0,                      0,                      0                     , 1  }
+                }
+            };
+
+            return globalToLocal;
+        }
+
+        /***************************************************/
+
+        public static TransformMatrix OrientationMatrixLocalToGlobal(Cartesian csFrom)
+        {
+            return OrientationMatrixGlobalToLocal(csFrom).Invert();
+        }
+    
+        /***************************************************/
+
+        public static TransformMatrix OrientationMatrix(this Cartesian csFrom, Cartesian csTo)
+        {
+            return OrientationMatrixGlobalToLocal(csTo) * OrientationMatrixLocalToGlobal(csFrom);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -205,6 +205,7 @@
     <Compile Include="Query\Side.cs" />
     <Compile Include="Query\IsSameSide.cs" />
     <Compile Include="Query\IsValid.cs" />
+    <Compile Include="Modify\Orient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Geometry_Engine/Modify/Orient.cs
+++ b/Geometry_Engine/Modify/Orient.cs
@@ -1,0 +1,44 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Geometry.CoordinateSystem;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /****         public Generic Interface          ****/
+        /***************************************************/
+
+        public static T Orient<T>(this T geometry, Cartesian csFrom, Cartesian csTo) where T: IGeometry
+        {
+            TransformMatrix orientationMatrix = Create.OrientationMatrix(csFrom, csTo);
+            return (T)ITransform(geometry, orientationMatrix);
+        }  
+    }
+}

--- a/Geometry_Engine/Modify/Orient.cs
+++ b/Geometry_Engine/Modify/Orient.cs
@@ -25,6 +25,7 @@ using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Engine.Geometry
@@ -34,7 +35,12 @@ namespace BH.Engine.Geometry
         /***************************************************/
         /****         public Generic Interface          ****/
         /***************************************************/
-
+        
+        [Description("Orients geometry from one coordinate sytem to another")]
+        [Input("geometry", "Geometry to be transformed")]
+        [Input("csFrom", "Coordinate system in which geometry is now")]
+        [Input("csTo", "Coordinate system in which we want geometry to be")]
+        [Output("G", "Geometry in new coordinate system")]
         public static T Orient<T>(this T geometry, Cartesian csFrom, Cartesian csTo) where T: IGeometry
         {
             TransformMatrix orientationMatrix = Create.OrientationMatrix(csFrom, csTo);

--- a/Geometry_Engine/Modify/Orient.cs
+++ b/Geometry_Engine/Modify/Orient.cs
@@ -35,16 +35,18 @@ namespace BH.Engine.Geometry
         /***************************************************/
         /****         public Generic Interface          ****/
         /***************************************************/
-        
+
         [Description("Orients geometry from one coordinate sytem to another")]
         [Input("geometry", "Geometry to be transformed")]
         [Input("csFrom", "Coordinate system in which geometry is now")]
         [Input("csTo", "Coordinate system in which we want geometry to be")]
         [Output("G", "Geometry in new coordinate system")]
-        public static T Orient<T>(this T geometry, Cartesian csFrom, Cartesian csTo) where T: IGeometry
+        public static T Orient<T>(this T geometry, Cartesian csFrom, Cartesian csTo) where T : IGeometry
         {
             TransformMatrix orientationMatrix = Create.OrientationMatrix(csFrom, csTo);
             return (T)ITransform(geometry, orientationMatrix);
-        }  
+        }
+
+        /***************************************************/
     }
 }

--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -83,6 +83,14 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static ICurve Rotate(this Ellipse curve, Point origin, Vector axis, double rad)
+        {
+            TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);
+            return Transform(curve, rotationMatrix);
+        }
+
+        /***************************************************/
+
         public static Line Rotate(this Line line, Point origin, Vector axis, double rad)
         {
             TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);

--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -63,22 +63,22 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
-        public static Arc Rotate(this Arc arc, Point origin, Vector axis, double rad)
+        public static Arc Rotate(this Arc curve, Point origin, Vector axis, double rad)
         {
             return new Arc
             {
-                CoordinateSystem = arc.CoordinateSystem.Rotate(origin, axis, rad),
-                Radius = arc.Radius,
-                StartAngle = arc.StartAngle,
-                EndAngle = arc.EndAngle
+                CoordinateSystem = curve.CoordinateSystem.Rotate(origin, axis, rad),
+                Radius = curve.Radius,
+                StartAngle = curve.StartAngle,
+                EndAngle = curve.EndAngle
             };
         }
 
         /***************************************************/
 
-        public static Circle Rotate(this Circle circle, Point origin, Vector axis, double rad)
+        public static Circle Rotate(this Circle curve, Point origin, Vector axis, double rad)
         {
-            return new Circle { Centre = circle.Centre.Rotate(origin, axis, rad), Normal = circle.Normal.Rotate(rad, axis), Radius = circle.Radius };
+            return new Circle { Centre = curve.Centre.Rotate(origin, axis, rad), Normal = curve.Normal.Rotate(rad, axis), Radius = curve.Radius };
         }
 
         /***************************************************/
@@ -91,10 +91,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static Line Rotate(this Line line, Point origin, Vector axis, double rad)
+        public static Line Rotate(this Line curve, Point origin, Vector axis, double rad)
         {
             TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);
-            return Transform(line, rotationMatrix);
+            return Transform(curve, rotationMatrix);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Scale.cs
+++ b/Geometry_Engine/Modify/Scale.cs
@@ -76,6 +76,14 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static ICurve Scale(this Ellipse curve, Point origin, Vector scaleVector)
+        {
+            TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
+            return Transform(curve, scaleMatrix);
+        }
+
+        /***************************************************/
+        
         public static Line Scale(this Line line, Point origin, Vector scaleVector)
         {
             TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);

--- a/Geometry_Engine/Modify/Scale.cs
+++ b/Geometry_Engine/Modify/Scale.cs
@@ -60,18 +60,18 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
-        public static ICurve Scale(this Arc arc, Point origin, Vector scaleVector)
+        public static ICurve Scale(this Arc curve, Point origin, Vector scaleVector)
         {
             TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
-            return Transform(arc, scaleMatrix);
+            return Transform(curve, scaleMatrix);
         }
 
         /***************************************************/
 
-        public static ICurve Scale(this Circle circle, Point origin, Vector scaleVector)
+        public static ICurve Scale(this Circle curve, Point origin, Vector scaleVector)
         {
             TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
-            return Transform(circle, scaleMatrix);
+            return Transform(curve, scaleMatrix);
         }
 
         /***************************************************/
@@ -84,10 +84,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
         
-        public static Line Scale(this Line line, Point origin, Vector scaleVector)
+        public static Line Scale(this Line curve, Point origin, Vector scaleVector)
         {
             TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
-            return Transform(line, scaleMatrix);
+            return Transform(curve, scaleMatrix);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Transform.cs
+++ b/Geometry_Engine/Modify/Transform.cs
@@ -38,7 +38,8 @@ namespace BH.Engine.Geometry
         {
             double[,] matrix = transform.Matrix;
 
-            return new Point {
+            return new Point
+            {
                 X = matrix[0, 0] * pt.X + matrix[0, 1] * pt.Y + matrix[0, 2] * pt.Z + matrix[0, 3],
                 Y = matrix[1, 0] * pt.X + matrix[1, 1] * pt.Y + matrix[1, 2] * pt.Z + matrix[1, 3],
                 Z = matrix[2, 0] * pt.X + matrix[2, 1] * pt.Y + matrix[2, 2] * pt.Z + matrix[2, 3]
@@ -254,7 +255,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods                           ****/
         /***************************************************/
 
-         private static bool IsUniformScaling(this TransformMatrix transform)
+        private static bool IsUniformScaling(this TransformMatrix transform)
         {
             double tol = 1e-6;
 
@@ -270,5 +271,7 @@ namespace BH.Engine.Geometry
 
             return false;
         }
+
+        /***************************************************/
     }
 }

--- a/Geometry_Engine/Modify/Transform.cs
+++ b/Geometry_Engine/Modify/Transform.cs
@@ -83,32 +83,69 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
-        public static ICurve Transform(this Arc arc, TransformMatrix transform)
+        public static ICurve Transform(this Arc curve, TransformMatrix transform)
         {
-            return arc.ToNurbsCurve().Transform(transform);
+            if (transform.Determinant() == 1 ||
+                (transform.Matrix[0, 0] == transform.Matrix[1, 1] && transform.Matrix[1, 1] == transform.Matrix[2, 2]))
+                return new Arc
+                {
+                    Radius = (curve.StartPoint() - curve.CoordinateSystem.Origin).Transform(transform).Length(),
+                    StartAngle = curve.StartAngle,
+                    EndAngle = curve.EndAngle,
+                    CoordinateSystem = curve.CoordinateSystem.Transform(transform)
+                };
+            else
+            {
+                Reflection.Compute.RecordNote("Transformation is not rigid. Converting into NurbsCurve. May occure change in shape");
+                return curve.ToNurbsCurve().Transform(transform);
+            }
         }
 
         /***************************************************/
 
-        public static ICurve Transform(this Circle circle, TransformMatrix transform)
+        public static ICurve Transform(this Circle curve, TransformMatrix transform)
         {
-            //TODO: an affine transform of a circle always returns a circle or an ellipse so we should improve on this
-            return circle.ToNurbsCurve().Transform(transform);
+            if (transform.Determinant() == 1 || 
+                (transform.Matrix[0,0] == transform.Matrix[1, 1] && transform.Matrix[1, 1]  == transform.Matrix[2, 2]))
+                return new Circle
+                {
+                    Centre = curve.Centre.Transform(transform),
+                    Radius = (curve.StartPoint() - curve.Centre).Transform(transform).Length(),
+                    Normal = curve.Normal.Transform(transform)
+                };
+            else
+            {
+                Reflection.Compute.RecordNote("Transformation is not rigid. Converting into NurbsCurve. May occure change in shape");
+                return curve.ToNurbsCurve().Transform(transform);
+            }
         }
 
         /***************************************************/
 
-        public static ICurve Transform(this Ellipse ellipse, TransformMatrix transform)
+        public static ICurve Transform(this Ellipse curve, TransformMatrix transform)
         {
-            //TODO: an affine transform of an ellipse always returns an ellipse so we should improve on this
-            return ellipse.ToNurbsCurve().Transform(transform); 
+            if (transform.Determinant() == 1 ||
+                (transform.Matrix[0, 0] == transform.Matrix[1, 1] && transform.Matrix[1, 1] == transform.Matrix[2, 2]))
+                return new Ellipse
+                {
+                    Centre = curve.Centre.Transform(transform),
+                    Axis1 = curve.Axis1.Transform(transform),
+                    Axis2 = curve.Axis2.Transform(transform),
+                    Radius1 = (curve.Axis1.Normalise() * curve.Radius1).Transform(transform).Length(),
+                    Radius2 = (curve.Axis2.Normalise() * curve.Radius2).Transform(transform).Length(),
+                };
+            else
+            {
+                Reflection.Compute.RecordNote("Transformation is not rigid. Converting into NurbsCurve. May occure change in shape");
+                return curve.ToNurbsCurve().Transform(transform);
+            }
         }
 
         /***************************************************/
 
-        public static Line Transform(this Line line, TransformMatrix transform)
+        public static Line Transform(this Line curve, TransformMatrix transform)
         {
-            return new Line { Start = line.Start.Transform(transform), End = line.End.Transform(transform) };
+            return new Line { Start = curve.Start.Transform(transform), End = curve.End.Transform(transform) };
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Transform.cs
+++ b/Geometry_Engine/Modify/Transform.cs
@@ -51,7 +51,8 @@ namespace BH.Engine.Geometry
         {
             double[,] matrix = transform.Matrix;
 
-            return new Vector {
+            return new Vector
+            {
                 X = matrix[0, 0] * vector.X + matrix[0, 1] * vector.Y + matrix[0, 2] * vector.Z,
                 Y = matrix[1, 0] * vector.X + matrix[1, 1] * vector.Y + matrix[1, 2] * vector.Z,
                 Z = matrix[2, 0] * vector.X + matrix[2, 1] * vector.Y + matrix[2, 2] * vector.Z
@@ -85,8 +86,7 @@ namespace BH.Engine.Geometry
 
         public static ICurve Transform(this Arc curve, TransformMatrix transform)
         {
-            if (transform.Determinant() == 1 ||
-                (transform.Matrix[0, 0] == transform.Matrix[1, 1] && transform.Matrix[1, 1] == transform.Matrix[2, 2]))
+            if (Math.Abs(transform.Determinant() - 1) <= 1e-6 || transform.IsUniformScaling())
                 return new Arc
                 {
                     Radius = (curve.StartPoint() - curve.CoordinateSystem.Origin).Transform(transform).Length(),
@@ -105,8 +105,7 @@ namespace BH.Engine.Geometry
 
         public static ICurve Transform(this Circle curve, TransformMatrix transform)
         {
-            if (transform.Determinant() == 1 || 
-                (transform.Matrix[0,0] == transform.Matrix[1, 1] && transform.Matrix[1, 1]  == transform.Matrix[2, 2]))
+            if (Math.Abs(transform.Determinant() - 1) <= 1e-6 || transform.IsUniformScaling())
                 return new Circle
                 {
                     Centre = curve.Centre.Transform(transform),
@@ -124,8 +123,7 @@ namespace BH.Engine.Geometry
 
         public static ICurve Transform(this Ellipse curve, TransformMatrix transform)
         {
-            if (transform.Determinant() == 1 ||
-                (transform.Matrix[0, 0] == transform.Matrix[1, 1] && transform.Matrix[1, 1] == transform.Matrix[2, 2]))
+            if (Math.Abs(transform.Determinant() - 1) <= 1e-6 || transform.IsUniformScaling())
                 return new Ellipse
                 {
                     Centre = curve.Centre.Transform(transform),
@@ -251,6 +249,26 @@ namespace BH.Engine.Geometry
             return Transform(geometry as dynamic, transform);
         }
 
+
         /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+         private static bool IsUniformScaling(this TransformMatrix transform)
+        {
+            double tol = 1e-6;
+
+            for (int i = 0; i < transform.Matrix.GetLength(0); i++)
+                for (int j = 0; j < transform.Matrix.GetLength(1) - 1; j++)
+                    if (i != j && Math.Abs(transform.Matrix[i, j]) > tol)
+                        return false;
+
+            if (Math.Abs(transform.Matrix[0, 0] - transform.Matrix[1, 1]) <= tol &&
+                Math.Abs(transform.Matrix[1, 1] - transform.Matrix[2, 2]) <= tol &&
+                Math.Abs(transform.Matrix[3, 3] - 1) <= tol)
+                return true;
+
+            return false;
+        }
     }
 }

--- a/Geometry_Engine/Modify/Translate.cs
+++ b/Geometry_Engine/Modify/Translate.cs
@@ -84,6 +84,14 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static ICurve Translate(this Ellipse curve, Vector transform)
+        {
+            TransformMatrix translationMatrix = Create.TranslationMatrix(transform);
+            return Transform(curve, translationMatrix);
+        }
+
+        /***************************************************/
+
         public static Line Translate(this Line line, Vector transform)
         {
             return new Line { Start = line.Start + transform, End = line.End + transform };

--- a/Geometry_Engine/Modify/Translate.cs
+++ b/Geometry_Engine/Modify/Translate.cs
@@ -64,22 +64,22 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                  ****/
         /***************************************************/
 
-        public static Arc Translate(this Arc arc, Vector transform)
+        public static Arc Translate(this Arc curve, Vector transform)
         {
             return new Arc
             {
-                CoordinateSystem = arc.CoordinateSystem.Translate(transform),
-                Radius = arc.Radius,
-                StartAngle = arc.StartAngle,
-                EndAngle = arc.EndAngle
+                CoordinateSystem = curve.CoordinateSystem.Translate(transform),
+                Radius = curve.Radius,
+                StartAngle = curve.StartAngle,
+                EndAngle = curve.EndAngle
             };
         }
 
         /***************************************************/
 
-        public static Circle Translate(this Circle circle, Vector transform)
+        public static Circle Translate(this Circle curve, Vector transform)
         {
-            return new Circle { Centre = circle.Centre + transform, Normal = circle.Normal.Clone() as Vector, Radius = circle.Radius };
+            return new Circle { Centre = curve.Centre + transform, Normal = curve.Normal.Clone() as Vector, Radius = curve.Radius };
         }
 
         /***************************************************/
@@ -92,9 +92,9 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static Line Translate(this Line line, Vector transform)
+        public static Line Translate(this Line curve, Vector transform)
         {
-            return new Line { Start = line.Start + transform, End = line.End + transform };
+            return new Line { Start = curve.Start + transform, End = curve.End + transform };
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1010 
Closes #1236 
Closes #1237 

<!-- Add short description of what has been fixed -->
- Added three new TransformMatrices:
  - `OrientationMatrixGlobalToLocal` - transforming geometry from global coordinate systems to given local coordinate system
  - `OrientationMatrixLocalToGlobal` - transforming geometry from given local coordinate systems to global coordinate system
  - `OrientationMatrix` - transform geometry between two given coordinate systems
- Added new method `Modify.Orient`, which orients geometry between two coordinate systems using `Transform(OrientationMatrix)`. **( IMPORTANT )** With @IsakNaslundBh we came up with an idea to cover all IGeometry classes with one Generics method. It works quite good for Orient so we'd like to hear your opinions and maybe discuss spreading this approach also over Rotate, Scale and Translate methods. **( /IMPORTANT )**
- Added methods for Ellipse in Rotate, Scale and Translate methods.
- Updated `Tranform(Arc)`, `Tranform(Circle)` and `Tranform(Ellipse)`. Now instead of instantly converting to Nurbscurve it checks if transformation is rigid ([by checking a determinant](https://en.wikipedia.org/wiki/Rigid_transformation#Formal_definition)) or is uniform scaling. If neither it converts to NurbsCurve with a proper note. For now the check won't pass a compounding of rigid transformation and uniform scaling despite it doesn't change the shape. (#toBeResolvedLater) But I believe it is still worth pushing as in most cases user would perform two transformations one after another rather than multiply TransformMatrices. Unless maybe you have any ideas?
- `Orient(Vector)` doesn't work as it should.. because I'm not sure how it should work. When GH orients Vectors it gives same results as when orienting Points. Should our method do the same or should the local vector point from csFrom.Origin.. or something else. Honestly I don't know.

### Test files
[Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FModify) is general test file for Orient Method.
[Here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%231236%231237%2DAvoidConvertingArcsAndCirclesToNurbsAndAddEllipseTransforms) is test file for new Ellipse, Arc and Circle methods. I've created a separate test file because generic test files for Translate, Rotate and Scale are empty and outdated.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Create.OrientationMatrixGlobalToLocal()` public method added in the `Geometry_Engine` for `Cartesian` class
- `Create.OrientationMatrixLocalToGlobal()` public method added in the `Geometry_Engine` for `Cartesian` class
- `Create.OrientationMatrix()` public method added in the `Geometry_Engine` for `Cartesian` class
- `Modify.Orient()` generic public method added in the `Geometry_Engine` for `IGeometry` class
- `Modify.Rotate()` public method added in the `Geometry_Engine` for `Ellipse` class
- `Modify.Scale()` public method added in the `Geometry_Engine` for `Ellipse` class
- `Modify.Translate()` public method added in the `Geometry_Engine` for `Ellipse` class
- `Modify.Transform()` public methods updated in the `Geometry_Engine` for `Arc`, `Circle` and `Ellipse` class
- `Modify.IsUniformScaling()` private method added in the `Geometry_Engine` for `TransformMatrix` class


### Additional comments
<!-- As required -->