### PR TITLE
Reflection_Engine: Remove the instance from the list of arguments when calculating an instance method

### DIFF
--- a/Reflection_Engine/Convert/ToFunc.cs
+++ b/Reflection_Engine/Convert/ToFunc.cs
@@ -103,14 +103,14 @@ namespace BH.Engine.Reflection
 
         public static Func<object[], object> ToFunc(this Func<object, object[], object> func)
         {
-            return inputs => { return func(inputs[0], inputs); };
+            return inputs => { return func(inputs[0], inputs.Skip(1).ToArray()); };
         }
 
         /***************************************************/
 
         public static Func<object[], object> ToFunc(this Action<object, object[]> act)
         {
-            return inputs => { act(inputs[0], inputs); return true; };
+            return inputs => { act(inputs[0], inputs.Skip(1).ToArray()); return true; };
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1345 
<!-- Add short description of what has been fixed -->
As described in the issue, when calling an instance method from the UI, the instance itself is passed as an argument. This pr is just removing that from that list.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EZp-V_m8TcZHmpyYCHk2uUIBazpG9AAh-flvoFqsMo9IYw?e=BdiNrm

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fix inputs handling when dealing with instance methods in the UI
