### PR TITLE
Geometry_Engine: Fix shape profile weld size

### DIFF
--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Geometry
 
         public static ISectionProfile ISectionProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius)
         {
-            List<ICurve> curves = IProfileCurves(flangeThickness, width, flangeThickness, width, webthickness, height - 2 * flangeThickness, rootRadius, toeRadius);
+            List<ICurve> curves = IProfileCurves(flangeThickness, width, flangeThickness, width, webthickness, height - 2 * flangeThickness, rootRadius, toeRadius,0);
             return new ISectionProfile(height, width, webthickness, flangeThickness, rootRadius, toeRadius, curves);
         }
 
@@ -113,7 +113,7 @@ namespace BH.Engine.Geometry
 
         public static FabricatedISectionProfile FabricatedISectionProfile(double height, double topFlangeWidth, double botFlangeWidth, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
-            List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness,0,0);
+            List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness,0,0,weldSize);
             return new FabricatedISectionProfile(height, topFlangeWidth, botFlangeWidth, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }
 

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -89,7 +89,7 @@ namespace BH.Engine.Geometry
 
         public static FabricatedBoxProfile FabricatedBoxProfile(double height, double width, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
-            List<ICurve> curves = FabricatedBoxProfileCurves(width, height, webThickness, topFlangeThickness, botFlangeThickness);
+            List<ICurve> curves = FabricatedBoxProfileCurves(width, height, webThickness, topFlangeThickness, botFlangeThickness, weldSize);
             return new FabricatedBoxProfile(height, width, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }
 

--- a/Geometry_Engine/Create/ShapeProfileCurves.cs
+++ b/Geometry_Engine/Create/ShapeProfileCurves.cs
@@ -61,8 +61,6 @@ namespace BH.Engine.Geometry
             perimeter.Add(new Line { Start = p, End = p - xAxis * (tfw) });
             perimeter.Add(new Line { Start = origin + xAxis * (-bfw / 2), End = origin + xAxis * (bfw / 2) });
 
-            //j start
-            //List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness,0,0, weldSize);
             List<ICurve> welds = new List<ICurve>();
             double weldLength = weldSize * 2 / Math.Sqrt(2);
             Point q1 = new Point { X = wt/2, Y = wd + bft, Z = 0 };
@@ -77,8 +75,7 @@ namespace BH.Engine.Geometry
             welds.Add(new Line { Start = q3 - wx, End = q3 + wy });
             welds.Add(new Line { Start = q4 + wx, End = q4 + wy });
             perimeter.AddRange(welds);
-            //j end
-
+            
             return perimeter;
         }
 

--- a/Geometry_Engine/Create/ShapeProfileCurves.cs
+++ b/Geometry_Engine/Create/ShapeProfileCurves.cs
@@ -62,20 +62,20 @@ namespace BH.Engine.Geometry
             perimeter.Add(new Line { Start = origin + xAxis * (-bfw / 2), End = origin + xAxis * (bfw / 2) });
 
             //j start
-            //List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness,0,0);
+            //List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness,0,0, weldSize);
             List<ICurve> welds = new List<ICurve>();
             double weldLength = weldSize * 2 / Math.Sqrt(2);
-            Point q1 = new Point { X = wt, Y = ((wd+tft+bft)/2)-tft, Z = 0 };
-            Point q2 = new Point { X = -wt, Y = ((wd + tft + bft) / 2) - tft, Z = 0 };
-            Point q3 = new Point { X = -wt, Y = -((wd + tft + bft) / 2) + bft, Z = 0 };
-            Point q4 = new Point { X = wt, Y = -((wd + tft + bft) / 2) + bft, Z = 0 };
+            Point q1 = new Point { X = wt/2, Y = wd + bft, Z = 0 };
+            Point q2 = new Point { X = -wt/2, Y = wd + bft, Z = 0 };
+            Point q3 = new Point { X = -wt/2, Y = bft, Z = 0 };
+            Point q4 = new Point { X = wt/2, Y = bft, Z = 0 };
             Vector wx = new Vector { X = weldLength, Y = 0, Z = 0 };
             Vector wy = new Vector { X = 0, Y = weldLength, Z = 0 };
 
