### PR TITLE
Reflection_Engine: Add possibility to include full path for parameters in method.ToText()

### DIFF
--- a/Reflection_Engine/Convert/ToText.cs
+++ b/Reflection_Engine/Convert/ToText.cs
@@ -48,7 +48,7 @@ namespace BH.Engine.Reflection
 
         /***************************************************/
 
-        public static string ToText(this MethodBase method, bool includePath = false, string paramStart = "(", string paramSeparator = ", ", string paramEnd = ")", bool removeIForInterface = true, bool includeParamNames = true, int maxParams = 5, int maxChars = 40)
+        public static string ToText(this MethodBase method, bool includePath = false, string paramStart = "(", string paramSeparator = ", ", string paramEnd = ")", bool removeIForInterface = true, bool includeParamNames = true, int maxParams = 5, int maxChars = 40, bool includeParamPaths = false)
         {
             string name = (method is ConstructorInfo) ? method.DeclaringType.ToText(false, true) : method.Name;
             if (removeIForInterface && Query.IsInterfaceMethod(method))
@@ -66,7 +66,7 @@ namespace BH.Engine.Reflection
                     for (int i = 0; i < parameters.Count(); i++)
                     {
                         string singleParamText = includeParamNames ?
-                            parameters[i].ParameterType.ToText() + " " + parameters[i].Name : parameters[i].ParameterType.ToText();
+                            parameters[i].ParameterType.ToText(includeParamPaths) + " " + parameters[i].Name : parameters[i].ParameterType.ToText(includeParamPaths);
 
                         if (i == 0)
                         {
@@ -125,7 +125,7 @@ namespace BH.Engine.Reflection
                 {
                     string text = type.Name.Substring(0, type.Name.IndexOf('`'))
                         + genericStart
-                        + types.Select(x => x.ToText()).Aggregate((x, y) => x + genericSeparator + y)
+                        + types.Select(x => x.ToText(includePath)).Aggregate((x, y) => x + genericSeparator + y)
                         + genericEnd;
 
                     if (includePath)


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1334

### Test files
You should get something like this when testing the ToText component on method (i.e. full path for method parameters):
![image](https://user-images.githubusercontent.com/16853390/69212922-91140200-0b9d-11ea-96ac-5209ead34057.png)


### Additional comments
Nothing depends on this. This is purely to help users generate the correct string when adding a method upgrader to the versioning engine.