### PR TITLE
Geometry engine: add Offset and Extend methods

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Modify\SetGeometry.cs" />
     <Compile Include="Modify\Simplify.cs" />
     <Compile Include="Modify\Extend.cs" />
+    <Compile Include="Modify\Offset.cs" />
     <Compile Include="Modify\Join.cs" />
     <Compile Include="Modify\ProjectAlong.cs" />
     <Compile Include="Modify\Reverse.cs" />

--- a/Geometry_Engine/Modify/Extend.cs
+++ b/Geometry_Engine/Modify/Extend.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -21,6 +21,11 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Geometry.CoordinateSystem;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Engine.Geometry
@@ -28,13 +33,339 @@ namespace BH.Engine.Geometry
     public static partial class Modify
     {
         /***************************************************/
-        /**** Public Methods - Curves                   ****/
+        /**** Public Methods - Curves                  ****/
         /***************************************************/
 
+        [DeprecatedAttribute("2.4", "Replaced with method taking more arguments", null, "Extend")]
         public static Line Extend(this Line curve, double start = 0.0, double end = 0.0)
         {
+            return curve.Extend(start, end, false, Tolerance.Distance);
+        }
+
+        /***************************************************/
+
+        [Description("Extends curve by given lengths")]
+        [Input("curve", "Curve to extend")]
+        [Input("start", "Length of extension on the begining of a curve. Negative value will trim the curve")]
+        [Input("end", "Length of extension on the end of a curve. Negative value will trim the curve")]
+        [Input("tangentExtensions", "True - extends on tangent lines\nFalse - extends by curve's shape")]
+        [Output("curve", "Extended curve")]
+        public static Line Extend(this Line curve, double start = 0.0, double end = 0.0, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            if (start + end + curve.Length() < tolerance)
+            {
+                Reflection.Compute.RecordError("Extend values too small");
+                return null;
+            }
             Vector dir = curve.Direction();
             return new Line { Start = curve.Start - dir * start, End = curve.End + dir * end };
+        }
+
+        /***************************************************/
+
+        [Description("Extends curve by given lengths")]
+        [Input("curve", "Curve to extend")]
+        [Input("start", "Length of extension on the begining of a curve. Negative value will trim the curve")]
+        [Input("end", "Length of extension on the end of a curve. Negative value will trim the curve")]
+        [Input("tangentExtensions", "True - extends on tangent lines\nFalse - extends by curve's shape")]
+        [Output("curve", "Extended curve")]
+        public static ICurve Extend(this Arc curve, double start = 0.0, double end = 0.0, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            if (tangentExtensions)
+                return curve.ExtendTangent(start, end, tolerance);
+
+            if (curve.StartAngle != 0)
+            {
+                curve.CoordinateSystem = curve.CoordinateSystem.Rotate(curve.CoordinateSystem.Origin, curve.CoordinateSystem.Z, curve.StartAngle);
+                curve.EndAngle = -curve.StartAngle;
+                curve.StartAngle = 0;
+            }
+
+            double startAngleExt = start / curve.Radius;
+            double endAngleExt = end / curve.Radius;
+
+            if (startAngleExt + endAngleExt + curve.EndAngle < tolerance)
+            {
+                Reflection.Compute.RecordError("Negative extend values are smaller than curve length.");
+                return null;
+            }
+            if (startAngleExt + endAngleExt + curve.EndAngle - (2 * Math.PI) > tolerance)
+            {
+                Reflection.Compute.RecordError("Extension values to great.");
+                return null;
+            }
+            Cartesian oldCS = curve.CoordinateSystem;
+            Cartesian newCS = oldCS.Rotate(oldCS.Origin, oldCS.Z, -startAngleExt);
+
+            return new Arc
+            {
+                CoordinateSystem = newCS,
+                Radius = curve.Radius,
+                StartAngle = 0,
+                EndAngle = curve.EndAngle + startAngleExt + endAngleExt
+
+            };
+        }
+
+        /***************************************************/
+
+        [Description("Extends curve by given lengths")]
+        [Input("curve", "Curve to extend")]
+        [Input("start", "Length of extension on the begining of a curve. Negative value will trim the curve")]
+        [Input("end", "Length of extension on the end of a curve. Negative value will trim the curve")]
+        [Input("tangentExtensions", "True - extends on tangent lines\nFalse - extends by curve's shape")]
+        [Output("curve", "Extended curve")]
+        public static Circle Extend(this Circle curve, double start = 0.0, double end = 0.0, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            Reflection.Compute.RecordNote("Cannot Trim or Extend closed curves.");
+            return curve;
+        }
+
+        /***************************************************/
+
+        [Description("Extends curve by given lengths")]
+        [Input("curve", "Curve to extend")]
+        [Input("start", "Length of extension on the begining of a curve. Negative value will trim the curve")]
+        [Input("end", "Length of extension on the end of a curve. Negative value will trim the curve")]
+        [Input("tangentExtensions", "True - extends on tangent lines\nFalse - extends by curve's shape")]
+        [Output("curve", "Extended curve")]
+        public static Ellipse Extend(this Ellipse curve, double start = 0.0, double end = 0.0, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            Reflection.Compute.RecordNote("Cannot Trim or Extend closed curves.");
+            return curve;
+        }
+
+        /***************************************************/
+
+        [NotImplemented]
+        public static NurbsCurve Extend(this NurbsCurve curve, double start = 0.0, double end = 0.0, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            throw new NotImplementedException();
+        }
+
+        /***************************************************/
+
+        [Description("Extends curve by given lengths")]
+        [Input("curve", "Curve to extend")]
+        [Input("start", "Length of extension on the begining of a curve. Negative value will trim the curve")]
+        [Input("end", "Length of extension on the end of a curve. Negative value will trim the curve")]
+        [Input("tangentExtensions", "True - extends on tangent lines\nFalse - extends by curve's shape")]
+        [Output("curve", "Extended curve")]
+        public static Polyline Extend(this Polyline curve, double start = 0.0, double end = 0.0, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            if (curve.IsClosed(tolerance))
+            {
+                Reflection.Compute.RecordNote("Cannot Trim or Extend closed curves.");
+                return curve;
+            }
+
+            if (start + end + curve.Length() < tolerance)
+            {
+                Reflection.Compute.RecordError("Negative extend values are smaller than curve length.");
+                return null;
+            }
+
+            Polyline result = new Polyline();
+            List<Line> lines = curve.SubParts();
+
+            if (start < 0 && -start > lines[0].ILength())
+            {
+                double startCut = -lines[0].ILength();
+                while (startCut > start && lines.Count > 1)
+                {
+                    lines.RemoveAt(0);
+                    startCut -= lines[0].ILength();
+                }
+                startCut += lines[0].ILength();
+                if (lines.Count > 1)
+                    lines[0] = lines[0].Extend(start - startCut, 0, false, tolerance);
+                else
+                {
+                    lines[0] = lines[0].Extend(start - startCut, end, tangentExtensions, tolerance);
+                    result = Create.Polyline(lines);
+                    return result;
+                }
+            }
+            else
+                lines[0] = lines[0].Extend(start, 0, tangentExtensions, tolerance);
+
+            if (end < 0 && -end > lines[lines.Count - 1].ILength())
+            {
+                double endCut = -lines[lines.Count - 1].ILength();
+                while (endCut > end)
+                {
+                    lines.RemoveAt(lines.Count - 1);
+                    endCut -= lines[lines.Count - 1].ILength();
+                }
+                endCut += lines[lines.Count - 1].ILength();
+                lines[lines.Count - 1] = lines[lines.Count - 1].Extend(0, end - endCut, tangentExtensions, tolerance);
+            }
+            else
+                lines[lines.Count - 1] = lines[lines.Count - 1].Extend(0, end, tangentExtensions, tolerance);
+
+            result = Create.Polyline(lines);
+            return result;
+        }
+
+        /***************************************************/
+        
+        [Description("Extends curve by given lengths")]
+        [Input("curve", "Curve to extend")]
+        [Input("start", "Length of extension on the begining of a curve. Negative value will trim the curve")]
+        [Input("end", "Length of extension on the end of a curve. Negative value will trim the curve")]
+        [Input("tangentExtensions", "True - extends on tangent lines\nFalse - extends by curve's shape")]
+        [Output("curve", "Extended curve")]
+        public static PolyCurve Extend(this PolyCurve curve, double start = 0.0, double end = 0.0, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            if (tangentExtensions)
+                return curve.ExtendTangent(start, end, tolerance);
+
+            if (curve.IsClosed(tolerance))
+            {
+                Reflection.Compute.RecordNote("Cannot Trim or Extend closed curves.");
+                return curve;
+            }
+
+            if (start + end + curve.Length() < tolerance)
+            {
+                Reflection.Compute.RecordError("Negative extend values are smaller than curve length.");
+                return null;
+            }
+
+            List<ICurve> curves = curve.SubParts();
+            if (start < 0 && -start > curves[0].ILength())
+            {
+                double startCut = -curves[0].ILength();
+                while (startCut > start && curves.Count > 1)
+                {
+                    curves.RemoveAt(0);
+                    startCut -= curves[0].ILength();
+                }
+                startCut += curves[0].ILength();
+                if (curves.Count > 1)
+                    curves[0] = curves[0].IExtend(start - startCut, 0, tangentExtensions, tolerance);
+                else
+                {
+                    curves[0] = curves[0].IExtend(start - startCut, end, tangentExtensions, tolerance);
+                    return new PolyCurve { Curves = curves };
+                }
+            }
+            else
+                curves[0] = curves[0].IExtend(start, 0, tangentExtensions, tolerance);
+
+            if (end < 0 && -end > curves[curves.Count - 1].ILength())
+            {
+                double endCut = -curves[curves.Count - 1].ILength();
+                while (endCut > end)
+                {
+                    curves.RemoveAt(curves.Count - 1);
+                    endCut -= curves[curves.Count - 1].ILength();
+                }
+                endCut += curves[curves.Count - 1].ILength();
+                curves[curves.Count - 1] = curves[curves.Count - 1].IExtend(0, end - endCut, tangentExtensions, tolerance);
+            }
+            else
+                curves[curves.Count - 1] = curves[curves.Count - 1].IExtend(0, end, tangentExtensions, tolerance);
+
+            return new PolyCurve { Curves = curves };
+        }
+
+        /***************************************************/
+
+        [Description("Extends curve by given lengths")]
+        [Input("curve", "Curve to extend")]
+        [Input("start", "Length of extension on the begining of a curve. Negative value will trim the curve")]
+        [Input("end", "Length of extension on the end of a curve. Negative value will trim the curve")]
+        [Input("tangentExtensions", "True - extends on tangent lines\nFalse - extends by curve's shape")]
+        [Output("curve", "Extended curve")]
+        public static ICurve IExtend(this ICurve curve, double start = 0.0, double end = 0.0, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            return Extend(curve as dynamic, start, end, tangentExtensions, tolerance);
+        }
+
+
+        /***************************************************/
+        /***   Private Methods - tangent extensions      ***/
+        /***************************************************/
+
+        private static ICurve ExtendTangent(this Arc curve, double start = 0.0, double end = 0.0, double tolerance = Tolerance.Distance)
+        {
+            if (-start > curve.Length() || -end > curve.Length()) //ExtendTangent allows to trim the curve but only to the limit of it's length. 
+            {
+                Reflection.Compute.RecordError("Extension value to small");
+                return null;
+            }
+            if (start < 0 && end < 0)
+                return curve.Extend(start, end, false, tolerance);
+
+            PolyCurve polyCurve = new PolyCurve();
+
+            if (start < 0 && !(end < 0))
+            {
+                ICurve iCurve = curve.Extend(start, 0, false, tolerance);
+                return iCurve.IExtend(0, end, true, tolerance);
+            }
+
+            if (!(start < 0) && end < 0)
+            {
+                ICurve iCurve = curve.Extend(0, end, false, tolerance);
+                return iCurve.IExtend(start, 0, true, tolerance);
+            }
+
+            Point stPt = curve.StartPoint();
+            Point enPt = curve.EndPoint();
+            Vector startTan = curve.TangentAtParameter(0);
+            Vector endTan = curve.TangentAtParameter(1);
+            List<ICurve> resultList = new List<ICurve>();
+
+            if (start != 0)
+                resultList.Add(new Line { Start = stPt - startTan * start, End = stPt, Infinite = false });
+
+            resultList.Add(curve);
+
+            if (end != 0)
+                resultList.Add(new Line { Start = enPt, End = enPt + endTan * end, Infinite = false });
+
+            if (resultList.Count == 1)
+                return resultList[0];
+            else
+                return new PolyCurve { Curves = resultList };
+        }
+
+        /***************************************************/
+
+        private static PolyCurve ExtendTangent(this PolyCurve curve, double start = 0.0, double end = 0.0, double tolerance = Tolerance.Distance)
+        {
+            if (-start > curve.Length() || -end > curve.Length()) //ExtendTangent allows to trim the curve but only to the limit of it's length. 
+            {
+                Reflection.Compute.RecordError("Extension value to small");
+                return null;
+            }
+
+            if (start < 0 && end < 0)
+                return curve.Extend(start, end, false, tolerance);
+
+            if (start < 0 && !(end < 0))
+            {
+                curve = curve.Extend(start, 0, false, tolerance);
+                return curve.ExtendTangent(0, end, tolerance);
+            }
+
+            if (!(start < 0) && end < 0)
+            {
+                curve = curve.Extend(0, end, false, tolerance);
+                return curve.ExtendTangent(start, 0, tolerance);
+            }
+
+            List<ICurve> curves = curve.SubParts();
+            if (curves.Count == 1)
+                return new PolyCurve { Curves = curves[0].IExtend(start, end, true, tolerance).ISubParts().ToList() };
+            else
+            {
+                curves[0] = curves[0].IExtend(start, 0, true, tolerance);
+                curves[curves.Count - 1] = curves[curves.Count - 1].IExtend(0, end, true, tolerance);
+                return new PolyCurve { Curves = curves };
+            }
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Extend.cs
+++ b/Geometry_Engine/Modify/Extend.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                  ****/
         /***************************************************/
 
-        [DeprecatedAttribute("2.4", "Replaced with method taking more arguments", null, "Extend")]
+        [DeprecatedAttribute("2.4", "Replaced with a method taking more arguments", null, "Extend")]
         public static Line Extend(this Line curve, double start = 0.0, double end = 0.0)
         {
             return curve.Extend(start, end, false, Tolerance.Distance);
@@ -103,7 +103,6 @@ namespace BH.Engine.Geometry
                 Radius = curve.Radius,
                 StartAngle = 0,
                 EndAngle = curve.EndAngle + startAngleExt + endAngleExt
-
             };
         }
 
@@ -208,7 +207,7 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
-        
+
         [Description("Extends curve by given lengths")]
         [Input("curve", "Curve to extend")]
         [Input("start", "Length of extension on the begining of a curve. Negative value will trim the curve")]
@@ -270,6 +269,9 @@ namespace BH.Engine.Geometry
             return new PolyCurve { Curves = curves };
         }
 