-            welds.Add(new Line { Start = q1 - wx, End = q1 - wy });
-            welds.Add(new Line { Start = q2 + wx, End = q2 - wy });
-            welds.Add(new Line { Start = q3 + wx, End = q3 + wy });
-            welds.Add(new Line { Start = q4 - wx, End = q4 + wy });
+            welds.Add(new Line { Start = q1 + wx, End = q1 - wy });
+            welds.Add(new Line { Start = q2 - wx, End = q2 - wy });
+            welds.Add(new Line { Start = q3 - wx, End = q3 + wy });
+            welds.Add(new Line { Start = q4 + wx, End = q4 + wy });
             perimeter.AddRange(welds);
             //j end
 

--- a/Geometry_Engine/Create/ShapeProfileCurves.cs
+++ b/Geometry_Engine/Create/ShapeProfileCurves.cs
@@ -42,39 +42,27 @@ namespace BH.Engine.Geometry
             Vector xAxis = oM.Geometry.Vector.XAxis;
             Vector yAxis = oM.Geometry.Vector.YAxis;
             Point origin = oM.Geometry.Point.Origin;
+            double weldLength = weldSize * 2 / Math.Sqrt(2);
 
             perimeter.Add(new Line { Start = p, End = p = p + yAxis * (bft - r2) });
             if (r2 > 0) perimeter.Add(BH.Engine.Geometry.Create.ArcByCentre(p - xAxis * r2, p, p = p + new Vector { X = -r2, Y = r2, Z = 0 }));
-            perimeter.Add(new Line { Start = p, End = p = p - xAxis * (bfw / 2 - wt / 2 - r1 - r2) });
+            perimeter.Add(new Line { Start = p, End = p = p - xAxis * (bfw / 2 - wt / 2 - r1 - r2 -weldLength) });
             if (r1 > 0) perimeter.Add(BH.Engine.Geometry.Create.ArcByCentre(p + yAxis * r1, p, p = p + new Vector { X = -r1, Y = r1, Z = 0 }));
-            perimeter.Add(new Line { Start = p, End = p = p + yAxis * (wd - 2 * r1) });
+            if (weldSize > 0) perimeter.Add(new Line { Start = p, End = p = p + new Vector { X = -weldLength, Y = weldLength, Z = 0 } });
+            perimeter.Add(new Line { Start = p, End = p = p + yAxis * (wd - 2 * r1 - 2 * weldLength) });
+            if (weldSize > 0) perimeter.Add(new Line { Start = p, End = p = p + new Vector { X = weldLength, Y = weldLength, Z = 0 } });
             if (r1 > 0) perimeter.Add(BH.Engine.Geometry.Create.ArcByCentre(p + xAxis * r1, p, p = p + new Vector { X = r1, Y = r1, Z = 0 }));
-            perimeter.Add(new Line { Start = p, End = p = p + xAxis * (tfw / 2 - wt / 2 - r1 - r2) });
+            perimeter.Add(new Line { Start = p, End = p = p + xAxis * (tfw / 2 - wt / 2 - r1 - r2 - weldLength) });
             if (r2 > 0) perimeter.Add(BH.Engine.Geometry.Create.ArcByCentre(p + yAxis * r2, p, p = p + new Vector { X = r2, Y = r2, Z = 0 }));
             perimeter.Add(new Line { Start = p, End = p = p + yAxis * (tft - r2) });
 
             int count = perimeter.Count;
-            for (int i = 0; i < count;i++)       
+            for (int i = 0; i < count;i++)
             {
                 perimeter.Add(perimeter[i].IMirror(new Plane { Origin = origin, Normal = xAxis }));
             }
             perimeter.Add(new Line { Start = p, End = p - xAxis * (tfw) });
             perimeter.Add(new Line { Start = origin + xAxis * (-bfw / 2), End = origin + xAxis * (bfw / 2) });
-
-            List<ICurve> welds = new List<ICurve>();
-            double weldLength = weldSize * 2 / Math.Sqrt(2);
-            Point q1 = new Point { X = wt/2, Y = wd + bft, Z = 0 };
-            Point q2 = new Point { X = -wt/2, Y = wd + bft, Z = 0 };
-            Point q3 = new Point { X = -wt/2, Y = bft, Z = 0 };
-            Point q4 = new Point { X = wt/2, Y = bft, Z = 0 };
-            Vector wx = new Vector { X = weldLength, Y = 0, Z = 0 };
-            Vector wy = new Vector { X = 0, Y = weldLength, Z = 0 };
-
-            welds.Add(new Line { Start = q1 + wx, End = q1 - wy });
-            welds.Add(new Line { Start = q2 - wx, End = q2 - wy });
-            welds.Add(new Line { Start = q3 - wx, End = q3 + wy });
-            welds.Add(new Line { Start = q4 + wx, End = q4 + wy });
-            perimeter.AddRange(welds);
             
             return perimeter;
         }

