### PR TITLE
Serialiser_Engine: Fix deserialisation of generic types

### DIFF
--- a/Reflection_Engine/Compute/UnqualifiedName.cs
+++ b/Reflection_Engine/Compute/UnqualifiedName.cs
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Reflection;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static string UnqualifiedName(string qualifiedName)
+        {
+            int openIndex = qualifiedName.IndexOf('[');
+            int closeIndex = qualifiedName.LastIndexOf(']');
+
+            if (openIndex < 0 || closeIndex < 0)
+                return qualifiedName.Split(',').First();
+
+            string inside = qualifiedName.Substring(openIndex + 1, closeIndex - openIndex - 1);
+            List<int> cuts = FindLevelZero(inside, ',', '[', ']');
+            List<string> parts = SplitByIndices(inside, cuts);
+
+            for (int i = 0; i < parts.Count; i++)
+            {
+                parts[i] = UnqualifiedName(parts[i].Trim('[', ']', ' '));
+            }
+
+            return qualifiedName.Substring(0, openIndex + 1) + parts.Aggregate((a, b) => a + ',' + b) + "]";
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static List<int> FindLevelZero(string text, char splitChar, char levelUpChar, char levelDownChar)
+        {
+            int level = 0;
+            List<int> indices = new List<int>();
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                char currentChar = text[i];
+                if (currentChar == levelUpChar)
+                    level++;
+                else if (currentChar == levelDownChar)
+                    level--;
+                else if (currentChar == splitChar && level == 0)
+                    indices.Add(i);
+            }
+
+            return indices;
+        }
+
+        /***************************************************/
+
+        public static List<string> SplitByIndices(string text, List<int> indices)
+        {
+            int previousIndex = 0;
+            List<string> result = new List<string>();
+
+            foreach (int index in indices.OrderBy(x => x))
+            {
+                result.Add(text.Substring(previousIndex, index - previousIndex));
+                previousIndex = index + 1;
+            }
+            result.Add(text.Substring(previousIndex));
+
+            return result;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Reflection_Engine/Reflection_Engine.csproj
+++ b/Reflection_Engine/Reflection_Engine.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Query\UsedAssemblies.cs" />
     <Compile Include="Query\UsedNamespaces.cs" />
     <Compile Include="Query\InheritedTypes.cs" />
+    <Compile Include="Compute\UnqualifiedName.cs" />
     <Compile Include="Query\UsedTypes.cs" />
     <Compile Include="Query\Events.cs" />
     <Compile Include="Query\DebugLog.cs" />

--- a/Serialiser_Engine/Objects/MemberMapConventions/GenericDiscriminatorConvention.cs
+++ b/Serialiser_Engine/Objects/MemberMapConventions/GenericDiscriminatorConvention.cs
@@ -68,7 +68,7 @@ namespace BH.Engine.Serialiser.Objects.MemberMapConventions
                     }
                     if (BsonSerializer.IsTypeDiscriminated(nominalType))
                         actualType = BsonSerializer.LookupActualType(nominalType, discriminator);
-                    else if (nominalType.ToString() != discriminator.ToString() && Config.AllowUpgradeFromBson && !Config.TypesWithoutUpgrade.Contains(actualType))
+                    else if (Reflection.Compute.UnqualifiedName(nominalType.FullName) != Reflection.Compute.UnqualifiedName(discriminator.ToString()) && Config.AllowUpgradeFromBson && !Config.TypesWithoutUpgrade.Contains(actualType))
                         actualType = typeof(IDeprecated);
 
                 }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1340

<!-- Add short description of what has been fixed -->


### Test files

- For the bug fix itself:
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Serializer_Engine/Serialiser_Engine-Issue1340-FailingToDeserialiseLoads.gh?csf=1&e=qhxese

- To make sure nothing is broken on the backward compatibility side
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/Versioning_Toolkit/Issue5_deserialise_Test.gh?csf=1&e=Ke9V5v

- To make sure `UnqualifyName` method work in all case:
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Reflection_Engine/Serialiser_Engine-Issue1340-UnqualifyName.gh?csf=1&e=ggdhbU


### Additional comments
Notice that I unqualify the name on both sides (nominalType and discriminator) because Type.ToString() gives us extra stuff when deserialising a generic template type (e.g. BHoM_Group`1[T]). 