### PR TITLE
Geometry_Engine: Create.Ellipse() unnormalised axes bug

### DIFF
--- a/Geometry_Engine/Create/Ellipse.cs
+++ b/Geometry_Engine/Create/Ellipse.cs
@@ -46,11 +46,14 @@ namespace BH.Engine.Geometry
 
         public static Ellipse Ellipse(Point centre, Vector axis1, Vector axis2, double radius1, double radius2)
         {
+            if (Math.Abs(axis1.DotProduct(axis2) - 1) > Tolerance.Angle)
+                Reflection.Compute.RecordWarning("Axis1 and axis2 are not orthogonal. Result may be wrong.");
+
             return new Ellipse
             {
                 Centre = centre,
-                Axis1 = axis1,
-                Axis2 = axis2,
+                Axis1 = axis1.Normalise(),
+                Axis2 = axis2.Normalise(),
                 Radius1 = radius1,
                 Radius2 = radius2
             };

--- a/Geometry_Engine/Create/Ellipse.cs
+++ b/Geometry_Engine/Create/Ellipse.cs
@@ -46,7 +46,7 @@ namespace BH.Engine.Geometry
 
         public static Ellipse Ellipse(Point centre, Vector axis1, Vector axis2, double radius1, double radius2)
         {
-            if (Math.Abs(axis1.DotProduct(axis2) - 1) > Tolerance.Angle)
+            if (Math.Abs(axis1.DotProduct(axis2)) > Tolerance.Angle)
                 Reflection.Compute.RecordWarning("Axis1 and axis2 are not orthogonal. Result may be wrong.");
 
             return new Ellipse


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1287 

<!-- Add short description of what has been fixed -->
Create.Ellipse was taking any input axes. Now the vectors are being normalised to prevent errors during further manipulations. Also a check if they are orthogonal is added.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Test file](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%20%231287%20CreateEllipseNoramliseAxesBug) from the issue is enough.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Create.Ellipse()` public method was updated in `Geometry.Engine()`

### Additional comments
<!-- As required -->