--- a/Geometry_Engine/Create/ShapeProfileCurves.cs
+++ b/Geometry_Engine/Create/ShapeProfileCurves.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static List<ICurve> IProfileCurves(double tft, double tfw, double bft, double bfw, double wt, double wd, double r1, double r2)
+        public static List<ICurve> IProfileCurves(double tft, double tfw, double bft, double bfw, double wt, double wd, double r1, double r2, double weldSize)
         {
             List<ICurve> perimeter = new List<ICurve>();
             Point p = new Point { X = bfw / 2, Y = 0, Z = 0 };
@@ -60,6 +60,25 @@ namespace BH.Engine.Geometry
             }
             perimeter.Add(new Line { Start = p, End = p - xAxis * (tfw) });
             perimeter.Add(new Line { Start = origin + xAxis * (-bfw / 2), End = origin + xAxis * (bfw / 2) });
+
+            //j start
+            //List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness,0,0);
+            List<ICurve> welds = new List<ICurve>();
+            double weldLength = weldSize * 2 / Math.Sqrt(2);
+            Point q1 = new Point { X = wt, Y = ((wd+tft+bft)/2)-tft, Z = 0 };
+            Point q2 = new Point { X = -wt, Y = ((wd + tft + bft) / 2) - tft, Z = 0 };
+            Point q3 = new Point { X = -wt, Y = -((wd + tft + bft) / 2) + bft, Z = 0 };
+            Point q4 = new Point { X = wt, Y = -((wd + tft + bft) / 2) + bft, Z = 0 };
+            Vector wx = new Vector { X = weldLength, Y = 0, Z = 0 };
+            Vector wy = new Vector { X = 0, Y = weldLength, Z = 0 };
+
+            welds.Add(new Line { Start = q1 - wx, End = q1 - wy });
+            welds.Add(new Line { Start = q2 + wx, End = q2 - wy });
+            welds.Add(new Line { Start = q3 + wx, End = q3 + wy });
+            welds.Add(new Line { Start = q4 - wx, End = q4 + wy });
+            perimeter.AddRange(welds);
+            //j end
+
             return perimeter;
         }
 
@@ -180,7 +199,6 @@ namespace BH.Engine.Geometry
         {
             List<ICurve> box = RectangleProfileCurves(width, height, 0);
             List<ICurve> innerBox = RectangleProfileCurves(width - 2 * webThickness, height - (topFlangeThickness + botFlangeThickness), 0);
-            List<ICurve> welds = new List<ICurve>();
             double diff = botFlangeThickness- topFlangeThickness;
 
             if (diff != 0)
@@ -189,6 +207,7 @@ namespace BH.Engine.Geometry
                 innerBox = innerBox.Select(x => Geometry.Modify.ITranslate(x, v)).ToList();
             }
 
+            List<ICurve> welds = new List<ICurve>();
             double weldLength = weldSize * 2 / Math.Sqrt(2);
             Point q1 = new Point { X = (width / 2) - webThickness, Y = (height / 2) - topFlangeThickness, Z = 0 };
             Point q2 = new Point { X = -(width / 2) + webThickness, Y = (height / 2) - topFlangeThickness, Z = 0 };

