### PR TITLE
Serialiser_Engine: Remove attempt to re-deserialise a custom object

### DIFF
--- a/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
@@ -31,6 +31,7 @@ using BH.Engine.Versioning;
 using System;
 using System.Reflection;
 using BH.Engine.Serialiser.Objects;
+using System.Collections.Generic;
 
 namespace BH.Engine.Serialiser.BsonSerializers
 {
@@ -294,12 +295,30 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 {
                     // A child of the object is causing problems. Try to recover from custom object
                     IBsonSerializer customSerializer = BsonSerializer.LookupSerializer(typeof(CustomObject));
-                    object customObject = customSerializer.Deserialize(context, args);
+                    object result = customSerializer.Deserialize(context, args);
+                    Guid objectId = ((CustomObject)result).BHoM_Guid;
 
-                    if (customObject is CustomObject)
+                    if (!Config.TypesWithoutUpgrade.Contains(actualType))
+                    {
+                        if (m_StackCounter.ContainsKey(objectId))
+                            m_StackCounter[objectId] += 1;
+                        else
+                            m_StackCounter[objectId] = 1;
+
+                        if (m_StackCounter[objectId] < 10)
+                        {
+                            result = Convert.FromBson(result.ToBson());
+                            m_StackCounter.Remove(objectId);
+                        }
+                    }
+                    
+                    if (result is CustomObject)
+                    {
                         Engine.Reflection.Compute.RecordWarning("The type " + actualType.FullName + " is unknown -> data returned as custom objects.");
-
-                    return customObject;
+                        Config.TypesWithoutUpgrade.Add(actualType);
+                    }
+                        
+                    return result;
 
                 }
                 else if (actualType != typeof(IDeprecated))
@@ -324,6 +343,8 @@ namespace BH.Engine.Serialiser.BsonSerializers
         /***************************************************/
 
         private readonly IDiscriminatorConvention _discriminatorConvention;
+
+        private static Dictionary<Guid, int> m_StackCounter = new Dictionary<Guid, int>();
 
 
         /*******************************************/

--- a/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
@@ -295,12 +295,11 @@ namespace BH.Engine.Serialiser.BsonSerializers
                     // A child of the object is causing problems. Try to recover from custom object
                     IBsonSerializer customSerializer = BsonSerializer.LookupSerializer(typeof(CustomObject));
                     object customObject = customSerializer.Deserialize(context, args);
-                    object result = Convert.FromBson(customObject.ToBson());
 
-                    if (result is CustomObject)
+                    if (customObject is CustomObject)
                         Engine.Reflection.Compute.RecordWarning("The type " + actualType.FullName + " is unknown -> data returned as custom objects.");
 
-                    return result;
+                    return customObject;
 
                 }
                 else if (actualType != typeof(IDeprecated))


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #1337 


### Test files
[Here](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Serializer_Engine/ROI_Rhino%20to%20IES_RoomReference(1).gh?csf=1&e=pitETz)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
During an investigation into Excel problems with @awakeman and @IsakNaslundBh today, it was discovered that some old scripts weren't loading following a change to fragment structure done by myself and @alelom . Namely, the PR to Serialiser_Engine of the 9th November suddenly caused old scripts not to deserialise.

The line which appeared to be causing it was `object result = Convert.FromBson(customObject.ToBson());` it appeared to be getting recursively stuck and never moving onto the next line.

Commenting out this line (and then removing it) appeared to fix the problem, in so much as the attached script could open, and Excel could load again.

I opted to remove the line, because I am unsure what it was adding to the function, because it appeared to be serialising the `customObject` to BSon, and then immediately deserialising it back to an `object`.

Which is why I'm only asking for a review from @adecler explicitly at this stage, as I am unsure what potential consequences this will have on the versioning stuff, and hopefully you'll be able to explain the above to me :smile: