### PR TITLE
Geometry_Engine CurveProximity, return single point twice for intersection events

### DIFF
--- a/Geometry_Engine/Compute/CurveProximity.cs
+++ b/Geometry_Engine/Compute/CurveProximity.cs
@@ -59,7 +59,8 @@ namespace BH.Engine.Geometry
             if (curve1.IsCoplanar(curve2))
                 return new Output<Point, Point> { Item1 = min1, Item2 = min2 };
 
-            double[] t = new double[] { curve1.SkewLineProximity(curve2).Item1, curve1.SkewLineProximity(curve2).Item2 };
+            Output<double,double> skewLineProximity = curve1.SkewLineProximity(curve2);
+            double[] t = new double[] { skewLineProximity.Item1, skewLineProximity.Item2 };
             double t1 = Math.Max(Math.Min(t[0], 1), 0);
             double t2 = Math.Max(Math.Min(t[1], 1), 0);
             Vector e1 = curve1.End - curve1.Start;

--- a/Geometry_Engine/Compute/CurveProximity.cs
+++ b/Geometry_Engine/Compute/CurveProximity.cs
@@ -176,6 +176,25 @@ namespace BH.Engine.Geometry
             plnPts.Add(curve2.Centre);
             Point tmp;
             Plane ftPln = plnPts.FitPlane();
+            Plane circlePlane = curve2.FitPlane();
+            Output<Point, Point> result = new Output<Point, Point>();
+
+            if (Math.Abs(circlePlane.Normal.DotProduct(curve1.Direction())) < Tolerance.Angle) // 2D solution
+            {
+                double startSqDist = curve2.Centre.SquareDistance(curve1.Start);
+                double endSqDist = curve2.Centre.SquareDistance(curve1.End);
+                double sqRadius = Math.Pow(curve2.Radius, 2);
+                if (startSqDist < sqRadius) // within circle
+                {
+                    result.Item1 = startSqDist < endSqDist ? curve1.End : curve1.Start;
+                }
+                else      // outside circle
+                {
+                    result.Item1 = curve1.ClosestPoint(curve2.Centre);
+                }
+                result.Item2 = curve2.ClosestPoint(result.Item1);
+                return result;
+            }
 
             if (ftPln != null)
             {
@@ -189,7 +208,7 @@ namespace BH.Engine.Geometry
             else
                 tmp = curve1.ClosestPoint(curve2.Centre);
 
-            Line prLn = curve1.Project(curve2.FitPlane());
+            Line prLn = curve1.Project(circlePlane);
             List<Point> lnInt = prLn.CurveIntersections(curve2);
 
             if (lnInt.Count > 0)
@@ -204,7 +223,6 @@ namespace BH.Engine.Geometry
                     tmp = lnInt[0];
             }
 
-            Output<Point, Point> result = new Output<Point, Point>();
             result.Item1 = curve1.ClosestPoint(tmp);
             result.Item2 = curve2.ClosestPoint(result.Item1);
             Output<Point, Point> oldresult = new Output<Point, Point>();
@@ -478,7 +496,7 @@ namespace BH.Engine.Geometry
             Plane ftPln1 = curve1.FitPlane();
             Plane ftPln2 = curve2.FitPlane();
             List<Point> intPts = new List<Point>();