--- a/Geometry_Engine/Create/ShapeProfileCurves.cs
+++ b/Geometry_Engine/Create/ShapeProfileCurves.cs
@@ -195,21 +195,13 @@ namespace BH.Engine.Geometry
         public static List<ICurve> FabricatedBoxProfileCurves(double width, double height, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
             List<ICurve> box = RectangleProfileCurves(width, height, 0);
-            List<ICurve> innerBox = RectangleProfileCurves(width - 2 * webThickness, height - (topFlangeThickness + botFlangeThickness), 0);
-            double diff = botFlangeThickness- topFlangeThickness;
-
-            if (diff != 0)
-            {
-                Vector v = new Vector() { X = 0, Y = diff / 2, Z = 0 };
-                innerBox = innerBox.Select(x => Geometry.Modify.ITranslate(x, v)).ToList();
-            }
-
+            
             List<ICurve> welds = new List<ICurve>();
             double weldLength = weldSize * 2 / Math.Sqrt(2);
             Point q1 = new Point { X = (width / 2) - webThickness, Y = (height / 2) - topFlangeThickness, Z = 0 };
             Point q2 = new Point { X = -(width / 2) + webThickness, Y = (height / 2) - topFlangeThickness, Z = 0 };
-            Point q3 = new Point { X = -(width / 2) + webThickness, Y = -(height / 2) + topFlangeThickness, Z = 0 };
-            Point q4 = new Point { X = (width / 2) - webThickness, Y = -(height / 2) + topFlangeThickness, Z = 0 };
+            Point q3 = new Point { X = -(width / 2) + webThickness, Y = -(height / 2) + botFlangeThickness, Z = 0 };
+            Point q4 = new Point { X = (width / 2) - webThickness, Y = -(height / 2) + botFlangeThickness, Z = 0 };
             Vector wx = new Vector { X = weldLength, Y = 0, Z = 0 };
             Vector wy = new Vector { X = 0, Y = weldLength, Z = 0 };
 
@@ -217,6 +209,12 @@ namespace BH.Engine.Geometry
             welds.Add(new Line { Start = q2 + wx, End = q2 - wy });
             welds.Add(new Line { Start = q3 + wx, End = q3 + wy });
             welds.Add(new Line { Start = q4 - wx, End = q4 + wy });
+
+            List<ICurve> innerBox = new List<ICurve>();
+            innerBox.Add(new Line { Start = q1 - wy, End = q4 + wy });
+            innerBox.Add(new Line { Start = q4 - wx, End = q3 + wx });
+            innerBox.Add(new Line { Start = q3 + wy, End = q2 - wy });
+            innerBox.Add(new Line { Start = q2 + wx, End = q1 - wx });
 
             box.AddRange(innerBox);
             box.AddRange(welds);

--- a/Geometry_Engine/Create/ShapeProfileCurves.cs
+++ b/Geometry_Engine/Create/ShapeProfileCurves.cs
@@ -176,10 +176,11 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static List<ICurve> FabricatedBoxProfileCurves(double width, double height, double webThickness, double topFlangeThickness, double botFlangeThickness)
+        public static List<ICurve> FabricatedBoxProfileCurves(double width, double height, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
             List<ICurve> box = RectangleProfileCurves(width, height, 0);
             List<ICurve> innerBox = RectangleProfileCurves(width - 2 * webThickness, height - (topFlangeThickness + botFlangeThickness), 0);
+            List<ICurve> welds = new List<ICurve>();
             double diff = botFlangeThickness- topFlangeThickness;
 
             if (diff != 0)
@@ -188,7 +189,21 @@ namespace BH.Engine.Geometry
                 innerBox = innerBox.Select(x => Geometry.Modify.ITranslate(x, v)).ToList();
             }
 
+            double weldLength = weldSize * 2 / Math.Sqrt(2);
+            Point q1 = new Point { X = (width / 2) - webThickness, Y = (height / 2) - topFlangeThickness, Z = 0 };
+            Point q2 = new Point { X = -(width / 2) + webThickness, Y = (height / 2) - topFlangeThickness, Z = 0 };
+            Point q3 = new Point { X = -(width / 2) + webThickness, Y = -(height / 2) + topFlangeThickness, Z = 0 };
+            Point q4 = new Point { X = (width / 2) - webThickness, Y = -(height / 2) + topFlangeThickness, Z = 0 };
+            Vector wx = new Vector { X = weldLength, Y = 0, Z = 0 };
+            Vector wy = new Vector { X = 0, Y = weldLength, Z = 0 };
+
+            welds.Add(new Line { Start = q1-wx, End = q1-wy });
+            welds.Add(new Line { Start = q2 + wx, End = q2 - wy });
+            welds.Add(new Line { Start = q3 + wx, End = q3 + wy });
+            welds.Add(new Line { Start = q4 - wx, End = q4 + wy });
+
             box.AddRange(innerBox);
+            box.AddRange(welds);
             return box;
         }
 


### PR DESCRIPTION
 ### Issues addressed by this PR
Closes #1251 

I have added lines for the weldSize parameter. Before it didn't create any curves no matter how much you slid the number slider. 

### Test files
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&e=CJWjNz&cid=0b727f4a%2Daf39%2D4d1d%2D8942%2D0c26c33d7c20&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DPullRequest1277%20weldSize

Test by changing weldSize to larger than 0 and look if a weld is shown in the profile.

### Additional comments
The problem with the weldSize being larger than the geometry allows is addressed by PR #1252