### PR TITLE
Diffing_Engine: Remove reference to Testing oM

### DIFF
--- a/Diffing_Engine/Diffing_Engine.csproj
+++ b/Diffing_Engine/Diffing_Engine.csproj
@@ -81,10 +81,6 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="Testing_oM">
-      <HintPath>..\..\BHoM\Build\Testing_oM.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Compute\Diffing.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #1299


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
If you take a look for the CI checks on BHoM UI that @adecler ran this morning, you'll find this snippet:
![image](https://user-images.githubusercontent.com/18049174/68186103-33779700-ff9b-11e9-86ce-dfbc2df40729.png)

This PR aims to remove that warning.