### PR TITLE
Geometry_Engine: Add fallback cases and support for Basis in Clone.cs

### DIFF
--- a/Geometry_Engine/Query/Clone.cs
+++ b/Geometry_Engine/Query/Clone.cs
@@ -192,6 +192,36 @@ namespace BH.Engine.Geometry
             return new TransformMatrix { Matrix = transform.Matrix };
         }
 
+        /***************************************************/
+
+        public static Basis Clone(this Basis basis)
+        {
+            return new Basis(basis.X, basis.Y, basis.Z);
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static object Clone(this object geometry)
+        {
+            return geometry;
+        }
+
+        /***************************************************/
+
+        private static ICurve Clone(this ICurve geometry)
+        {
+            return geometry;
+        }
+
+        /***************************************************/
+
+        private static ISurface Clone(this ISurface geometry)
+        {
+            return geometry;
+        }
 
         /***************************************************/
         /**** Public Methods - Interfaces               ****/


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1307 


### Test files
<!-- Link to test files to validate the proposed changes -->
![image](https://user-images.githubusercontent.com/16853390/68354473-71192300-0147-11ea-8b1a-0d4ea0d16087.png)


### Additional comments
- This was actually highlighted when trying to add default value for each input of the new `CreateObject` component (see https://github.com/BHoM/BHoM_UI/pull/152)
- I suppose it might be worth checking if other geometry methods are missing support for `Basis` and fallback method. Something to fix in another PR though as this one is purely to make sure the UI PR is not held up because of this.