### PR TITLE
Environment_Engine: fix NormalAwayFromSpace bug  

### DIFF
--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -85,18 +85,7 @@ namespace BH.Engine.Environment
         {
             List<Plane> planes = new List<Plane>();
             foreach (Panel be in panels)
-            {
-                Plane p = be.Polyline().IControlPoints().FitPlane();
-                if (!be.Polyline().IsInPlane(p))
-                {
-                    //Create a different plane...
-                    List<Point> pnts = be.Polyline().IDiscontinuityPoints();
-                    if (pnts.Count >= 3)
-                        p = BH.Engine.Geometry.Create.Plane(pnts[0], pnts[1], pnts[2]);
-                }
-
-                planes.Add(p);
-            }
+                planes.Add(be.Polyline().IControlPoints().FitPlane());
 
             List<Point> ctrPoints = panels.SelectMany(x => x.Polyline().IControlPoints()).ToList();
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1217 

<!-- Add short description of what has been fixed -->
Fixes bug on NormalAwayFromSpace which returned "false" even though the the Normal was away from space. Now it returns "true". 

### Test files
See issue 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->