### PR TITLE
Environment_Engine: Adding cleanPanel method 

### DIFF
--- a/Environment_Engine/Environment_Engine.csproj
+++ b/Environment_Engine/Environment_Engine.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Create\LightTransmittanceFragment.cs" />
     <Compile Include="Create\Location.cs" />
     <Compile Include="Create\SpaceTime.cs" />
+    <Compile Include="Modify\CleanPanel.cs" />
     <Compile Include="Modify\FixNormal.cs" />
     <Compile Include="Modify\Remove.cs" />
     <Compile Include="Modify\SetOpeningType.cs" />

--- a/Environment_Engine/Modify/CleanPanel.cs
+++ b/Environment_Engine/Modify/CleanPanel.cs
@@ -1,0 +1,57 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.oM.Environment.Elements;
+using BH.oM.Environment;
+using BH.oM.Geometry;
+
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Linq;
+using BH.Engine.Base;
+
+namespace BH.Engine.Environment
+{
+    public static partial class Modify
+    {
+        [Description(" hej")]
+        [Input("panels", " ")]
+        [Output("cleanedPanels", " ")]
+        public static List<Panel> CleanPanel(this List<Panel> panels, Polyline polyline)
+        {
+            List<Panel> clonedPanels = new List<Panel>(panels.Select(x => x.DeepClone<Panel>()).ToList());
+            //List<Panel> clonedPolyline = new List<Polyline>(polyline.Select(x => x.DeepClone<Polyline>()).ToList());
+
+            foreach (Panel p in clonedPanels)
+            {
+                polyline = polyline.CleanPolyline();
+                p.ExternalEdges = polyline.ToEdges(); 
+
+               // p.Polyline().CleanPolyline().ToEdges();
+            }
+            return clonedPanels;
+        }
+        
+    }
+}

--- a/Environment_Engine/Modify/CleanPanel.cs
+++ b/Environment_Engine/Modify/CleanPanel.cs
@@ -35,20 +35,17 @@ namespace BH.Engine.Environment
 {
     public static partial class Modify
     {
-        [Description(" hej")]
-        [Input("panels", " ")]
-        [Output("cleanedPanels", " ")]
-        public static List<Panel> CleanPanel(this List<Panel> panels, double minimumAcceptableAngle, double minimunSegmentLength)
+        [Description("Returns a list of panels that has been cleaned from short segments and insignificant vertices")]
+        [Input("panels", "A list of panels that will be cleaned")]
+        [Input("angleTolerance", "The tolerance of the angle that defines a straight line. Default is set to the value defined by BH.oM.Geometry.Tolerance.Angle")]
+        [Input("minimumSegmentLength", "The length of the smallest allowed segment. Segments smaller than this will be removed. Default is set to the value defined by BH.oM.Geometry.Tolerance.Distance")]
+        [Output("cleanedPanels", "A list of panels that has been cleaned")]
+        public static List<Panel> CleanPanel(this List<Panel> panels, double angleTolerance = Tolerance.Angle, double minimunSegmentLength = Tolerance.Distance)
         {
-            //Two tolerances coming in:
-            //minimumSegmentLength - default to Tolerance.Distance
-            //minimumAcceptableAngle - default to Tolerance.Angle
-
             List<Panel> clonedPanels = new List<Panel>(panels.Select(x => x.DeepClone<Panel>()).ToList());
 
             foreach (Panel p in clonedPanels)
-                p.ExternalEdges = p.Polyline().CleanPolyline().ToEdges();
-
+                p.ExternalEdges = p.Polyline().CleanPolyline(angleTolerance, minimunSegmentLength).ToEdges();
             return clonedPanels;
         }
     }

--- a/Environment_Engine/Modify/CleanPanel.cs
+++ b/Environment_Engine/Modify/CleanPanel.cs
@@ -40,12 +40,12 @@ namespace BH.Engine.Environment
         [Input("angleTolerance", "The tolerance of the angle that defines a straight line. Default is set to the value defined by BH.oM.Geometry.Tolerance.Angle")]
         [Input("minimumSegmentLength", "The length of the smallest allowed segment. Segments smaller than this will be removed. Default is set to the value defined by BH.oM.Geometry.Tolerance.Distance")]
         [Output("cleanedPanels", "A list of panels that has been cleaned")]
-        public static List<Panel> CleanPanel(this List<Panel> panels, double angleTolerance = Tolerance.Angle, double minimunSegmentLength = Tolerance.Distance)
+        public static List<Panel> CleanPanel(this List<Panel> panels, double angleTolerance = Tolerance.Angle, double minimumSegmentLength = Tolerance.Distance)
         {
             List<Panel> clonedPanels = new List<Panel>(panels.Select(x => x.DeepClone<Panel>()).ToList());
 
             foreach (Panel p in clonedPanels)
-                p.ExternalEdges = p.Polyline().CleanPolyline(angleTolerance, minimunSegmentLength).ToEdges();
+                p.ExternalEdges = p.Polyline().CleanPolyline(angleTolerance, minimumSegmentLength).ToEdges();
             return clonedPanels;
         }
     }

--- a/Environment_Engine/Modify/CleanPanel.cs
+++ b/Environment_Engine/Modify/CleanPanel.cs
@@ -38,20 +38,18 @@ namespace BH.Engine.Environment
         [Description(" hej")]
         [Input("panels", " ")]
         [Output("cleanedPanels", " ")]
-        public static List<Panel> CleanPanel(this List<Panel> panels, Polyline polyline)
+        public static List<Panel> CleanPanel(this List<Panel> panels, double minimumAcceptableAngle, double minimunSegmentLength)
         {
+            //Two tolerances coming in:
+            //minimumSegmentLength - default to Tolerance.Distance
+            //minimumAcceptableAngle - default to Tolerance.Angle
+
             List<Panel> clonedPanels = new List<Panel>(panels.Select(x => x.DeepClone<Panel>()).ToList());
-            //List<Panel> clonedPolyline = new List<Polyline>(polyline.Select(x => x.DeepClone<Polyline>()).ToList());
 
             foreach (Panel p in clonedPanels)
-            {
-                polyline = polyline.CleanPolyline();
-                p.ExternalEdges = polyline.ToEdges(); 
+                p.ExternalEdges = p.Polyline().CleanPolyline().ToEdges();
 
-               // p.Polyline().CleanPolyline().ToEdges();
-            }
             return clonedPanels;
         }
-        
     }
 }


### PR DESCRIPTION

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1152 

Clean panel method added to clean panels from short segments and extra control points. 


### Test files
[Test file](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&e=qi5MJa&cid=6a0a6b5b%2D06a5%2D4f34%2D8198%2D92b8c6f54303&RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FEnvironment%5FEngine%2FEnvironment%5FEngine%2DIssue%2D1152%20CleanPanel&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->