### PR TITLE
BHoM_Engine: Added `FindFragmentsInheriting(Type t)` that returns all Fragments that inherit from a parent type

### DIFF
--- a/BHoM_Engine/Query/FindFragment.cs
+++ b/BHoM_Engine/Query/FindFragment.cs
@@ -69,5 +69,17 @@ namespace BH.Engine.Base
             fragment = default(IBHoMFragment);
             return false;
         }
+
+
+        [Description("Returns an enumerable with all Fragments of a type that inherits from the specified parentType.")]
+        [Input("iBHoMObject", "A generic IBHoMObject object")]
+        [Input("parentType", "The parent type of fragment. All fragments of a type that inherits from this type will be returned.")]
+        [Output("fragments", "All fragments of a type that inherits from parentType.")]
+        public static IEnumerable<T> FindFragmentsInheriting<T>(this IBHoMObject iBHoMObject, Type parentType)
+        {
+            var allFragms = iBHoMObject.Fragments.Where(f => parentType.IsAssignableFrom(f.GetType()));
+
+            return allFragms.Select(f => (T)System.Convert.ChangeType(f, parentType));
+        }
     }
 }

--- a/BHoM_Engine/Query/FindFragment.cs
+++ b/BHoM_Engine/Query/FindFragment.cs
@@ -73,13 +73,11 @@ namespace BH.Engine.Base
 
         [Description("Returns an enumerable with all Fragments of a type that inherits from the specified parentType.")]
         [Input("iBHoMObject", "A generic IBHoMObject object")]
-        [Input("parentType", "The parent type of fragment. All fragments of a type that inherits from this type will be returned.")]
+        [Input("parentFragmentType", "The parent fragment type. All fragments of a type that inherits from this type will be returned.")]
         [Output("fragments", "All fragments of a type that inherits from parentType.")]
-        public static IEnumerable<T> FindFragmentsInheriting<T>(this IBHoMObject iBHoMObject, Type parentType)
+        public static IEnumerable<object> FindFragmentsInheriting(this IBHoMObject iBHoMObject, Type parentFragmentType)
         {
-            var allFragms = iBHoMObject.Fragments.Where(f => parentType.IsAssignableFrom(f.GetType()));
-
-            return allFragms.Select(f => (T)System.Convert.ChangeType(f, parentType));
+            return iBHoMObject.Fragments.Where(f => parentFragmentType.IsAssignableFrom(f.GetType()));
         }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1282 

Essentially, `FragmentSet` allows you to store only one type of Fragment in the FragmentSet. However, that rightly does not prevent you from storing different Fragment types that inherit from a common parent type or interface.

`FindFragmentsInheriting(Type t)` allows you to query out all Fragments that inherit from a parent fragment type.

<!-- Add short description of what has been fixed -->
