### PR TITLE
Geometry_Engine: Remove Degrees() method for NurbsSurface

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Query\IsCoplanar.cs" />
     <Compile Include="Query\IsLinear.cs" />
     <Compile Include="Query\IsOnCurve.cs" />
+    <Compile Include="Query\IsPeriodic.cs" />
     <Compile Include="Query\IsPlanar.cs" />
     <Compile Include="Query\IsPolylinear.cs" />
     <Compile Include="Query\IsQuad.cs" />

--- a/Geometry_Engine/Query/Degree.cs
+++ b/Geometry_Engine/Query/Degree.cs
@@ -37,18 +37,5 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
-
-        public static List<int> Degrees(this NurbsSurface surf)
-        {
-            int uDegree = 1;
-            int vDegree = 1;
-            while (surf.UKnots[uDegree - 1] == surf.UKnots[uDegree])
-                uDegree++;
-            while (surf.VKnots[vDegree - 1] == surf.VKnots[vDegree])
-                vDegree++;
-            return new List<int>() { uDegree, vDegree };
-        }
-
-        /***************************************************/
     }
 }

--- a/Geometry_Engine/Query/IsClosed.cs
+++ b/Geometry_Engine/Query/IsClosed.cs
@@ -110,6 +110,43 @@ namespace BH.Engine.Geometry
             return IsClosed(curve as dynamic, tolerance);
         }
 
+
+        /***************************************************/
+        /**** Public Methods - Nurbs Surfaces           ****/
+        /***************************************************/
+
+        public static bool IsClosed(this NurbsSurface surface, double tolerance = Tolerance.Distance)
+        {
+            bool result = true;
+            double sqTolerance = tolerance * tolerance;
+            List<int> uvCount = surface.UVCount();
+            int pointCount = surface.ControlPoints.Count;
+            for (int i = 0; i < uvCount[1]; i++)
+            {
+                if (surface.ControlPoints[i].SquareDistance(surface.ControlPoints[pointCount - uvCount[1] + i]) > sqTolerance)
+                {
+                    result = false;
+                    break;
+                }
+            }
+
+            if (result == true)
+                return result;
+
+            result = true;
+            for (int i = 0; i < uvCount[0]; i++)
+            {
+                if (surface.ControlPoints[i * uvCount[1]].SquareDistance(surface.ControlPoints[(i + 1) * uvCount[1] - 1]) > sqTolerance)
+                {
+                    result = false;
+                    break;
+                }
+            }
+
+            return result;
+
+        }
+
         /***************************************************/
     }
 }

--- a/Geometry_Engine/Query/IsClosed.cs
+++ b/Geometry_Engine/Query/IsClosed.cs
@@ -117,34 +117,10 @@ namespace BH.Engine.Geometry
 
         public static bool IsClosed(this NurbsSurface surface, double tolerance = Tolerance.Distance)
         {
-            bool result = true;
             double sqTolerance = tolerance * tolerance;
             List<int> uvCount = surface.UVCount();
-            int pointCount = surface.ControlPoints.Count;
-            for (int i = 0; i < uvCount[1]; i++)
-            {
-                if (surface.ControlPoints[i].SquareDistance(surface.ControlPoints[pointCount - uvCount[1] + i]) > sqTolerance)
-                {
-                    result = false;
-                    break;
-                }
-            }
-
-            if (result == true)
-                return result;
-
-            result = true;
-            for (int i = 0; i < uvCount[0]; i++)
-            {
-                if (surface.ControlPoints[i * uvCount[1]].SquareDistance(surface.ControlPoints[(i + 1) * uvCount[1] - 1]) > sqTolerance)
-                {
-                    result = false;
-                    break;
-                }
-            }
-
-            return result;
-
+            return Enumerable.Range(0, uvCount[1]).All(i => surface.ControlPoints[i].SquareDistance(surface.ControlPoints[surface.ControlPoints.Count - uvCount[1] + i]) <= sqTolerance)
+                || Enumerable.Range(0, uvCount[0]).All(i => surface.ControlPoints[i * uvCount[1]].SquareDistance(surface.ControlPoints[(i + 1) * uvCount[1] - 1]) <= sqTolerance);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/IsPeriodic.cs
+++ b/Geometry_Engine/Query/IsPeriodic.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using BH.oM.Geometry;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static bool IsPeriodic(this NurbsSurface surface)
+        {
+            int uMultiplicity = 1;
+            int vMultiplicity = 1;
+
+            while (surface.UKnots[uMultiplicity - 1] == surface.UKnots[uMultiplicity])
+                uMultiplicity++;
+            while (surface.VKnots[vMultiplicity - 1] == surface.VKnots[vMultiplicity])
+                vMultiplicity++;
+
+            return (uMultiplicity != surface.UDegree || vMultiplicity != surface.VDegree);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Geometry_Engine/Query/UVCount.cs
+++ b/Geometry_Engine/Query/UVCount.cs
@@ -33,8 +33,7 @@ namespace BH.Engine.Geometry
 
         public static List<int> UVCount(this NurbsSurface surf)
         {
-            List<int> degrees = surf.Degrees();
-            return new List<int> { surf.UKnots.Count - degrees[0] + 1, surf.VKnots.Count - degrees[1] + 1 };
+            return new List<int> { surf.UKnots.Count - surf.UDegree + 1, surf.VKnots.Count - surf.VDegree + 1 };
         }
 
         /***************************************************/


### PR DESCRIPTION
### !!! PLEASE DO NOT MERGE !!! ###

### NOTE: Depends on 
[#603](https://github.com/BHoM/BHoM/pull/603)

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1297 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Test file is located on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%2FGeometry%5FoM%2DIssue425%2DCreationOfTrimmedNurbsSurfaceDefinition). To run it, please switch to the branches related to the following PRs:
- [#603 ](https://github.com/BHoM/BHoM/pull/603)
- [#1298](https://github.com/BHoM/BHoM_Engine/pull/1298)
- [#120](https://github.com/BHoM/Rhinoceros_Toolkit/pull/120)
- [#431](https://github.com/BHoM/Grasshopper_Toolkit/pull/431)

The error in the test file is caused by the bug in Cone convert logged [here](https://github.com/BHoM/Rhinoceros_Toolkit/issues/121).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.Geometry.Query.Degrees(this NurbsSurface surf)` has been removed.

### Additional comments
Please see [#603](https://github.com/BHoM/BHoM/pull/603).
The PR should not conflict with #1283 as there is no overlap.