+
+        /***************************************************/
+        /***   Public Methods - Interfaces               ***/
         /***************************************************/
 
         [Description("Extends curve by given lengths")]
@@ -285,7 +287,7 @@ namespace BH.Engine.Geometry
 
 
         /***************************************************/
-        /***   Private Methods - tangent extensions      ***/
+        /***   Private Methods - Tangent extensions      ***/
         /***************************************************/
 
         private static ICurve ExtendTangent(this Arc curve, double start = 0.0, double end = 0.0, double tolerance = Tolerance.Distance)

--- a/Geometry_Engine/Modify/Extend.cs
+++ b/Geometry_Engine/Modify/Extend.cs
@@ -57,7 +57,7 @@ namespace BH.Engine.Geometry
                 Reflection.Compute.RecordError("Extend values too small");
                 return null;
             }
-            Vector dir = curve.Direction();
+            Vector dir = curve.Direction(tolerance);
             return new Line { Start = curve.Start - dir * start, End = curve.End + dir * end };
         }
 
@@ -89,6 +89,7 @@ namespace BH.Engine.Geometry
                 Reflection.Compute.RecordError("Negative extend values are smaller than curve length.");
                 return null;
             }
+
             if (startAngleExt + endAngleExt + curve.EndAngle - (2 * Math.PI) > tolerance)
             {
                 Reflection.Compute.RecordError("Extension values to great.");
@@ -170,12 +171,15 @@ namespace BH.Engine.Geometry
             if (start < 0 && -start > lines[0].ILength())
             {
                 double startCut = -lines[0].ILength();
+
                 while (startCut > start && lines.Count > 1)
                 {
                     lines.RemoveAt(0);
                     startCut -= lines[0].ILength();
                 }
+
                 startCut += lines[0].ILength();
+
                 if (lines.Count > 1)
                     lines[0] = lines[0].Extend(start - startCut, 0, false, tolerance);
                 else
@@ -240,7 +244,9 @@ namespace BH.Engine.Geometry
                     curves.RemoveAt(0);
                     startCut -= curves[0].ILength();
                 }
+
                 startCut += curves[0].ILength();
+
                 if (curves.Count > 1)
                     curves[0] = curves[0].IExtend(start - startCut, 0, tangentExtensions, tolerance);
                 else
@@ -294,9 +300,10 @@ namespace BH.Engine.Geometry
         {
             if (-start > curve.Length() || -end > curve.Length()) //ExtendTangent allows to trim the curve but only to the limit of it's length. 
             {
-                Reflection.Compute.RecordError("Extension value to small");
+                Reflection.Compute.RecordError("Extension value too small");
                 return null;
             }
+
             if (start < 0 && end < 0)
                 return curve.Extend(start, end, false, tolerance);
 
@@ -316,8 +323,8 @@ namespace BH.Engine.Geometry
 
             Point stPt = curve.StartPoint();
             Point enPt = curve.EndPoint();
-            Vector startTan = curve.TangentAtParameter(0);
-            Vector endTan = curve.TangentAtParameter(1);
+            Vector startTan = curve.TangentAtParameter(0, tolerance);
+            Vector endTan = curve.TangentAtParameter(1, tolerance);
             List<ICurve> resultList = new List<ICurve>();
 
             if (start != 0)
@@ -340,7 +347,7 @@ namespace BH.Engine.Geometry
         {
             if (-start > curve.Length() || -end > curve.Length()) //ExtendTangent allows to trim the curve but only to the limit of it's length. 
             {
-                Reflection.Compute.RecordError("Extension value to small");
+                Reflection.Compute.RecordError("Extension value too small");
                 return null;
             }
 

--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -126,6 +126,22 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [NotImplemented]
+        public static Ellipse Offset(this Ellipse curve, double offset, Vector normal = null, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            throw new NotImplementedException();
+        }
+
+        /***************************************************/
+
+        [NotImplemented]
+        public static NurbsCurve Offset(this NurbsCurve curve, double offset, Vector normal = null, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            throw new NotImplementedException();
+        }
+
+        /***************************************************/
+
         [Description("Creates an offset of a curve. Works only on planar curves")]
         [Input("curve", "Curve to offset")]
         [Input("distance", "Offset distance. Positive value offsets outside of a curve. If normal is given then offsets to the right with normal pointing up and direction of a curve pointing forward")]
@@ -498,7 +514,7 @@ namespace BH.Engine.Geometry
         /***         Private Methods                     ***/
         /***************************************************/
 
-        private static List<ICurve> TrimExtendToPoint(this ICurve curve, Point startPoint, Point endPoint, bool tangentExtension, double tolerance)
+        private static List<ICurve> ExtendToPoint(this ICurve curve, Point startPoint, Point endPoint, bool tangentExtension, double tolerance)
         {
             //TODO:
             //Decide if useful enough to make public. If so, rewrite and test.
@@ -597,26 +613,26 @@ namespace BH.Engine.Geometry
 
                 if (C1SP && C2SP)
                 {
-                    resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
-                    resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
                     resultCurves[1] = resultCurves[1].IFlip();
                 }
                 else if (C1SP && !C2SP)
                 {
-                    resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
-                    resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
                 }
                 else if (!C1SP && C2SP)
                 {
-                    resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
-                    resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve1.ExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
                     resultCurves[0] = resultCurves[0].IFlip();
                     resultCurves[1] = resultCurves[1].IFlip();
                 }
                 else
                 {
-                    resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
-                    resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve1.ExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
                     resultCurves[0] = resultCurves[0].IFlip();
                 }
             }
@@ -635,8 +651,8 @@ namespace BH.Engine.Geometry
                             Reflection.Compute.RecordWarning("Couldn't provide correct fillet for given input");
                             return null;
                         }
-                        resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
-                        resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
                         resultCurves[1] = resultCurves[1].IFlip();
                     }
                     else if (C1SP && !C2SP)
@@ -649,8 +665,8 @@ namespace BH.Engine.Geometry
                             Reflection.Compute.RecordWarning("Couldn't provide correct fillet for given input");
                             return null;
                         }
