### PR TITLE
Reflection_Engine: Add a ToText() method for MemberInfo

### DIFF
--- a/Reflection_Engine/Convert/ToText.cs
+++ b/Reflection_Engine/Convert/ToText.cs
@@ -35,6 +35,19 @@ namespace BH.Engine.Reflection
         /**** Public Methods                            ****/
         /***************************************************/
 
+        public static string ToText(this MemberInfo member, bool includePath = false)
+        {
+            if (member is MethodBase)
+                return ToText(member as MethodBase, includePath);
+            else if (member is Type)
+                return ToText(member as Type, includePath);
+            else
+                return member.ToString();
+        }
+
+
+        /***************************************************/
+
         public static string ToText(this MethodBase method, bool includePath = false, string paramStart = "(", string paramSeparator = ", ", string paramEnd = ")", bool removeIForInterface = true, bool includeParamNames = true, int maxParams = 5, int maxChars = 40)
         {
             string name = (method is ConstructorInfo) ? method.DeclaringType.ToText(false, true) : method.Name;


### PR DESCRIPTION
   
### Issues addressed by this PR
This assists solving this issue: https://github.com/BHoM/BHoM_UI/issues/124


### Test files
I honestly don't think this needs testing. Inspection of the code and making it compiles should be enough here. 

Unless you see a reason for the fallback case to not be `member.ToString()` ?

