### PR TITLE
Geometry_Engine: Ensures all section profile constructors are correct

### DIFF
--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -58,6 +58,18 @@ namespace BH.Engine.Geometry
 
         public static BoxProfile BoxProfile(double height, double width, double thickness, double outerRadius, double innerRadius)
         {
+            if (thickness > height / 2 || thickness > width / 2 || outerRadius > height / 2 || outerRadius > width / 2 || innerRadius * 2 > width - thickness * 2 || innerRadius * 2 > height - thickness * 2 ||
+                Math.Sqrt(2) * thickness <= Math.Sqrt(2) *outerRadius - outerRadius - Math.Sqrt(2) * innerRadius + innerRadius)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || width <= 0 || thickness <= 0 || outerRadius < 0 || innerRadius < 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
+
             List<ICurve> curves = BoxProfileCurves(width, height, thickness, thickness, innerRadius, outerRadius);
             return new BoxProfile(height, width, thickness, outerRadius, innerRadius, curves);
         }

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -171,6 +171,16 @@ namespace BH.Engine.Geometry
 
         public static FabricatedISectionProfile FabricatedISectionProfile(double height, double topFlangeWidth, double botFlangeWidth, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
+            if (height <= topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize || botFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize || topFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || topFlangeWidth <= 0 || botFlangeWidth <= 0 || webThickness <= 0 || topFlangeThickness <= 0 || botFlangeThickness <= 0 || weldSize < 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness,0,0);
             return new FabricatedISectionProfile(height, topFlangeWidth, botFlangeWidth, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -236,6 +236,16 @@ namespace BH.Engine.Geometry
 
         public static GeneralisedTSectionProfile GeneralisedTSectionProfile(double height, double webThickness, double leftOutstandWidth, double leftOutstandThickness, double rightOutstandWidth, double rightOutstandThickness, bool mirrorAboutLocalY = false)
         {
+            if (height <= leftOutstandThickness || height <= rightOutstandThickness)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || webThickness <= 0 || leftOutstandThickness <= 0 || leftOutstandThickness <= 0 || rightOutstandThickness < 0 || rightOutstandWidth <= 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = GeneralisedTeeProfileCurves(height, webThickness, leftOutstandWidth, leftOutstandThickness, rightOutstandWidth, rightOutstandThickness);
 
             if (mirrorAboutLocalY)

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -155,6 +155,16 @@ namespace BH.Engine.Geometry
 
         public static GeneralisedFabricatedBoxProfile GeneralisedFabricatedBoxProfile(double height, double width, double webThickness, double topFlangeThickness = 0.0, double botFlangeThickness = 0.0, double topCorbelWidth = 0.0, double botCorbelWidth = 0.0)
         {
+            if (webThickness>=width/2 ||height <= topFlangeThickness+botFlangeThickness)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || width <= 0 || webThickness <= 0 || topFlangeThickness <= 0 || botFlangeThickness <= 0 || topCorbelWidth < 0 || botCorbelWidth < 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = GeneralisedFabricatedBoxProfileCurves(height, width, webThickness, topFlangeThickness, botFlangeThickness, topCorbelWidth, topCorbelWidth, botCorbelWidth, botCorbelWidth);
             return new GeneralisedFabricatedBoxProfile(height, width, webThickness, topFlangeThickness, botFlangeThickness, topCorbelWidth, topCorbelWidth, botCorbelWidth, botCorbelWidth, curves);
         }
@@ -163,6 +173,16 @@ namespace BH.Engine.Geometry
 
         public static KiteProfile KiteProfile(double width1, double angle1, double thickness)
         {
+            if ((width1*Math.Sin(angle1/2)/Math.Sqrt(2)) /(Math.Sin(Math.PI*0.75- (angle1/2)))<thickness)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (width1 <= 0 || angle1 <= 0 || thickness <= 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = KiteProfileCurves(width1, angle1, thickness);
             return new KiteProfile(width1, angle1, thickness, curves);
         }
@@ -258,6 +278,16 @@ namespace BH.Engine.Geometry
 
         public static TubeProfile TubeProfile(double diameter, double thickness)
         {
+            if (thickness >= diameter/2)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (diameter<=0 || thickness<=0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = TubeProfileCurves(diameter / 2, thickness);
             return new TubeProfile(diameter, thickness, curves);
         }

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -42,19 +42,19 @@ namespace BH.Engine.Geometry
         {
             if (height < flangeThickness * 2 + rootRadius * 2)
             {
-                InvalidRatioError2("height","flangeThickness and rootRadius");
+                InvalidRatioError("height","flangeThickness and rootRadius");
                 return null;
             }
 
             if (width < webthickness + rootRadius * 2 + toeRadius * 2)
             {
-                InvalidRatioError2("width", "webthickness, rootRadius and toeRadius");
+                InvalidRatioError("width", "webthickness, rootRadius and toeRadius");
                 return null;
             }
 
             if (toeRadius > flangeThickness)
             {
-                InvalidRatioError("toeRadius and flangeThickness");
+                InvalidRatioError("toeRadius", "flangeThickness");
                 return null;
             }
 
@@ -74,43 +74,43 @@ namespace BH.Engine.Geometry
         {
             if (thickness > height / 2)
             {
-                InvalidRatioError("thickness and height");
+                InvalidRatioError("thickness", "height");
                 return null;
             }
 
             if (thickness > width / 2)
             {
-                InvalidRatioError("thickness and width");
+                InvalidRatioError("thickness", "width");
                 return null;
             }
 
             if (outerRadius > height / 2)
             {
-                InvalidRatioError("outerRadius and height");
+                InvalidRatioError("outerRadius", "height");
                 return null;
             }
 
             if (outerRadius > width / 2)
             {
-                InvalidRatioError("outerRadius and width");
+                InvalidRatioError("outerRadius", "width");
                 return null;
             }
 
             if (innerRadius * 2 > width - thickness * 2)
             {
-                InvalidRatioError2("innerRadius","width and thickness");
+                InvalidRatioError("innerRadius","width and thickness");
                 return null;
             }
 
             if (innerRadius * 2 > height - thickness * 2)
             {
-                InvalidRatioError2("innerRadius", "height and thickness");
+                InvalidRatioError("innerRadius", "height and thickness");
                 return null;
             }
 
             if (Math.Sqrt(2) * thickness <= Math.Sqrt(2) * outerRadius - outerRadius - Math.Sqrt(2) * innerRadius + innerRadius)
             {
-                InvalidRatioError2("thickness", "outerRadius and innerRadius");
+                InvalidRatioError("thickness", "outerRadius and innerRadius");
                 return null;
             }
 
@@ -130,25 +130,25 @@ namespace BH.Engine.Geometry
         {
             if (height < flangeThickness + rootRadius + toeRadius)
             {
-                InvalidRatioError2("height", "flangeThickness, rootRadius and toeRadius");
+                InvalidRatioError("height", "flangeThickness, rootRadius and toeRadius");
                 return null;
             }
 
             if (width < webthickness + rootRadius + toeRadius)
             {
-                InvalidRatioError2("width", "webthickness, rootRadius and toeRadius");
+                InvalidRatioError("width", "webthickness, rootRadius and toeRadius");
                 return null;
             }
 
             if (flangeThickness < toeRadius)
             {
-                InvalidRatioError("flangeThickness and toeRadius");
+                InvalidRatioError("flangeThickness", "toeRadius");
                 return null;
             }
 
             if (webthickness < toeRadius)
             {
-                InvalidRatioError("webthickness and toeRadius");
+                InvalidRatioError("webthickness", "toeRadius");
                 return null;
             }
 
@@ -174,19 +174,19 @@ namespace BH.Engine.Geometry
         {
             if (height < flangeThickness * 2 + rootRadius * 2)
             {
-                InvalidRatioError2("height", "flangeThickness and rootRadius");
+                InvalidRatioError("height", "flangeThickness and rootRadius");
                 return null;
             }
 
             if (width < webthickness + rootRadius + toeRadius)
             {
-                InvalidRatioError2("width", "webthickness, toeRadius and rootRadius");
+                InvalidRatioError("width", "webthickness, toeRadius and rootRadius");
                 return null;
             }
 
             if (flangeThickness < toeRadius)
             {
-                InvalidRatioError("flangeThickness and toeRadius");
+                InvalidRatioError("flangeThickness", "toeRadius");
                 return null;
             }
 
@@ -223,13 +223,13 @@ namespace BH.Engine.Geometry
         {
             if (height <= topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
             {
-                InvalidRatioError2("height", "topFlangeThickness, botFlangeThickness and weldSize");
+                InvalidRatioError("height", "topFlangeThickness, botFlangeThickness and weldSize");
                 return null;
             }
 
             if (width <= webThickness * 2 + 2 * Math.Sqrt(2) * weldSize)
             {
-                InvalidRatioError2("width", "webThickness and weldSize");
+                InvalidRatioError("width", "webThickness and weldSize");
                 return null;
             }
 
@@ -249,13 +249,13 @@ namespace BH.Engine.Geometry
         {
             if (webThickness >= width / 2)
             {
-                InvalidRatioError("webThickness and width");
+                InvalidRatioError("webThickness", "width");
                 return null;
             }
 
             if (height <= topFlangeThickness + botFlangeThickness)
             {
-                InvalidRatioError2("height","topFlangeThickness and botFlangeThickness");
+                InvalidRatioError("height","topFlangeThickness and botFlangeThickness");
                 return null;
             }
 
@@ -275,7 +275,7 @@ namespace BH.Engine.Geometry
         {
             if ((width1*Math.Sin(angle1/2)/Math.Sqrt(2)) /(Math.Sin(Math.PI*0.75- (angle1/2)))<thickness)
             {
-                InvalidRatioError2("thickness", "width and angle1");
+                InvalidRatioError("thickness", "width and angle1");
                 return null;
             }
 
@@ -295,19 +295,19 @@ namespace BH.Engine.Geometry
         {
             if (height <= topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
             {
-                InvalidRatioError2("height","topFlangeThickness, botFlangeThickness and weldSize");
+                InvalidRatioError("height","topFlangeThickness, botFlangeThickness and weldSize");
                 return null;
             }
 
             if (botFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize)
             {
-                InvalidRatioError2("botFlangeWidth", "webThickness and weldSize");
+                InvalidRatioError("botFlangeWidth", "webThickness and weldSize");
                 return null;
             }
 
             if (topFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize)
             {
-                InvalidRatioError2("topFlangeWidth", "webThickness and weldSize");
+                InvalidRatioError("topFlangeWidth", "webThickness and weldSize");
                 return null;
             }
 
@@ -334,13 +334,13 @@ namespace BH.Engine.Geometry
         {
             if (cornerRadius > height / 2)
             {
-                InvalidRatioError("cornerRadius and height");
+                InvalidRatioError("cornerRadius", "height");
                 return null;
             }
 
             if (cornerRadius > width / 2)
             {
-                InvalidRatioError("cornerRadius and width");
+                InvalidRatioError("cornerRadius", "width");
                 return null;
             }
 
@@ -359,19 +359,19 @@ namespace BH.Engine.Geometry
         {
             if (height < flangeThickness + rootRadius)
             {
-                InvalidRatioError2("height", "flangeThickness and rootRadius");
+                InvalidRatioError("height", "flangeThickness and rootRadius");
                 return null;
             }
 
             if (width < webthickness + 2 * rootRadius + 2 * toeRadius)
             {
-                InvalidRatioError2("width", "webThickess, rootRadius and toeRadius");
+                InvalidRatioError("width", "webThickess, rootRadius and toeRadius");
                 return null;
             }
 
             if (toeRadius > flangeThickness)
             {
-                InvalidRatioError("toeTadius and flangeThickness");
+                InvalidRatioError("toeTadius", "flangeThickness");
                 return null;
             }
 
@@ -395,25 +395,25 @@ namespace BH.Engine.Geometry
         {
             if (height <= leftOutstandThickness)
             {
-                InvalidRatioError("height and leftOutstandThickness");
+                InvalidRatioError("height", "leftOutstandThickness");
                 return null;
             }
 
             if (height <= rightOutstandThickness)
             {
-                InvalidRatioError("height and rightOutstandThickness");
+                InvalidRatioError("height", "rightOutstandThickness");
                 return null;
             }
 
             if (leftOutstandThickness <= 0 && leftOutstandWidth > 0 || leftOutstandWidth <= 0 && leftOutstandThickness > 0)
             {
-                InvalidRatioError("leftOutstandThickness and leftOutstandWidth");
+                InvalidRatioError("leftOutstandThickness","leftOutstandWidth");
                 return null;
             }
 
             if (rightOutstandThickness <= 0 && rightOutstandWidth > 0 || rightOutstandWidth <= 0 && rightOutstandThickness > 0)
             {
-                InvalidRatioError("rightOutstandThickness and rightOutstandWidth");
+                InvalidRatioError("rightOutstandThickness", "rightOutstandWidth");
                 return null;
             }
 
@@ -437,7 +437,7 @@ namespace BH.Engine.Geometry
         {
             if (thickness >= diameter/2)
             {
-                InvalidRatioError("diameter and thickness");
+                InvalidRatioError("diameter", "thickness");
                 return null;
             }
 
@@ -482,16 +482,9 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        private static void InvalidRatioError(string inputs)
+        private static void InvalidRatioError(string first, string second)
         {
-            Engine.Reflection.Compute.RecordError("The ratio between " + inputs + " makes section inconceivable");
-        }
-
-        /***************************************************/
-
-        private static void InvalidRatioError2(string first, string second)
-        {
-            Engine.Reflection.Compute.RecordError("The ratio between " + first + " in relation to " + second + " makes section inconceivable");
+            Engine.Reflection.Compute.RecordError("The ratio of the " + first + " in relation to the " + second + " makes section inconceivable");
         }
 
         /***************************************************/

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -28,6 +28,7 @@ using BH.oM.Geometry;
 using System;
 using BH.oM.Reflection.Attributes;
 using BH.Engine.Geometry;
+using System.ComponentModel;
 
 namespace BH.Engine.Geometry
 {
@@ -39,6 +40,16 @@ namespace BH.Engine.Geometry
 
         public static ISectionProfile ISectionProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius)
         {
+            if (height < flangeThickness * 2 + rootRadius * 2 || width < webthickness + rootRadius * 2 +toeRadius*2 || toeRadius > flangeThickness)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || width <= 0 || webthickness <= 0 || flangeThickness<= 0 || rootRadius< 0 ||toeRadius< 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null; 
+            }
             List<ICurve> curves = IProfileCurves(flangeThickness, width, flangeThickness, width, webthickness, height - 2 * flangeThickness, rootRadius, toeRadius);
             return new ISectionProfile(height, width, webthickness, flangeThickness, rootRadius, toeRadius, curves);
         }
@@ -55,6 +66,16 @@ namespace BH.Engine.Geometry
 
         public static AngleProfile AngleProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius, bool mirrorAboutLocalZ = false, bool mirrorAboutLocalY = false)
         {
+            if (height < flangeThickness + rootRadius + toeRadius|| width < webthickness + rootRadius + toeRadius || flangeThickness < toeRadius || webthickness < toeRadius)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || width <= 0 || webthickness <= 0 || flangeThickness <= 0 || rootRadius < 0 || toeRadius < 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = AngleProfileCurves(width, height, flangeThickness, webthickness, rootRadius, toeRadius);
 
             if (mirrorAboutLocalZ)

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -102,6 +102,16 @@ namespace BH.Engine.Geometry
 
         public static ChannelProfile ChannelProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius, bool mirrorAboutLocalZ = false)
         {
+            if (height < flangeThickness*2 + rootRadius*2 || width < webthickness + rootRadius + toeRadius || flangeThickness < toeRadius)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || width <= 0 || webthickness <= 0 || flangeThickness <= 0 || rootRadius < 0 || toeRadius < 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = ChannelProfileCurves(height, width, webthickness, flangeThickness, rootRadius, toeRadius);
 
             if (mirrorAboutLocalZ)

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -137,6 +137,16 @@ namespace BH.Engine.Geometry
 
         public static FabricatedBoxProfile FabricatedBoxProfile(double height, double width, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
+            if (height < topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize || width <= webThickness*2 + 2*Math.Sqrt(2)*weldSize)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || width <= 0 || webThickness <= 0 || topFlangeThickness <= 0 || botFlangeThickness <= 0 || weldSize < 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = FabricatedBoxProfileCurves(width, height, webThickness, topFlangeThickness, botFlangeThickness);
             return new FabricatedBoxProfile(height, width, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -256,12 +256,12 @@ namespace BH.Engine.Geometry
 
         public static GeneralisedTSectionProfile GeneralisedTSectionProfile(double height, double webThickness, double leftOutstandWidth, double leftOutstandThickness, double rightOutstandWidth, double rightOutstandThickness, bool mirrorAboutLocalY = false)
         {
-            if (height <= leftOutstandThickness || height <= rightOutstandThickness)
+            if (height <= leftOutstandThickness || height <= rightOutstandThickness || webThickness <= 0 || leftOutstandThickness <= 0 && leftOutstandWidth > 0 || leftOutstandWidth <= 0 && leftOutstandThickness > 0 || webThickness <= 0 || rightOutstandThickness <= 0 && rightOutstandWidth > 0 || rightOutstandWidth <= 0 && rightOutstandThickness > 0)
             {
                 Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
                 return null;
             }
-            if (height <= 0 || webThickness <= 0 || leftOutstandThickness <= 0 || leftOutstandThickness <= 0 || rightOutstandThickness < 0 || rightOutstandWidth <= 0)
+            if (height <= 0 || webThickness <= 0 || leftOutstandThickness < 0 || leftOutstandWidth < 0 || rightOutstandThickness < 0 || rightOutstandWidth < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -196,6 +196,16 @@ namespace BH.Engine.Geometry
 
         public static RectangleProfile RectangleProfile(double height, double width, double cornerRadius)
         {
+            if (cornerRadius > height / 2 || cornerRadius > width /2)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || width <= 0 || cornerRadius< 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = RectangleProfileCurves(width, height, cornerRadius);
             return new RectangleProfile(height, width, cornerRadius, curves);
         }
@@ -204,6 +214,16 @@ namespace BH.Engine.Geometry
 
         public static TSectionProfile TSectionProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius, bool mirrorAboutLocalY = false)
         {
+            if (height < flangeThickness + rootRadius || width < webthickness + 2 * rootRadius + 2 * toeRadius || toeRadius>flangeThickness)
+            {
+                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                return null;
+            }
+            if (height <= 0 || width <= 0 || webthickness<= 0 || flangeThickness <= 0 || rootRadius < 0 || toeRadius < 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = TeeProfileCurves(flangeThickness, width, webthickness, height - flangeThickness, rootRadius, toeRadius);
 
             if (mirrorAboutLocalY)

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -40,16 +40,30 @@ namespace BH.Engine.Geometry
 
         public static ISectionProfile ISectionProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius)
         {
-            if (height < flangeThickness * 2 + rootRadius * 2 || width < webthickness + rootRadius * 2 +toeRadius*2 || toeRadius > flangeThickness)
+            if (height < flangeThickness * 2 + rootRadius * 2)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError2("height","flangeThickness and rootRadius");
                 return null;
             }
+
+            if (width < webthickness + rootRadius * 2 + toeRadius * 2)
+            {
+                InvalidRatioError2("width", "webthickness, rootRadius and toeRadius");
+                return null;
+            }
+
+            if (toeRadius > flangeThickness)
+            {
+                InvalidRatioError("toeRadius and flangeThickness");
+                return null;
+            }
+
             if (height <= 0 || width <= 0 || webthickness <= 0 || flangeThickness<= 0 || rootRadius< 0 ||toeRadius< 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null; 
             }
+
             List<ICurve> curves = IProfileCurves(flangeThickness, width, flangeThickness, width, webthickness, height - 2 * flangeThickness, rootRadius, toeRadius);
             return new ISectionProfile(height, width, webthickness, flangeThickness, rootRadius, toeRadius, curves);
         }
@@ -58,12 +72,48 @@ namespace BH.Engine.Geometry
 
         public static BoxProfile BoxProfile(double height, double width, double thickness, double outerRadius, double innerRadius)
         {
-            if (thickness > height / 2 || thickness > width / 2 || outerRadius > height / 2 || outerRadius > width / 2 || innerRadius * 2 > width - thickness * 2 || innerRadius * 2 > height - thickness * 2 ||
-                Math.Sqrt(2) * thickness <= Math.Sqrt(2) *outerRadius - outerRadius - Math.Sqrt(2) * innerRadius + innerRadius)
+            if (thickness > height / 2)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError("thickness and height");
                 return null;
             }
+
+            if (thickness > width / 2)
+            {
+                InvalidRatioError("thickness and width");
+                return null;
+            }
+
+            if (outerRadius > height / 2)
+            {
+                InvalidRatioError("outerRadius and height");
+                return null;
+            }
+
+            if (outerRadius > width / 2)
+            {
+                InvalidRatioError("outerRadius and width");
+                return null;
+            }
+
+            if (innerRadius * 2 > width - thickness * 2)
+            {
+                InvalidRatioError2("innerRadius","width and thickness");
+                return null;
+            }
+
+            if (innerRadius * 2 > height - thickness * 2)
+            {
+                InvalidRatioError2("innerRadius", "height and thickness");
+                return null;
+            }
+
+            if (Math.Sqrt(2) * thickness <= Math.Sqrt(2) * outerRadius - outerRadius - Math.Sqrt(2) * innerRadius + innerRadius)
+            {
+                InvalidRatioError2("thickness", "outerRadius and innerRadius");
+                return null;
+            }
+
             if (height <= 0 || width <= 0 || thickness <= 0 || outerRadius < 0 || innerRadius < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
@@ -78,16 +128,36 @@ namespace BH.Engine.Geometry
 
         public static AngleProfile AngleProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius, bool mirrorAboutLocalZ = false, bool mirrorAboutLocalY = false)
         {
-            if (height < flangeThickness + rootRadius + toeRadius|| width < webthickness + rootRadius + toeRadius || flangeThickness < toeRadius || webthickness < toeRadius)
+            if (height < flangeThickness + rootRadius + toeRadius)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError2("height", "flangeThickness, rootRadius and toeRadius");
                 return null;
             }
+
+            if (width < webthickness + rootRadius + toeRadius)
+            {
+                InvalidRatioError2("width", "webthickness, rootRadius and toeRadius");
+                return null;
+            }
+
+            if (flangeThickness < toeRadius)
+            {
+                InvalidRatioError("flangeThickness and toeRadius");
+                return null;
+            }
+
+            if (webthickness < toeRadius)
+            {
+                InvalidRatioError("webthickness and toeRadius");
+                return null;
+            }
+
             if (height <= 0 || width <= 0 || webthickness <= 0 || flangeThickness <= 0 || rootRadius < 0 || toeRadius < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = AngleProfileCurves(width, height, flangeThickness, webthickness, rootRadius, toeRadius);
 
             if (mirrorAboutLocalZ)
@@ -102,16 +172,30 @@ namespace BH.Engine.Geometry
 
         public static ChannelProfile ChannelProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius, bool mirrorAboutLocalZ = false)
         {
-            if (height < flangeThickness*2 + rootRadius*2 || width < webthickness + rootRadius + toeRadius || flangeThickness < toeRadius)
+            if (height < flangeThickness * 2 + rootRadius * 2)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError2("height", "flangeThickness and rootRadius");
                 return null;
             }
+
+            if (width < webthickness + rootRadius + toeRadius)
+            {
+                InvalidRatioError2("width", "webthickness, toeRadius and rootRadius");
+                return null;
+            }
+
+            if (flangeThickness < toeRadius)
+            {
+                InvalidRatioError("flangeThickness and toeRadius");
+                return null;
+            }
+
             if (height <= 0 || width <= 0 || webthickness <= 0 || flangeThickness <= 0 || rootRadius < 0 || toeRadius < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = ChannelProfileCurves(height, width, webthickness, flangeThickness, rootRadius, toeRadius);
 
             if (mirrorAboutLocalZ)
@@ -137,16 +221,24 @@ namespace BH.Engine.Geometry
 
         public static FabricatedBoxProfile FabricatedBoxProfile(double height, double width, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
-            if (height < topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize || width <= webThickness*2 + 2*Math.Sqrt(2)*weldSize)
+            if (height <= topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError2("height", "topFlangeThickness, botFlangeThickness and weldSize");
                 return null;
             }
+
+            if (width <= webThickness * 2 + 2 * Math.Sqrt(2) * weldSize)
+            {
+                InvalidRatioError2("width", "webThickness and weldSize");
+                return null;
+            }
+
             if (height <= 0 || width <= 0 || webThickness <= 0 || topFlangeThickness <= 0 || botFlangeThickness <= 0 || weldSize < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = FabricatedBoxProfileCurves(width, height, webThickness, topFlangeThickness, botFlangeThickness);
             return new FabricatedBoxProfile(height, width, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }
@@ -155,16 +247,24 @@ namespace BH.Engine.Geometry
 
         public static GeneralisedFabricatedBoxProfile GeneralisedFabricatedBoxProfile(double height, double width, double webThickness, double topFlangeThickness = 0.0, double botFlangeThickness = 0.0, double topCorbelWidth = 0.0, double botCorbelWidth = 0.0)
         {
-            if (webThickness>=width/2 ||height <= topFlangeThickness+botFlangeThickness)
+            if (webThickness >= width / 2)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError("webThickness and width");
                 return null;
             }
+
+            if (height <= topFlangeThickness + botFlangeThickness)
+            {
+                InvalidRatioError2("height","topFlangeThickness and botFlangeThickness");
+                return null;
+            }
+
             if (height <= 0 || width <= 0 || webThickness <= 0 || topFlangeThickness <= 0 || botFlangeThickness <= 0 || topCorbelWidth < 0 || botCorbelWidth < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = GeneralisedFabricatedBoxProfileCurves(height, width, webThickness, topFlangeThickness, botFlangeThickness, topCorbelWidth, topCorbelWidth, botCorbelWidth, botCorbelWidth);
             return new GeneralisedFabricatedBoxProfile(height, width, webThickness, topFlangeThickness, botFlangeThickness, topCorbelWidth, topCorbelWidth, botCorbelWidth, botCorbelWidth, curves);
         }
@@ -175,14 +275,16 @@ namespace BH.Engine.Geometry
         {
             if ((width1*Math.Sin(angle1/2)/Math.Sqrt(2)) /(Math.Sin(Math.PI*0.75- (angle1/2)))<thickness)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError2("thickness", "width and angle1");
                 return null;
             }
+
             if (width1 <= 0 || angle1 <= 0 || thickness <= 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = KiteProfileCurves(width1, angle1, thickness);
             return new KiteProfile(width1, angle1, thickness, curves);
         }
@@ -191,16 +293,30 @@ namespace BH.Engine.Geometry
 
         public static FabricatedISectionProfile FabricatedISectionProfile(double height, double topFlangeWidth, double botFlangeWidth, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
-            if (height <= topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize || botFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize || topFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize)
+            if (height <= topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError2("height","topFlangeThickness, botFlangeThickness and weldSize");
                 return null;
             }
+
+            if (botFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize)
+            {
+                InvalidRatioError2("botFlangeWidth", "webThickness and weldSize");
+                return null;
+            }
+
+            if (topFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize)
+            {
+                InvalidRatioError2("topFlangeWidth", "webThickness and weldSize");
+                return null;
+            }
+
             if (height <= 0 || topFlangeWidth <= 0 || botFlangeWidth <= 0 || webThickness <= 0 || topFlangeThickness <= 0 || botFlangeThickness <= 0 || weldSize < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness,0,0);
             return new FabricatedISectionProfile(height, topFlangeWidth, botFlangeWidth, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }
@@ -216,11 +332,18 @@ namespace BH.Engine.Geometry
 
         public static RectangleProfile RectangleProfile(double height, double width, double cornerRadius)
         {
-            if (cornerRadius > height / 2 || cornerRadius > width /2)
+            if (cornerRadius > height / 2)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError("cornerRadius and height");
                 return null;
             }
+
+            if (cornerRadius > width / 2)
+            {
+                InvalidRatioError("cornerRadius and width");
+                return null;
+            }
+
             if (height <= 0 || width <= 0 || cornerRadius< 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
@@ -234,16 +357,30 @@ namespace BH.Engine.Geometry
 
         public static TSectionProfile TSectionProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius, bool mirrorAboutLocalY = false)
         {
-            if (height < flangeThickness + rootRadius || width < webthickness + 2 * rootRadius + 2 * toeRadius || toeRadius>flangeThickness)
+            if (height < flangeThickness + rootRadius)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError2("height", "flangeThickness and rootRadius");
                 return null;
             }
+
+            if (width < webthickness + 2 * rootRadius + 2 * toeRadius)
+            {
+                InvalidRatioError2("width", "webThickess, rootRadius and toeRadius");
+                return null;
+            }
+
+            if (toeRadius > flangeThickness)
+            {
+                InvalidRatioError("toeTadius and flangeThickness");
+                return null;
+            }
+
             if (height <= 0 || width <= 0 || webthickness<= 0 || flangeThickness <= 0 || rootRadius < 0 || toeRadius < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = TeeProfileCurves(flangeThickness, width, webthickness, height - flangeThickness, rootRadius, toeRadius);
 
             if (mirrorAboutLocalY)
@@ -256,16 +393,36 @@ namespace BH.Engine.Geometry
 
         public static GeneralisedTSectionProfile GeneralisedTSectionProfile(double height, double webThickness, double leftOutstandWidth, double leftOutstandThickness, double rightOutstandWidth, double rightOutstandThickness, bool mirrorAboutLocalY = false)
         {
-            if (height <= leftOutstandThickness || height <= rightOutstandThickness || webThickness <= 0 || leftOutstandThickness <= 0 && leftOutstandWidth > 0 || leftOutstandWidth <= 0 && leftOutstandThickness > 0 || webThickness <= 0 || rightOutstandThickness <= 0 && rightOutstandWidth > 0 || rightOutstandWidth <= 0 && rightOutstandThickness > 0)
+            if (height <= leftOutstandThickness)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError("height and leftOutstandThickness");
                 return null;
             }
+
+            if (height <= rightOutstandThickness)
+            {
+                InvalidRatioError("height and rightOutstandThickness");
+                return null;
+            }
+
+            if (leftOutstandThickness <= 0 && leftOutstandWidth > 0 || leftOutstandWidth <= 0 && leftOutstandThickness > 0)
+            {
+                InvalidRatioError("leftOutstandThickness and leftOutstandWidth");
+                return null;
+            }
+
+            if (rightOutstandThickness <= 0 && rightOutstandWidth > 0 || rightOutstandWidth <= 0 && rightOutstandThickness > 0)
+            {
+                InvalidRatioError("rightOutstandThickness and rightOutstandWidth");
+                return null;
+            }
+
             if (height <= 0 || webThickness <= 0 || leftOutstandThickness < 0 || leftOutstandWidth < 0 || rightOutstandThickness < 0 || rightOutstandWidth < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = GeneralisedTeeProfileCurves(height, webThickness, leftOutstandWidth, leftOutstandThickness, rightOutstandWidth, rightOutstandThickness);
 
             if (mirrorAboutLocalY)
@@ -280,14 +437,16 @@ namespace BH.Engine.Geometry
         {
             if (thickness >= diameter/2)
             {
-                Engine.Reflection.Compute.RecordError("The ratio between inputs makes section inconceivable");
+                InvalidRatioError("diameter and thickness");
                 return null;
             }
+
             if (diameter<=0 || thickness<=0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;
             }
+
             List<ICurve> curves = TubeProfileCurves(diameter / 2, thickness);
             return new TubeProfile(diameter, thickness, curves);
         }
@@ -319,6 +478,20 @@ namespace BH.Engine.Geometry
         {
             Plane plane = oM.Geometry.Plane.YZ;
             return curves.Select(x => x.IMirror(plane)).ToList();
+        }
+
+        /***************************************************/
+
+        private static void InvalidRatioError(string inputs)
+        {
+            Engine.Reflection.Compute.RecordError("The ratio between " + inputs + " makes section inconceivable");
+        }
+
+        /***************************************************/
+
+        private static void InvalidRatioError2(string first, string second)
+        {
+            Engine.Reflection.Compute.RecordError("The ratio between " + first + " in relation to " + second + " makes section inconceivable");
         }
 
         /***************************************************/

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -124,6 +124,11 @@ namespace BH.Engine.Geometry
 
         public static CircleProfile CircleProfile(double diameter)
         {
+            if (diameter <= 0)
+            {
+                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+                return null;
+            }
             List<ICurve> curves = CircleProfileCurves(diameter / 2);
             return new CircleProfile(diameter, curves);
         }


### PR DESCRIPTION
 ### Issues addressed by this PR
Closes Issue #259

### Changes
Added code to not make profile components not output inconceivable profiles.
With inconceivable i mean for example where the profile is inside out or it self intersects. With the changes you are still able to make unrealistic profiles structure wise, but not geometry wise. 

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Adding checks for all ratios used to generate section profiles, raising error messages and returning null if the provided values does not generate a functioning profile.


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&e=CJWjNz&cid=0b727f4a%2Daf39%2D4d1d%2D8942%2D0c26c33d7c20&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DPull%20Request%201252%20section%20profiles

### How to test
Slide number sliders to try and make a profile that is inconceivable. If the component stops working and returns null and an error message the changes works as intended.