-                        resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
-                        resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
                     }
                     else if (!C1SP && C2SP)
                     {
@@ -662,8 +678,8 @@ namespace BH.Engine.Geometry
                             Reflection.Compute.RecordWarning("Couldn't provide correct fillet for given input");
                             return null;
                         }
-                        resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
-                        resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve1.ExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
                         resultCurves[0] = resultCurves[0].IFlip();
                         resultCurves[1] = resultCurves[1].IFlip();
                     }
@@ -677,8 +693,8 @@ namespace BH.Engine.Geometry
                             Reflection.Compute.RecordWarning("Couldn't provide correct fillet for given input");
                             return null;
                         }
-                        resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
-                        resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve1.ExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
                         resultCurves[0] = resultCurves[0].IFlip();
                     }
                 }
@@ -709,29 +725,29 @@ namespace BH.Engine.Geometry
                         {
                             intersection = curveIntersections.ClosestPoint(curve1.IEndPoint());
 
-                            resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
-                            resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
                             resultCurves[1] = resultCurves[1].IFlip();
                         }
                         else if (C1SP && !C2SP)
                         {
                             intersection = curveIntersections.ClosestPoint(curve1.IEndPoint());
-                            resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
-                            resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
                         }
                         else if (!C1SP && C2SP)
                         {
                             intersection = curveIntersections.ClosestPoint(curve1.IStartPoint());
-                            resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
-                            resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve1.ExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
                             resultCurves[0] = resultCurves[0].IFlip();
                             resultCurves[1] = resultCurves[1].IFlip();
                         }
                         else
                         {
                             intersection = curveIntersections.ClosestPoint(curve1.IStartPoint());
-                            resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
-                            resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve1.ExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
                             resultCurves[0] = resultCurves[0].IFlip();
                         }
                     }
@@ -756,8 +772,8 @@ namespace BH.Engine.Geometry
                                 Reflection.Compute.RecordWarning("Couldn't create fillet");
                                 return null;
                             }
-                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
-                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
                             subResult2 = subResult2.Flip();
                             resultCurves.AddRange(subResult1.Curves);
                             resultCurves.AddRange(subResult2.Curves);                            
@@ -781,8 +797,8 @@ namespace BH.Engine.Geometry
                                 return null;
                             }
                             
-                            resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
-                            resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
                         }
                         else if (!C1SP && C2SP)
                         {
@@ -802,8 +818,8 @@ namespace BH.Engine.Geometry
                                 Reflection.Compute.RecordWarning("Couldn't create fillet");
                                 return null;
                             }
-                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance).ToList() };
-                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.ExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
                             subResult1 = subResult1.Flip();
                             subResult2 = subResult2.Flip();
                             resultCurves.AddRange(subResult1.Curves);
@@ -827,8 +843,8 @@ namespace BH.Engine.Geometry
                                 Reflection.Compute.RecordWarning("Couldn't create fillet");
                                 return null;
                             }
-                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance).ToList() };
-                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.ExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance).ToList() };
                             subResult1 = subResult1.Flip();
                             resultCurves.AddRange(subResult1.Curves);
                             resultCurves.AddRange(subResult2.Curves);

--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -511,7 +511,7 @@ namespace BH.Engine.Geometry
 
 
         /***************************************************/
-        /***         Private Methods                     ***/
+        /***  Private Methods                            ***/
         /***************************************************/
 
         private static List<ICurve> ExtendToPoint(this ICurve curve, Point startPoint, Point endPoint, bool tangentExtension, double tolerance)
@@ -523,10 +523,10 @@ namespace BH.Engine.Geometry
             double end = endPoint.Distance(curve.IEndPoint());
 
             if (startPoint.IsOnCurve(curve, tolerance))
-                start = -start;            
+                start = -start;
 
             if (endPoint.IsOnCurve(curve, tolerance))
