### PR TITLE
Geometry engine: reenable NurbsCurves

### DIFF
--- a/Geometry_Engine/Convert/NurbsForm.cs
+++ b/Geometry_Engine/Convert/NurbsForm.cs
@@ -154,51 +154,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [NotImplemented]
         public static NurbsCurve ToNurbsCurve(this PolyCurve curve)
         {
-            List<Point> cPts = new List<Point>();
-            List<double> knots = new List<double>();
-            List<double> weights = new List<double>();
-            NurbsCurve subNurbCurve = new NurbsCurve();
-            List<ICurve> subCurves = curve.SubParts();
-            Boolean isLine;
-
-            for (int i = subCurves.Count - 1; i >= 0; i--)
-            {
-                subNurbCurve = subCurves[i].IToNurbsCurve();
-                if (subCurves[i] is Arc)
-                    isLine = false;
-                else
-                    isLine = true;
-
-                if (i == subCurves.Count - 1)
-                {
-                    cPts.AddRange(subNurbCurve.ControlPoints);
-                    knots.AddRange(subNurbCurve.Knots);
-                    weights.AddRange(subNurbCurve.Weights);
-                }
-                else
-                {
-                    // Joining based on https://saccade.com/writing/graphics/KnotVectors.pdf (page 7) 
-                    //if (isLine)
-                    //    knots.Insert(0,0);     
-                    for (int j = 0; j < knots.Count; j++)
-                        knots[j] = knots[j] + subNurbCurve.Knots[subNurbCurve.Knots.Count - 1]; // Add the last value in the first curve’s knot vector to all the knots in the second curve.
-                    if (isLine)
-                        knots.RemoveRange(0, 2); // Remove the k first knots from the second curve (k = order) linear -> k = 2
-                    if (!isLine)
-                        knots.RemoveRange(0, 3); // Remove the k first knots from the second curve (k = order) circular -> k = 3
-
-                    subNurbCurve.Knots.RemoveAt(subNurbCurve.Knots.Count - 1); //Remove the last knot from the first curve
-                    knots.InsertRange(0, subNurbCurve.Knots); //Concatenate the second curve’s  knot vector.
-
-                    cPts.RemoveAt(0);
-                    cPts.InsertRange(0, subNurbCurve.ControlPoints);
-                    weights.RemoveAt(0);
-                    weights.InsertRange(0, subNurbCurve.Weights);
-                }
-            }
-            return Create.NurbsCurve(cPts, weights, knots);
+            throw new NotImplementedException();
         }
 
         /***************************************************/

--- a/Geometry_Engine/Create/NurbsCurve.cs
+++ b/Geometry_Engine/Create/NurbsCurve.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -49,11 +49,10 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
-
-        [NotImplemented]
+                
         public static NurbsCurve NurbsCurve(IEnumerable<Point> controlPoints, IEnumerable<double> weights, IEnumerable<double> knots)
         {
-            throw new NotImplementedException();
+            return new NurbsCurve { ControlPoints = controlPoints.ToList(), Knots = knots.ToList(), Weights = weights.ToList() };
         }
 
 

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -102,7 +102,7 @@
     <Compile Include="Create\Face.cs" />
     <Compile Include="Create\Polyline.cs" />
     <Compile Include="Create\PolyCurve.cs" />
-    <Compile Include="Create\NurbCurve.cs" />
+    <Compile Include="Create\NurbsCurve.cs" />
     <Compile Include="Create\Line.cs" />
     <Compile Include="Create\Ellipse.cs" />
     <Compile Include="Create\IntegrationSlice.cs" />

--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -98,7 +98,7 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
-                
+
         public static NurbsCurve Rotate(this NurbsCurve curve, Point origin, Vector axis, double rad)
         {
             TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);
@@ -204,7 +204,7 @@ namespace BH.Engine.Geometry
 
         public static ICurve IRotate(this ICurve geometry, Point origin, Vector axis, double rad)
         {
-            return Rotate(geometry as dynamic, origin,axis, rad);
+            return Rotate(geometry as dynamic, origin, axis, rad);
         }
 
         /***************************************************/