-            Point tmp = null ;
+            Point tmp = null;
 
             if ((intPts = curve1.PlaneIntersections(ftPln2)).Count != 0)
             {

--- a/Geometry_Engine/Compute/CurveProximity.cs
+++ b/Geometry_Engine/Compute/CurveProximity.cs
@@ -176,22 +176,15 @@ namespace BH.Engine.Geometry
             plnPts.Add(curve2.Centre);
             Point tmp;
             Plane ftPln = plnPts.FitPlane();
-            Plane circlePlane = curve2.FitPlane();
             Output<Point, Point> result = new Output<Point, Point>();
 
-            if (Math.Abs(circlePlane.Normal.DotProduct(curve1.Direction())) < Tolerance.Angle) // 2D solution
+            if (Math.Abs(curve2.Normal.DotProduct(curve1.Direction())) < Tolerance.Angle) // 2D solution
             {
                 double startSqDist = curve2.Centre.SquareDistance(curve1.Start);
-                double endSqDist = curve2.Centre.SquareDistance(curve1.End);
-                double sqRadius = Math.Pow(curve2.Radius, 2);
-                if (startSqDist < sqRadius) // within circle
-                {
-                    result.Item1 = startSqDist < endSqDist ? curve1.End : curve1.Start;
-                }
+                if (startSqDist < Math.Pow(curve2.Radius, 2)) // within circle
+                    result.Item1 = startSqDist < curve2.Centre.SquareDistance(curve1.End) ? curve1.End : curve1.Start;
                 else      // outside circle
-                {
                     result.Item1 = curve1.ClosestPoint(curve2.Centre);
-                }
                 result.Item2 = curve2.ClosestPoint(result.Item1);
                 return result;
             }
@@ -208,7 +201,7 @@ namespace BH.Engine.Geometry
             else
                 tmp = curve1.ClosestPoint(curve2.Centre);
 
-            Line prLn = curve1.Project(circlePlane);
+            Line prLn = curve1.Project(curve2.FitPlane());
             List<Point> lnInt = prLn.CurveIntersections(curve2);
 
             if (lnInt.Count > 0)

--- a/Geometry_Engine/Compute/CurveProximity.cs
+++ b/Geometry_Engine/Compute/CurveProximity.cs
@@ -658,12 +658,8 @@ namespace BH.Engine.Geometry
 
             Output<Point, Point> result = new Output<Point, Point>();
 
-            if (Math.Abs(curve1.Normal.IsParallel(curve2.Normal)) == 1)
-            {
-                result.Item1 = curve1.PointAtParameter(0);
-                result.Item2 = curve2.ClosestPoint(result.Item1);
-                return result;
-            }
+            //if (Math.Abs(curve1.Normal.IsParallel(curve2.Normal)) == 1) //TODO find solution for special case
+            //{}
 
             Plane ftPln1 = curve1.FitPlane();
             Plane ftPln2 = curve2.FitPlane();

--- a/Geometry_Engine/Compute/CurveProximity.cs
+++ b/Geometry_Engine/Compute/CurveProximity.cs
@@ -36,8 +36,9 @@ namespace BH.Engine.Geometry
 
         public static Output<Point, Point> CurveProximity(this Line curve1, Line curve2, double tolerance = Tolerance.Distance)
         {
-            if (curve1.CurveIntersections(curve2).Count > 0)
-                return new Output<Point, Point> { Item1 = curve1.CurveIntersections(curve2)[0], Item2 = curve1.CurveIntersections(curve2)[0] };
+            List<Point> cIntersections = curve1.CurveIntersections(curve2);
+            if (cIntersections.Count > 0)
+                return new Output<Point, Point> { Item1 = cIntersections[0], Item2 = cIntersections[0] };
 
             Point min1 = new Point();
             Point min2 = new Point();
@@ -75,8 +76,9 @@ namespace BH.Engine.Geometry
 
         public static Output<Point, Point> CurveProximity(this Line curve1, Arc curve2, double tolerance = Tolerance.Distance)
         {
-            if (curve1.CurveIntersections(curve2).Count > 0)
-                return new Output<Point, Point> { Item1 = curve1.CurveIntersections(curve2)[0], Item2 = curve1.CurveIntersections(curve2)[0] };
+            List<Point> cIntersections = curve1.CurveIntersections(curve2);
+            if (cIntersections.Count > 0)
+                return new Output<Point, Point> { Item1 = cIntersections[0], Item2 = cIntersections[0] };
 
             List<Point> plnPts = new List<Point>();
             plnPts.Add(curve1.Start);
@@ -163,8 +165,9 @@ namespace BH.Engine.Geometry
 
         public static Output<Point, Point> CurveProximity(this Line curve1, Circle curve2, double tolerance = Tolerance.Distance)
         {
-            if (curve1.CurveIntersections(curve2).Count > 0)
-                return new Output<Point, Point> { Item1 = curve1.CurveIntersections(curve2)[0], Item2 = curve1.CurveIntersections(curve2)[0] };
+            List<Point> cIntersections = curve1.CurveIntersections(curve2);
+            if (cIntersections.Count > 0)
+                return new Output<Point, Point> { Item1 = cIntersections[0], Item2 = cIntersections[0] };
 
             List<Point> plnPts = new List<Point>();
             plnPts.Add(curve1.Start);
@@ -245,8 +248,9 @@ namespace BH.Engine.Geometry
 
         public static Output<Point, Point> CurveProximity(this Arc curve1, Arc curve2, double tolerance = Tolerance.Distance)
         {
-            if (curve1.CurveIntersections(curve2).Count > 0)
-                return new Output<Point, Point> { Item1 = curve1.CurveIntersections(curve2)[0], Item2 = curve1.CurveIntersections(curve2)[1] };
+            List<Point> cIntersections = curve1.CurveIntersections(curve2);
+            if (cIntersections.Count > 0)
+                return new Output<Point, Point> { Item1 = cIntersections[0], Item2 = cIntersections[0] };
 
             Output<Point, Point> result = new Output<Point, Point>();
             Output<Point, Point> oldresult = new Output<Point, Point>();
@@ -465,8 +469,9 @@ namespace BH.Engine.Geometry
 
         public static Output<Point, Point> CurveProximity(this Arc curve1, Circle curve2, double tolerance = Tolerance.Distance)
         {
-            if (curve1.CurveIntersections(curve2).Count > 0)
-                return new Output<Point, Point> { Item1 = curve1.CurveIntersections(curve2)[0], Item2 = curve1.CurveIntersections(curve2)[1] };
+            List<Point> cIntersections = curve1.CurveIntersections(curve2);
+            if (cIntersections.Count > 0)
+                return new Output<Point, Point> { Item1 = cIntersections[0], Item2 = cIntersections[0] };
 
             Output<Point, Point> result = new Output<Point, Point>();
             Plane ftPln1 = curve1.FitPlane();
@@ -646,8 +651,9 @@ namespace BH.Engine.Geometry
 
         public static Output<Point, Point> CurveProximity(this Circle curve1, Circle curve2, double tolerance = Tolerance.Distance)
         {
-            if (curve1.CurveIntersections(curve2).Count > 0)
-                return new Output<Point, Point> { Item1 = curve1.CurveIntersections(curve2)[0], Item2 = curve1.CurveIntersections(curve2)[1] };
+            List<Point> cIntersections = curve1.CurveIntersections(curve2);
+            if (cIntersections.Count > 0)
+                return new Output<Point, Point> { Item1 = cIntersections[0], Item2 = cIntersections[0] };
 
             Output<Point, Point> result = new Output<Point, Point>();
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1327 
CurveProximity always tried to return both intersection events for some curves, which caused issues when there only was one.

Now it returns the first point of the intersection twice if there is an intersection event.
The method is really not structured to be able to return all closest points

### Test files
<!-- Link to test files to validate the proposed changes -->
[CurveProximity](https://burohappold.sharepoint.com/:u:/s/BHoM/EW3dPy2DKiBEuYL3nxchY6sBKpYfVyxIj032G682HsQSOg?e=saKZxY)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.Geometry.Compute.CurveProximity(Line, Circle)` coplanar curve edge case bug fixed

### Additional comments
also @pawelbaran  @FraserGreenroyd  @KonradStolarski  why did it try to return separate intersections (i.e both of two planar circles intersection points)? I thought that this was used in to find distance between curves (and this would cause some intersecting curves to have a distance between them)

The points it retuned:
![image](https://user-images.githubusercontent.com/53530468/68853040-fb75ff80-06d0-11ea-9e8b-60f6a32acb0c.png)
