### PR TITLE
Structure_Engine: Add null check for load combination create method

### DIFF
--- a/Structure_Engine/Create/Loadcombination.cs
+++ b/Structure_Engine/Create/Loadcombination.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Structure
 
             for (int i = 0; i < cases.Count; i++)
             {
-                if (!excludeZeroFactorCases || factors[i] > 0)
+                if (!excludeZeroFactorCases || factors[i] > 0 || cases[i] != null)
                     factoredCases.Add(new Tuple<double, ICase>(factors[i], cases[i]));
             }
 

--- a/Structure_Engine/Create/Loadcombination.cs
+++ b/Structure_Engine/Create/Loadcombination.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Structure
 
             for (int i = 0; i < cases.Count; i++)
             {
-                if (!excludeZeroFactorCases || factors[i] > 0 || cases[i] != null)
+                if (cases[i] != null || !excludeZeroFactorCases || factors[i] > 0)
                     factoredCases.Add(new Tuple<double, ICase>(factors[i], cases[i]));
             }
 

--- a/Structure_Engine/Create/Loadcombination.cs
+++ b/Structure_Engine/Create/Loadcombination.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Structure
 
             for (int i = 0; i < cases.Count; i++)
             {
-                if (cases[i] != null || !excludeZeroFactorCases || factors[i] > 0)
+                if (cases[i] != null && (!excludeZeroFactorCases || factors[i] > 0))
                     factoredCases.Add(new Tuple<double, ICase>(factors[i], cases[i]));
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1336 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Structure_Engine/Issues?csf=1&e=CNo5DP

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
 - Prevent load combinations from adding a null loadcase where a case factor is input without a corresponding loadcase.

### Additional comments
<!-- As required -->
To test, open the spreadsheet and try combinations into a clean Robot/analysis model. The spreasheet includes reference to cells with no loadcase, so the null check removes these and allows the combinations to be created. 