@@ -213,5 +213,7 @@ namespace BH.Engine.Geometry
         {
             return Rotate(geometry as dynamic, rad, axis);
         }
+
+        /***************************************************/
     }
 }

--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -98,11 +98,11 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
-
-        [NotImplemented]
+                
         public static NurbsCurve Rotate(this NurbsCurve curve, Point origin, Vector axis, double rad)
         {
-            throw new NotImplementedException();
+            TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);
+            return Transform(curve, rotationMatrix);
         }
 
 

--- a/Geometry_Engine/Modify/Scale.cs
+++ b/Geometry_Engine/Modify/Scale.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/Geometry_Engine/Modify/Scale.cs
+++ b/Geometry_Engine/Modify/Scale.cs
@@ -92,10 +92,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static NurbsCurve Scale(this NurbsCurve curve, Point origin, Vector scaleVector)
         {
-            throw new NotImplementedException();
+            TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
+            return Transform(curve, scaleMatrix);
         }
 
 

--- a/Geometry_Engine/Modify/Transform.cs
+++ b/Geometry_Engine/Modify/Transform.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -149,12 +149,15 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static NurbsCurve Transform(this NurbsCurve curve, TransformMatrix transform)
         {
-            throw new NotImplementedException();
+            return new NurbsCurve()
+            {
+                ControlPoints = curve.ControlPoints.Select(cp => cp.Transform(transform)).ToList(),
+                Weights = curve.Weights,
+                Knots = curve.Knots
+            };
         }
-
 
         /***************************************************/
 

--- a/Geometry_Engine/Modify/Translate.cs
+++ b/Geometry_Engine/Modify/Translate.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/Geometry_Engine/Modify/Translate.cs
+++ b/Geometry_Engine/Modify/Translate.cs
@@ -99,10 +99,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static NurbsCurve Translate(this NurbsCurve curve, Vector transform)
         {
-            throw new NotImplementedException();
+            TransformMatrix translationMatrix = Create.TranslationMatrix(transform);
+            return Transform(curve, translationMatrix);
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #764 
Closes #960 
Closes #1148 

<!-- Add short description of what has been fixed -->
- Re-enabling conversions of basic geometry into NurbsCurves, heavily inspired by what was disabled in [that commit](
https://github.com/BHoM/BHoM_Engine/commit/ee1643f3403cefb97fe2f845e541d224e7c1ffd0#diff-4d3e0b17ced26bb9f91e2f284a923b9c). Did not implement `ToNurbsCurve(PolyCurve)` as it's hard to implement and not very needed.
- Implementing scaling, rotating and translating (orienting wasn't needed thanks to generics method) for NurbsCurves.
- Implementing Transform for NurbsCurves.
- Changing file name from `NurbCurve` to `NurbsCurve` and implemeting basic creation method.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Click](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%20%231148%20ReenableNurbsCurves)
Tried to cover as much as possible without redundancy. First is test of randomly transforming random NurbsCurves. Then tests of converting Lines and Polylines into NurbsCurves. Last four are of Arcs, Circles and Ellipses being converted into nurbs and then Scaled, Translated, Rotated and Oriented (what includes test of conversion).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Convert.NurbsForms()` public methods implemented in the `Geometry_Engine` for `Arc`, `Circle`, `Ellipse`, `Line`, `NurbsCurve`, `Polyline` and `ICurve` classes.
- `NurbCurve.cs` file renamed to `NurbsCurve.cs`.
- `Create.NurbsCurve()` method implemented in the `Geometry_Engine`.
- `Modify.Rotate()` public method implemented in the `Geometry_Engine` for `NurbsCurve` class.
- `Modify.Scale()` public method implemented in the `Geometry_Engine` for `NurbsCurve` class.
- `Modify.Translate()` public method implemented in the `Geometry_Engine` for `NurbsCurve` class.
- `Modify.Transform()` public method implemented in the `Geometry_Engine` for `NurbsCurve` class.
### Additional comments
<!-- As required -->