-                end = -end;            
+                end = -end;
 
             List<ICurve> result = new List<ICurve>();
 
@@ -564,9 +564,9 @@ namespace BH.Engine.Geometry
 
             return result;
         }
-        
+
         /***************************************************/
-            
+
         private static PolyCurve Fillet(this ICurve curve1, ICurve curve2, bool tangentExtensions, bool keepCurve1StartPoint, bool keepCurve2StartPoint, double tolerance = Tolerance.Distance)
         {
             //TODO:
@@ -714,8 +714,8 @@ namespace BH.Engine.Geometry
                             pCurve2.Curves.Add(new Circle { Centre = (curve2 as Arc).Centre(), Normal = (curve2 as Arc).Normal(), Radius = (curve2 as Arc).Radius });
                         else
                             pCurve2.Curves.Add(new Line { Start = (curve2 as Line).Start, End = (curve2 as Line).End, Infinite = true });
-                        
-                        List<Point> curveIntersections = pCurve1.CurveIntersections(pCurve2, tolerance);                        
+
+                        List<Point> curveIntersections = pCurve1.CurveIntersections(pCurve2, tolerance);
                         if (curveIntersections.Count == 0)
                         {
                             Reflection.Compute.RecordError("Curves' extensions do not intersect");
@@ -755,11 +755,10 @@ namespace BH.Engine.Geometry
                     {
                         if (C1SP && C2SP)
                         {
-                            
                             Line tanLine1 = Create.Line(curve1.IEndPoint(), curve1.IEndDir() / tolerance);
                             tanLine1.Infinite = false;
                             PolyCurve pCurve1 = new PolyCurve { Curves = { curve1, tanLine1 } };
-                            
+
                             Line tanLine2 = Create.Line(curve2.IEndPoint(), curve2.IEndDir() / tolerance);
                             tanLine2.Infinite = false;
                             PolyCurve pCurve2 = new PolyCurve { Curves = { curve2, tanLine2 } };
@@ -776,7 +775,7 @@ namespace BH.Engine.Geometry
                             PolyCurve subResult2 = new PolyCurve { Curves = curve2.ExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
                             subResult2 = subResult2.Flip();
                             resultCurves.AddRange(subResult1.Curves);
-                            resultCurves.AddRange(subResult2.Curves);                            
+                            resultCurves.AddRange(subResult2.Curves);
                         }
                         else if (C1SP && !C2SP)
                         {
@@ -786,8 +785,8 @@ namespace BH.Engine.Geometry
 
                             Line tanLine2 = Create.Line(curve2.IStartPoint(), curve2.IStartDir().Reverse() / tolerance);
                             tanLine2.Infinite = false;
-                            PolyCurve pCurve2 = new PolyCurve { Curves = { tanLine2, curve2 } };                            
-                                                        
+                            PolyCurve pCurve2 = new PolyCurve { Curves = { tanLine2, curve2 } };
+
                             List<Point> curveIntersecions = pCurve1.ICurveIntersections(pCurve2, tolerance);
                             if (curveIntersecions.Count > 0)
                                 intersection = curveIntersecions.ClosestPoint(curve1.IEndPoint());
@@ -796,7 +795,7 @@ namespace BH.Engine.Geometry
                                 Reflection.Compute.RecordWarning("Couldn't create fillet");
                                 return null;
                             }
-                            
+
                             resultCurves.AddRange(curve1.ExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
                             resultCurves.AddRange(curve2.ExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
                         }
@@ -804,7 +803,7 @@ namespace BH.Engine.Geometry
                         {
                             Line tanLine1 = Create.Line(curve1.IStartPoint(), curve1.IStartDir().Reverse() / tolerance);
                             tanLine1.Infinite = false;
-                            PolyCurve pCurve1 = new PolyCurve { Curves = {  tanLine1, curve1 } };
+                            PolyCurve pCurve1 = new PolyCurve { Curves = { tanLine1, curve1 } };
 
                             Line tanLine2 = Create.Line(curve2.IEndPoint(), curve2.IEndDir() / tolerance);
                             tanLine2.Infinite = false;
@@ -860,10 +859,10 @@ namespace BH.Engine.Geometry
                     resultCurves.InsertRange(i, temp.Curves);
                 }
 
-            PolyCurve result =  new PolyCurve { Curves = resultCurves };
+            PolyCurve result = new PolyCurve { Curves = resultCurves };
             return result;
         }
-        
+
         /***************************************************/
     }
 }

--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -1,0 +1,853 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Reflection.Debugging;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods - Curves                   ****/
+        /***************************************************/
+
+        [Description("Creates an offset of a curve")]
+        [Input("curve", "Curve to offset")]
+        [Input("distance", "Offset distance. Positive value offsets to the right with normal pointing up and direction of a curve pointing forward")]
+        [Input("normal", "Normal of a plane for offset operation")]
+        [Input("tangentExtensions", "If true, arc segments of a PolyCurve will be extend by a tangent line, if false - by arc")]
+        [Output("curve", "Resulting offset")]
+        public static Line Offset(this Line curve, double offset, Vector normal, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            return curve.Translate(normal.CrossProduct(curve.Start - curve.End).Normalise() * offset);
+        }
+
+        /***************************************************/
+
+        [Description("Creates an offset of a curve")]
+        [Input("curve", "Curve to offset")]
+        [Input("distance", "Offset distance. Positive value offsets outside of a curve. If normal is given then offsets to the right with normal pointing up and direction of a curve pointing forward")]
+        [Input("normal", "Normal of a plane for offset operation")]
+        [Input("tangentExtensions", "If true, arc segments of a PolyCurve will be extend by a tangent line, if false - by arc")]
+        [Output("curve", "Resulting offset")]
+        public static Arc Offset(this Arc curve, double offset, Vector normal, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            if (!curve.IsPlanar())
+            {
+                Reflection.Compute.RecordError("Offset works only on planar curves");
+                return null;
+            }
+
+            if (offset == 0)
+                return curve.Clone();
+            double radius = curve.Radius;
+            Arc result = curve.Clone();
+
+            if (normal == null)
+                normal = curve.Normal();
+
+            if (normal.DotProduct(curve.Normal()) > 0)
+                radius += offset;
+            else
+                radius -= offset;
+
+            if (radius > 0)
+            {
+                result.Radius = radius;
+                return result;
+            }
+            else
+            {
+                Reflection.Compute.RecordError("Offset value is greater than arc radius");
+                return null;
+            }
+        }
+
+        /***************************************************/
+
+        [Description("Creates an offset of a curve")]
+        [Input("curve", "Curve to offset")]
+        [Input("distance", "Offset distance. Positive value offsets outside of a curve. If normal is given then offsets to the right with normal pointing up and direction of a curve pointing forward")]
+        [Input("normal", "Normal of a plane for offset operation")]
+        [Input("tangentExtensions", "If true, arc segments of a PolyCurve will be extend by a tangent line, if false - by arc")]
+        [Output("curve", "Resulting offset")]
+        public static Circle Offset(this Circle curve, double offset, Vector normal = null, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            if (offset == 0)
+                return curve.Clone();
+
+            double radius = curve.Radius;
+            Circle result = curve.Clone();
+
+            if (normal == null)
+                normal = curve.Normal();
+
+            if (normal.DotProduct(curve.Normal()) > 0)
+                radius += offset;
+            else
+                radius -= offset;
+
+            if (radius > 0)
+            {
+                result.Radius = radius;
+                return result;
+            }
+            else
+            {
+                Reflection.Compute.RecordError("Offset value is greater than circle radius");
+                return null;
+            }
+        }
+
+        /***************************************************/
+
+        [Description("Creates an offset of a curve. Works only on planar curves")]
+        [Input("curve", "Curve to offset")]
+        [Input("distance", "Offset distance. Positive value offsets outside of a curve. If normal is given then offsets to the right with normal pointing up and direction of a curve pointing forward")]
+        [Input("tangentExtensions", "If true, arc segments of a PolyCurve will be extend by a tangent line, if false - by arc")]
+        [Input("normal", "Normal of a plane for offset operation, not needed for closed curves")]
+        [Output("curve", "Resulting offset")]
+        public static Polyline Offset(this Polyline curve, double offset, Vector normal = null, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            if (!curve.IsPlanar())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset works only on planar curves");
+                return null;
+            }
+            bool isClosed = curve.IsClosed(tolerance);
+            if (normal == null)
+                if (!isClosed)
+                    BH.Engine.Reflection.Compute.RecordError("Normal is missing. Normal vector is not needed only for closed curves");
+                else
+                    normal = curve.Normal();
+            else
+                normal = normal.Normalise();
+
+            if (offset == 0)
+                return curve.Clone();
+
+            if (offset > 0.05 * curve.Length())
+                return (curve.Offset(offset / 2, normal, tangentExtensions, tolerance)).Offset(offset / 2, normal, tangentExtensions, tolerance);
+
+            List<Point> cPts = new List<Point>(curve.ControlPoints);
+            List<Point> tmp = new List<Point>(curve.ControlPoints);
+
+            if (!isClosed)
+            {
+                for (int i = 0; i < cPts.Count - 1; i++) //moving every vertex perpendicularly to each of it's edgses. At this point only direction of move is good.
+                {
+                    Vector trans = (cPts[i + 1] - cPts[i]).CrossProduct(normal);
+                    trans = trans.Normalise() * offset;
+                    tmp[i] += trans;
+                    tmp[i + 1] += trans;
+                }
+
+                for (int i = 1; i < cPts.Count - 1; i++) //adjusting move distance
+                {
+                    Vector trans = (tmp[i] - cPts[i]);
+                    trans = trans.Normalise() * Math.Abs(offset) / Math.Sin(Math.Abs((cPts[i] - cPts[i - 1]).Angle(cPts[i] - cPts[i + 1])) / 2);
+                    tmp[i] = cPts[i] + trans;
+                }
+            }
+            else
+            {
+                cPts.RemoveAt(cPts.Count - 1);
+                tmp.RemoveAt(tmp.Count - 1);
+                for (int i = 0; i < cPts.Count; i++) //moving every vertex perpendicularly to each of it's edgses. At this point only direction of move is good.
+                {
+                    Vector trans = (cPts[(i + 1) % cPts.Count] - cPts[i]).CrossProduct(normal);
+                    trans = trans.Normalise() * offset;
+                    tmp[i] += trans;
+                    tmp[(i + 1) % cPts.Count] += trans;
+                }
+
+                for (int i = 0; i < cPts.Count; i++)  //adjusting move distance
+                {
+                    if (!(Math.Abs(Math.Sin((cPts[i] - cPts[(i + cPts.Count - 1) % cPts.Count]).Angle(cPts[i] - cPts[(i + 1) % cPts.Count]))) < Tolerance.Angle))
+                    {
+                        Vector trans = (tmp[i] - cPts[i]);
+                        trans = trans.Normalise() * Math.Abs(offset) / Math.Sin(Math.Abs((cPts[i] - cPts[(i + cPts.Count - 1) % cPts.Count]).Angle(cPts[i] - cPts[(i + 1) % cPts.Count])) / 2);
+                        tmp[i] = cPts[i] + trans;
+                    }
+                }
+                tmp.Add(tmp[0]);
+            }
+
+            Polyline result = new Polyline { ControlPoints = tmp };
+            List<Line> Lines = result.SubParts();
+
+            if (isClosed)
+                tmp.RemoveAt(tmp.Count - 1);
+
+            //removing erroneous curves
+            int counter = 0;
+            for (int i = 0; i < Lines.Count; i++)
+            {
+                if (Lines[i].PointAtParameter(0.5).Distance(curve) + tolerance < Math.Abs(offset) &&
+                   (Lines[i].Start.Distance(curve) + tolerance < Math.Abs(offset) ||
+                    Lines[i].End.Distance(curve) + tolerance < Math.Abs(offset)))
+                {
+                    Line line1 = new Line { Start = tmp[i], End = tmp[(i + tmp.Count - 1) % tmp.Count], Infinite = true };
+                    Line line2 = new Line { Start = tmp[(i + 1) % tmp.Count], End = tmp[(i + 2) % tmp.Count], Infinite = true };
+
+                    if (!(line1.LineIntersection(line2, false, tolerance) == null))
+                        tmp[i] = line1.LineIntersection(line2, false, tolerance);
+
+                    tmp.RemoveAt((i + 1) % tmp.Count);
+
+                    if (tmp.Count == 0)
+                    {
+                        Reflection.Compute.RecordError("Method failed to produce corretct offset. Returning null.");
+                        return null;
+                    }
+                    tmp.Add(tmp[0]);
+                    Lines = result.SubParts();
+                    tmp.RemoveAt(tmp.Count - 1);
+                    i--;
+                    counter++;
+                }
+            }
+
+            if (isClosed)
+                tmp.Add(tmp[0]);
+
+            if (tmp.Count < 3 || (isClosed && tmp.Count < 4))
+            {
+                Reflection.Compute.RecordError("Method failed to produce corretct offset. Returning null.");
+                return null;
+            }
+
+            if (counter > 0)
+                Reflection.Compute.RecordWarning("Reduced " + counter + " line(s). Offset may be wrong. Please inspect the results.");
+
+            if (result.IsSelfIntersecting(tolerance) || result.LineIntersections(curve, tolerance).Count != 0)
+                Reflection.Compute.RecordWarning("Intersections occured. Offset may be wrong. Please inspect the results.");
+
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Creates an offset of a curve. Works only on planar curves")]
+        [Input("curve", "Curve to offset")]
+        [Input("distance", "Offset distance. Positive value offsets outside of a curve. If normal is given then offsets to the right with normal pointing up and direction of a curve pointing forward")]
+        [Input("normal", "Normal of a plane for offset operation, not needed for closed curves")]
+        [Output("curve", "Resulting offset")]
+        public static PolyCurve Offset(this PolyCurve curve, double offset, Vector normal = null, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            if (!curve.IsPlanar(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset works only on planar curves");
+                return null;
+            }
+
+            if (curve.IsSelfIntersecting(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Offset works only on non-self intersecting curves");
+                return null;
+            }
+
+            if (offset == 0)
+                return curve.Clone();
+
+            bool isClosed = curve.IsClosed(tolerance);
+            if (normal == null)
+                if (!isClosed)
+                {
+                    BH.Engine.Reflection.Compute.RecordError("Normal is missing. Normal vector is not needed only for closed curves");
+                    return null;
+                }
+                else
+                    normal = curve.Normal();
+
+            if (offset > 0.05 * curve.Length())
+                return (curve.Offset(offset / 2, normal, tangentExtensions, tolerance)).Offset(offset / 2, normal, tangentExtensions, tolerance);
+
+            PolyCurve result = new PolyCurve();
+
+            //if there are no Arcs switching to polyline method which is more reliable 
+            if (!curve.Curves.Any(x => x is Arc))
+            {
+                Polyline polyline = new Polyline { ControlPoints = curve.DiscontinuityPoints() };
+                result.Curves.AddRange(polyline.Offset(offset, normal, tangentExtensions, tolerance).SubParts());
+                return result;
+            }
+
+            Vector normalNormalised = normal.Normalise();
+            List<ICurve> ICrvs = curve.SubParts();
+
+            if (ICrvs[0] is Circle)
+            {
+                result.Curves.Add(Offset((Circle)ICrvs[0], offset, normal));
+                return result;
+            }
+            List<Event> log = Reflection.Query.CurrentEvents();
+            //First - offseting each individual element
+            List<ICurve> offsetCurves = new List<ICurve>();
+            foreach (ICurve crv in ICrvs)
+                if (crv.IOffset(offset, normal, false, tolerance) != null)
+                    offsetCurves.Add(crv.IOffset(offset, normal, false, tolerance));
+                else
+                    log.RemoveAt(log.Count - 1);
+
+            int counter = 0;
+            //removing curves that are on a wrong side of the main curve
+            for (int i = 0; i < offsetCurves.Count; i++)
+            {
+                Point sp = offsetCurves[i].IStartPoint();
+                Point ep = offsetCurves[i].IEndPoint();
+                Point mp = offsetCurves[i].IPointAtParameter(0.5);
+                Point spOnCurve = curve.ClosestPoint(sp);
+                Point epOnCurve = curve.ClosestPoint(ep);
+                Point mpOnCurve = curve.ClosestPoint(mp);
+                Vector sTan = curve.TangentAtPoint(spOnCurve, tolerance);
+                Vector eTan = curve.TangentAtPoint(epOnCurve, tolerance);
+                Vector mTan = curve.TangentAtPoint(mpOnCurve, tolerance);
+                Vector sCheck = sp - spOnCurve;
+                Vector eCheck = ep - epOnCurve;
+                Vector mCheck = mp - mpOnCurve;
+                Vector sCP = sTan.CrossProduct(sCheck).Normalise();
+                Vector eCP = eTan.CrossProduct(eCheck).Normalise();
+                Vector mCP = mTan.CrossProduct(mCheck).Normalise();
+                if (offset > 0)
+                {
+                    if (sCP.IsEqual(normalNormalised, tolerance) && eCP.IsEqual(normalNormalised, tolerance) && mCP.IsEqual(normalNormalised, tolerance))
+                    {
+                        offsetCurves.RemoveAt(i);
+                        i--;
+                        counter++;
+                    }
+                }
+                else
+                {
+                    if (!sCP.IsEqual(normalNormalised, tolerance) && !eCP.IsEqual(normalNormalised, tolerance) && !mCP.IsEqual(normalNormalised, tolerance))
+                    {
+                        offsetCurves.RemoveAt(i);
+                        i--;
+                        counter++;
+                    }
+                }
+            }
+
+            //Again if there are no Arcs switching to polyline method as it is more reliable 
+            if (!offsetCurves.Any(x => x is Arc))
+            {
+                Polyline polyline = new Polyline { ControlPoints = curve.DiscontinuityPoints() };
+                result.Curves.AddRange(polyline.Offset(offset, normal, tangentExtensions, tolerance).SubParts());
+                return result;
+            }
+            bool connectingError = false;
+            //Filleting offset curves to create continuous curve
+            for (int i = 0; i < offsetCurves.Count; i++)
+            {
+                int j;
+                if (i == offsetCurves.Count - 1)
+                {
+                    if (isClosed)
+                    { j = 0; }
+                    else
+                    { break; }
+                }
+                else
+                    j = i + 1;
+
+                PolyCurve temp = offsetCurves[i].Fillet(offsetCurves[j], tangentExtensions, true, false, tolerance);
+                if (temp == null) //trying to fillet with next curve 
+                {
+                    offsetCurves.RemoveAt(j);
+                    if (j == 0)
+                        i--;
+                    if (j == offsetCurves.Count)
+                        j = 0;
+                    temp = offsetCurves[i].Fillet(offsetCurves[j], tangentExtensions, true, false, tolerance);
+                }
+                if (!(temp == null)) //inserting filetted curves
+                {
+                    if (j != 0)
+                    {
+                        offsetCurves.RemoveRange(i, 2);
+                        offsetCurves.InsertRange(i, temp.Curves);
+                    }
+                    else
+                    {
+                        offsetCurves.RemoveAt(i);
+                        offsetCurves.RemoveAt(0);
+                        offsetCurves.InsertRange(i - 1, temp.Curves);
+                    }
+                    i = i + temp.Curves.Count - 2;
+                }
+                else
+                    connectingError = true;
+            }
+
+            //removing curves that are to close to the main curve
+            for (int i = 0; i < offsetCurves.Count; i++)
+            {
+                if ((offsetCurves[i].IPointAtParameter(0.5).Distance(curve) + tolerance < Math.Abs(offset) &&
+                     (offsetCurves[i].IStartPoint().Distance(curve) + tolerance < Math.Abs(offset) ||
+                      offsetCurves[i].IEndPoint().Distance(curve) + tolerance < Math.Abs(offset))))
+                {
+                    PolyCurve temp = offsetCurves[((i - 1) + offsetCurves.Count) % offsetCurves.Count].Fillet(offsetCurves[(i + 1) % offsetCurves.Count], tangentExtensions, true, false, tolerance);
+                    if (temp != null)
+                        if (i == 0)
+                        {
+                            offsetCurves.RemoveRange(0, 2);
+                            offsetCurves.RemoveAt(offsetCurves.Count - 1);
+                            offsetCurves.InsertRange(0, temp.Curves);
+                            i = temp.Curves.Count - 1;
+                        }
+                        else if (i == offsetCurves.Count - 1)
+                        {
+                            offsetCurves.RemoveRange(i - 1, 2);
+                            offsetCurves.RemoveAt(0);
+                            offsetCurves.InsertRange(offsetCurves.Count - 1, temp.Curves);
+                            i = offsetCurves.Count - 1;
+                        }
+                        else
+                        {
+                            offsetCurves.RemoveRange(i - 1, 3);
+                            offsetCurves.InsertRange(i - 1, temp.Curves);
+                            i = i - 3 + temp.Curves.Count;
+                        }
+                    if (offsetCurves.Count < 1)
+                    {
+                        log.Clear();
+                        Reflection.Compute.RecordError("Method failed to produce corretct offset. Returning null.");
+                        return null;
+                    }
+                    counter++;
+                }
+            }
+
+            log.Clear();
+
+            if (connectingError)
+                Reflection.Compute.RecordWarning("Couldn't connect offset subCurves properly.");
+
+            if (offsetCurves.Count == 0 || (isClosed && offsetCurves.Count < 3))
+            {
+                Reflection.Compute.RecordError("Method failed to produce corretct offset. Returning null.");
+                return null;
+            }
+
+            List<PolyCurve> resultList = Compute.IJoin(offsetCurves, tolerance);
+
+            if (resultList.Count == 1)
+                result = resultList[0];
+            else
+            {
+                result.Curves = offsetCurves;
+                Reflection.Compute.RecordWarning("Offset may be wrong. Please inspect the results.");
+            }
+
+            if (counter > 0)
+                Reflection.Compute.RecordWarning("Reduced " + counter + " line(s). Please inspect the results.");
+
+            if (result.IsSelfIntersecting(tolerance) || result.CurveIntersections(curve, tolerance).Count != 0)
+                Reflection.Compute.RecordWarning("Intersections occured. Please inspect the results.");
+
+            if (isClosed && !result.IsClosed(tolerance))
+                Reflection.Compute.RecordError("Final curve is not closed. Please inspect the results.");
+
+            return result;
+        }
+
+
+        /***************************************************/
+        /***  Public methods - Interfaces                ***/
+        /***************************************************/
+
+        [Description("Creates an offset of a curve. Works only on planar curves")]
+        [Input("curve", "Curve to offset")]
+        [Input("distance", "Offset distance. Positive value offsets outside of a closed curve. If normal is given then offsets to the right with normal pointing up and direction of a curve pointing forward")]
+        [Input("normal", "Normal of a plane for offset operation, not needed for closed curves")]
+        [Input("tangentExtensions", "If true, arc segments of a PolyCurve will be extend by a tangent line, if false - by arc")]
+        [Output("curve", "Resulting offset")]
+        public static ICurve IOffset(this ICurve curve, double offset, Vector normal = null, bool tangentExtensions = false, double tolerance = Tolerance.Distance)
+        {
+            return Offset(curve as dynamic, offset, normal, tangentExtensions, tolerance);
+        }
+
+
+        /***************************************************/
+        /***         Private Methods                     ***/
+        /***************************************************/
+
+        private static List<ICurve> TrimExtendToPoint(this ICurve curve, Point startPoint, Point endPoint, bool tangentExtension, double tolerance)
+        {
+            //TODO:
+            //Decide if useful enough to make public. If so, rewrite and test.
+
+            double start = startPoint.Distance(curve.IStartPoint());
+            double end = endPoint.Distance(curve.IEndPoint());
+
+            if (startPoint.IsOnCurve(curve, tolerance))
+                start = -start;            
+
+            if (endPoint.IsOnCurve(curve, tolerance))
+                end = -end;            
+
+            List<ICurve> result = new List<ICurve>();
+
+            if (!tangentExtension)
+            {
+                if (curve is Arc)
+                    result.Add((curve as Arc).Extend(2 * Math.Asin(start / (2 * (curve as Arc).Radius)) * (curve as Arc).Radius, 2 * Math.Asin(end / (2 * (curve as Arc).Radius)) * (curve as Arc).Radius, false, tolerance));
+                else
+                    result.Add((curve as Line).Extend(start, end, false, tolerance));
+            }
+            else
+            {
+                if (curve is Arc)
+                {
+                    if (start >= 0 && end >= 0)
+                        result.Add((curve as Arc).Extend(start, end, true, tolerance));
+                    else if (start >= 0 && end < 0)
+                        result.Add((curve as Arc).Extend(start, 2 * Math.Asin(end / (2 * (curve as Arc).Radius)) * (curve as Arc).Radius, true, tolerance));
+                    else if (start < 0 && end >= 0)
+                        result.Add((curve as Arc).Extend(2 * Math.Asin(start / (2 * (curve as Arc).Radius)) * (curve as Arc).Radius, end, true, tolerance));
+                    else
+                        result.Add((curve as Arc).Extend(2 * Math.Asin(start / (2 * (curve as Arc).Radius)) * (curve as Arc).Radius, 2 * Math.Asin(end / (2 * (curve as Arc).Radius)) * (curve as Arc).Radius, true, tolerance));
+                }
+                else
+                    result.Add((curve as Line).Extend(start, end, true, tolerance));
+            }
+
+            for (int i = 0; i < result.Count; i++)
+                if (result[i] is PolyCurve)
+                {
+                    PolyCurve temp = (PolyCurve)result[i];
+                    result.RemoveAt(i);
+                    result.InsertRange(i, temp.Curves);
+                }
+
+            return result;
+        }
+        
+        /***************************************************/
+            
+        private static PolyCurve Fillet(this ICurve curve1, ICurve curve2, bool tangentExtensions, bool keepCurve1StartPoint, bool keepCurve2StartPoint, double tolerance = Tolerance.Distance)
+        {
+            //TODO:
+            //Write a proper fillet method, test and make it public            
+
+            if (!((curve1 is Line || curve1 is Arc) && (curve2 is Line || curve2 is Arc))) //for now works only with combinations of lines and arcs
+                throw new NotImplementedException();
+
+            List<ICurve> resultCurves = new List<ICurve>();
+
+            bool C1SP = keepCurve1StartPoint;
+            bool C2SP = keepCurve2StartPoint;
+
+            List<Point> intersections = curve1.ICurveIntersections(curve2, tolerance);
+            if (intersections.Count > 2)
+                Reflection.Compute.RecordError("How on Earth did you manage to create a pair of Arcs and/or Lines which have more than two intersections??");
+            else if (intersections.Count == 2 || intersections.Count == 1)
+            {
+                Point intersection = intersections[0];
+                if (intersections.Count == 2)
+                {
+                    double maxdist = double.MaxValue;
+                    if (C1SP)
+                        foreach (Point p in intersections)
+                        {
+                            if (p.Distance(curve1.IStartPoint()) < maxdist)
+                            {
+                                intersection = p;
+                                maxdist = p.Distance(curve1.IStartPoint());
+                            }
+                        }
+                    else
+                        foreach (Point p in intersections)
+                        {
+                            if (p.Distance(curve1.IEndPoint()) < maxdist)
+                            {
+                                intersection = p;
+                                maxdist = p.Distance(curve1.IEndPoint());
+                            }
+                        }
+                }
+                else
+                    intersection = intersections[0];
+
+                if (C1SP && C2SP)
+                {
+                    resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                    resultCurves[1] = resultCurves[1].IFlip();
+                }
+                else if (C1SP && !C2SP)
+                {
+                    resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                }
+                else if (!C1SP && C2SP)
+                {
+                    resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                    resultCurves[0] = resultCurves[0].IFlip();
+                    resultCurves[1] = resultCurves[1].IFlip();
+                }
+                else
+                {
+                    resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                    resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                    resultCurves[0] = resultCurves[0].IFlip();
+                }
+            }
+            else
+            {
+                if (curve1 is Line && curve2 is Line)
+                {
+                    Point intersection = (curve1 as Line).LineIntersection(curve2 as Line, true, tolerance);
+                    if (C1SP && C2SP)
+                    {
+                        if ((curve1.IStartPoint().Distance((curve2 as Line), true) < curve1.IEndPoint().Distance((curve2 as Line), true) &&
+                            !intersection.IsOnCurve(curve1)) ||
+                            (curve2.IStartPoint().Distance((curve1 as Line), true) < curve2.IEndPoint().Distance((curve1 as Line), true) &&
+                             !intersection.IsOnCurve(curve2)))
+                        {
+                            Reflection.Compute.RecordWarning("Couldn't provide correct fillet for given input");
+                            return null;
+                        }
+                        resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                        resultCurves[1] = resultCurves[1].IFlip();
+                    }
+                    else if (C1SP && !C2SP)
+                    {
+                        if ((curve1.IStartPoint().Distance((curve2 as Line), true) < curve1.IEndPoint().Distance((curve2 as Line), true) &&
+                            !intersection.IsOnCurve(curve1)) ||
+                            (curve2.IStartPoint().Distance((curve1 as Line), true) > curve2.IEndPoint().Distance((curve1 as Line), true) &&
+                             !intersection.IsOnCurve(curve2)))
+                        {
+                            Reflection.Compute.RecordWarning("Couldn't provide correct fillet for given input");
+                            return null;
+                        }
+                        resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                    }
+                    else if (!C1SP && C2SP)
+                    {
+                        if ((curve1.IStartPoint().Distance((curve2 as Line), true) > curve1.IEndPoint().Distance((curve2 as Line), true) &&
+                            !intersection.IsOnCurve(curve1)) ||
+                            (curve2.IStartPoint().Distance((curve1 as Line), true) < curve2.IEndPoint().Distance((curve1 as Line), true) &&
+                             !intersection.IsOnCurve(curve2)))
+                        {
+                            Reflection.Compute.RecordWarning("Couldn't provide correct fillet for given input");
+                            return null;
+                        }
+                        resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                        resultCurves[0] = resultCurves[0].IFlip();
+                        resultCurves[1] = resultCurves[1].IFlip();
+                    }
+                    else
+                    {
+                        if ((curve1.IStartPoint().Distance((curve2 as Line), true) > curve1.IEndPoint().Distance((curve2 as Line), true) &&
+                            !intersection.IsOnCurve(curve1)) ||
+                            (curve2.IStartPoint().Distance((curve1 as Line), true) > curve2.IEndPoint().Distance((curve1 as Line), true) &&
+                             !intersection.IsOnCurve(curve2)))
+                        {
+                            Reflection.Compute.RecordWarning("Couldn't provide correct fillet for given input");
+                            return null;
+                        }
+                        resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                        resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                        resultCurves[0] = resultCurves[0].IFlip();
+                    }
+                }
+                else
+                {
+                    Point intersection = new Point();
+                    if (!tangentExtensions)
+                    {
+                        PolyCurve pCurve1 = new PolyCurve();
+                        PolyCurve pCurve2 = new PolyCurve();
+                        if (curve1 is Arc)
+                            pCurve1.Curves.Add(new Circle { Centre = (curve1 as Arc).Centre(), Normal = (curve1 as Arc).Normal(), Radius = (curve1 as Arc).Radius });
+                        else
+                            pCurve1.Curves.Add(new Line { Start = (curve1 as Line).Start, End = (curve1 as Line).End, Infinite = true });
+
+                        if (curve2 is Arc)
+                            pCurve2.Curves.Add(new Circle { Centre = (curve2 as Arc).Centre(), Normal = (curve2 as Arc).Normal(), Radius = (curve2 as Arc).Radius });
+                        else
+                            pCurve2.Curves.Add(new Line { Start = (curve2 as Line).Start, End = (curve2 as Line).End, Infinite = true });
+                        
+                        List<Point> curveIntersections = pCurve1.CurveIntersections(pCurve2, tolerance);                        
+                        if (curveIntersections.Count == 0)
+                        {
+                            Reflection.Compute.RecordError("Curves' extensions do not intersect");
+                            return null;
+                        }
+                        if (C1SP && C2SP)
+                        {
+                            intersection = curveIntersections.ClosestPoint(curve1.IEndPoint());
+
+                            resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves[1] = resultCurves[1].IFlip();
+                        }
+                        else if (C1SP && !C2SP)
+                        {
+                            intersection = curveIntersections.ClosestPoint(curve1.IEndPoint());
+                            resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                        }
+                        else if (!C1SP && C2SP)
+                        {
+                            intersection = curveIntersections.ClosestPoint(curve1.IStartPoint());
+                            resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves[0] = resultCurves[0].IFlip();
+                            resultCurves[1] = resultCurves[1].IFlip();
+                        }
+                        else
+                        {
+                            intersection = curveIntersections.ClosestPoint(curve1.IStartPoint());
+                            resultCurves.AddRange(curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                            resultCurves[0] = resultCurves[0].IFlip();
+                        }
+                    }
+                    else
+                    {
+                        if (C1SP && C2SP)
+                        {
+                            
+                            Line tanLine1 = Create.Line(curve1.IEndPoint(), curve1.IEndDir() / tolerance);
+                            tanLine1.Infinite = false;
+                            PolyCurve pCurve1 = new PolyCurve { Curves = { curve1, tanLine1 } };
+                            
+                            Line tanLine2 = Create.Line(curve2.IEndPoint(), curve2.IEndDir() / tolerance);
+                            tanLine2.Infinite = false;
+                            PolyCurve pCurve2 = new PolyCurve { Curves = { curve2, tanLine2 } };
+
+                            List<Point> curveIntersecions = pCurve1.CurveIntersections(pCurve2, tolerance);
+                            if (curveIntersecions.Count > 0)
+                                intersection = curveIntersecions.ClosestPoint(curve1.IEndPoint());
+                            else
+                            {
+                                Reflection.Compute.RecordWarning("Couldn't create fillet");
+                                return null;
+                            }
+                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
+                            subResult2 = subResult2.Flip();
+                            resultCurves.AddRange(subResult1.Curves);
+                            resultCurves.AddRange(subResult2.Curves);                            
+                        }
+                        else if (C1SP && !C2SP)
+                        {
+                            Line tanLine1 = Create.Line(curve1.IEndPoint(), curve1.IEndDir() / tolerance);
+                            tanLine1.Infinite = false;
+                            PolyCurve pCurve1 = new PolyCurve { Curves = { curve1, tanLine1 } };
+
+                            Line tanLine2 = Create.Line(curve2.IStartPoint(), curve2.IStartDir().Reverse() / tolerance);
+                            tanLine2.Infinite = false;
+                            PolyCurve pCurve2 = new PolyCurve { Curves = { tanLine2, curve2 } };                            
+                                                        
+                            List<Point> curveIntersecions = pCurve1.ICurveIntersections(pCurve2, tolerance);
+                            if (curveIntersecions.Count > 0)
+                                intersection = curveIntersecions.ClosestPoint(curve1.IEndPoint());
+                            else
+                            {
+                                Reflection.Compute.RecordWarning("Couldn't create fillet");
+                                return null;
+                            }
+                            
+                            resultCurves.AddRange(curve1.TrimExtendToPoint(curve1.IStartPoint(), intersection, tangentExtensions, tolerance));
+                            resultCurves.AddRange(curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance));
+                        }
+                        else if (!C1SP && C2SP)
+                        {
+                            Line tanLine1 = Create.Line(curve1.IStartPoint(), curve1.IStartDir().Reverse() / tolerance);
+                            tanLine1.Infinite = false;
+                            PolyCurve pCurve1 = new PolyCurve { Curves = {  tanLine1, curve1 } };
+
+                            Line tanLine2 = Create.Line(curve2.IEndPoint(), curve2.IEndDir() / tolerance);
+                            tanLine2.Infinite = false;
+                            PolyCurve pCurve2 = new PolyCurve { Curves = { curve2, tanLine2 } };
+
+                            List<Point> curveIntersecions = pCurve1.ICurveIntersections(pCurve2, tolerance);
+                            if (curveIntersecions.Count > 0)
+                                intersection = curveIntersecions.ClosestPoint(curve1.IStartPoint());
+                            else
+                            {
+                                Reflection.Compute.RecordWarning("Couldn't create fillet");
+                                return null;
+                            }
+                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.TrimExtendToPoint(curve2.IStartPoint(), intersection, tangentExtensions, tolerance).ToList() };
+                            subResult1 = subResult1.Flip();
+                            subResult2 = subResult2.Flip();
+                            resultCurves.AddRange(subResult1.Curves);
+                            resultCurves.AddRange(subResult2.Curves);
+                        }
+                        else
+                        {
+                            Line tanLine1 = Create.Line(curve1.IStartPoint(), curve1.IStartDir().Reverse() / tolerance);
+                            tanLine1.Infinite = false;
+                            PolyCurve pCurve1 = new PolyCurve { Curves = { tanLine1, curve1 } };
+
+                            Line tanLine2 = Create.Line(curve2.IStartPoint(), curve2.IStartDir().Reverse() / tolerance);
+                            tanLine2.Infinite = false;
+                            PolyCurve pCurve2 = new PolyCurve { Curves = { tanLine2, curve2 } };
+
+                            List<Point> curveIntersecions = pCurve1.ICurveIntersections(pCurve2, tolerance);
+                            if (curveIntersecions.Count > 0)
+                                intersection = curveIntersecions.ClosestPoint(curve1.IStartPoint());
+                            else
+                            {
+                                Reflection.Compute.RecordWarning("Couldn't create fillet");
+                                return null;
+                            }
+                            PolyCurve subResult1 = new PolyCurve { Curves = curve1.TrimExtendToPoint(intersection, curve1.IEndPoint(), tangentExtensions, tolerance).ToList() };
+                            PolyCurve subResult2 = new PolyCurve { Curves = curve2.TrimExtendToPoint(intersection, curve2.IEndPoint(), tangentExtensions, tolerance).ToList() };
+                            subResult1 = subResult1.Flip();
+                            resultCurves.AddRange(subResult1.Curves);
+                            resultCurves.AddRange(subResult2.Curves);
+                        }
+                    }
+                }
+            }
+            for (int i = 0; i < resultCurves.Count; i++)
+                if (resultCurves[i] is PolyCurve)
+                {
+                    PolyCurve temp = (PolyCurve)resultCurves[i];
+                    resultCurves.RemoveAt(i);
+                    resultCurves.InsertRange(i, temp.Curves);
+                }
+
+            PolyCurve result =  new PolyCurve { Curves = resultCurves };
+            return result;
+        }
+        
+        /***************************************************/
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1066 

<!-- Add short description of what has been fixed -->
Replacing over-dated #1229.

- Added `Offset` method for `Line`, `Arc`, `Polyline` and `PolyCurve`. `Polycurve` has been rewritten from the top down and now it is based on new private method `Fillet()`. **It is not perfect.** In more complicated cases `Offset` method is very intuitive and does not have one objective solution. I'd say there is no such a thing as a perfect Offset method (even a GrassHopper's one :wink:). This version is the closest I can get us to a proper Offset and is fully functional for most of engineering applications.
- Extended `Extend` method to `Arc`, `Polyline` and `PolyCurve`. Also added an option to choose between tangent extensions or following the curve shape.
- Added three private methods:
  - `Fillet(ICurve, ICurve)` - works like Autocad fillet but only for radius = 0. Not tested at all besides in Offest. Works only for Lines and Arcs. To be decided if useful enough to be rewritten and made public. Strongly depends on `ExtendToPoint()`
  - `ExtendToPoint(ICurve, Point, Point)` - as above, also not tested and works only for Arcs and Lines. It's more like Interface that points to regular `Extend()`. Also to be decided if useful.
  - `ExtendTangent(ICurve, double, double)` - auxiliary method for `Extend()` to deal with tangent extensions.

### Test files
<!-- Link to test files to validate the proposed changes -->
General test files are [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FModify) (files Extend and Offset). Highly recommend to additionally test Offset yourself. Generic tests are pointless in this case.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Modify.Offset()` public methods added in the `Geometry_Engine` for `Line`, `Arc`, `Circle`, `Polyline` and `PolyCurve` classes
- `Modify.Extend()` public method deprecated in the `Geometry_Engine` for `Line` class.
- `Modify.Extend()` public methods added in the `Geometry_Engine` for `Line`, `Arc`, `Circle`, `Ellipse`, `NurbsCurve`, `Polyline`, `PolyCurve` and `ICurve` classes.
- `Modify.ExtendTangent()` private methods added in the `Geometry_Engine` for `Arc` and `PolyCurve` classes
- `Modify.ExtendToPoint()` private method added in the `Geometry_Engine` for `ICurve` class, but really works only on `Line` and `Arc` classes.
- `Modify.Fillet()` private method added in the `Geometry_Engine` for `ICurve` class, but really works only on `Line` and `Arc` classes.

### Additional comments
<!-- As required -->
- After merging I will raise issues with ideas how Offset and Fillet could be improved.
- In Offset I create (l: 326) and clear (l: 455, 463) CurrentEvents log. It's to hide warnings coming from nested methods. I don't know it is the best way to do so. It refers to issue #1306 