### PR TITLE
Adding Create method for IResultRequest from type

### DIFF
--- a/Structure_Engine/Create/IResultRequest.cs
+++ b/Structure_Engine/Create/IResultRequest.cs
@@ -1,0 +1,130 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Collections;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Base;
+using BH.oM.Structure.Requests;
+using BH.oM.Data.Requests;
+using BH.oM.Structure.Results;
+
+namespace BH.Engine.Structure
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Generates a IResultRequest of the appropriate type based on provided type as well as optional ids, cases and divisions."+
+            "\n As a user, please have a look at BarResultRequest, MeshResultRequest, NodeResultRequest and GlobalResultRequest instead for greater control.")]
+        [Input("Type", "Type of result")]
+        [Input("ids", "Object ids to extract results for")]
+        [Input("cases", "Cases to extract results for")]
+        [Input("divisions", "Only used for bar results. Sets how many points should be looked at for the result extraction")]
+        [Output("resultRequest", "A resultRequest matching the inputs provided")]
+        public static IResultRequest IResultRequest(Type type, IList ids = null, IList cases = null, int divisions = 5)
+        {
+            IResultRequest request = null;
+
+            if (typeof(BarResult).IsAssignableFrom(type))
+            {
+                BarResultType resType = BarResultType.BarForce;
+
+                if (type == typeof(BarForce))
+                    resType = BarResultType.BarForce;
+                else if (type == typeof(BarDeformation))
+                    resType = BarResultType.BarDeformation;
+                else if (type == typeof(BarStress))
+                    resType = BarResultType.BarStress;
+                else if (type == typeof(BarStrain))
+                    resType = BarResultType.BarStrain;
+                else if (type == typeof(BarDisplacement))
+                    resType = BarResultType.BarDisplacement;
+
+                request = new BarResultRequest { Divisions = divisions, DivisionType = DivisionType.EvenlyDistributed, ResultType = resType };
+            }
+            else if (typeof(MeshResult).IsAssignableFrom(type) || typeof(MeshElementResult).IsAssignableFrom(type))
+            {
+                MeshResultType resType = MeshResultType.Forces;
+
+                if (type == typeof(MeshForce))
+                    resType = MeshResultType.Forces;
+                else if (type == typeof(MeshStress))
+                    resType = MeshResultType.Stresses;
+                else if (type == typeof(MeshVonMises))
+                    resType = MeshResultType.VonMises;
+                else if (type == typeof(MeshDisplacement))
+                    resType = MeshResultType.Displacements;
+
+                request = new MeshResultRequest { ResultType = resType };
+
+            }
+            else if (typeof(StructuralGlobalResult).IsAssignableFrom(type))
+            {
+                GlobalResultType resType = GlobalResultType.Reactions;
+
+                if (type == typeof(GlobalReactions))
+                    resType = GlobalResultType.Reactions;
+                else if (type == typeof(ModalDynamics))
+                    resType = GlobalResultType.ModalDynamics;
+
+                request = new GlobalResultRequest { ResultType = resType };
+            }
+            else if (typeof(NodeResult).IsAssignableFrom(type))
+            {
+                NodeResultType resType = NodeResultType.NodeReaction;
+
+                if (type == typeof(NodeReaction))
+                    resType = NodeResultType.NodeReaction;
+                else if (type == typeof(NodeDisplacement))
+                    resType = NodeResultType.NodeDisplacement;
+                else if (type == typeof(NodeAcceleration))
+                    resType = NodeResultType.NodeAcceleration;
+                else if (type == typeof(NodeVelocity))
+                    resType = NodeResultType.NodeVelocity;
+
+                request = new NodeResultRequest { ResultType = resType };
+            }
+            else
+            {
+                return null;
+            }
+
+
+            if (ids != null)
+                request.ObjectIds = ids.Cast<object>().ToList();
+
+            if (cases != null)
+                request.Cases = cases.Cast<object>().ToList();
+
+            return request;
+
+        }
+
+        /***************************************************/
+    }
+}

--- a/Structure_Engine/Create/IResultRequest.cs
+++ b/Structure_Engine/Create/IResultRequest.cs
@@ -64,6 +64,8 @@ namespace BH.Engine.Structure
                     resType = BarResultType.BarStrain;
                 else if (type == typeof(BarDisplacement))
                     resType = BarResultType.BarDisplacement;
+                else
+                    Reflection.Compute.RecordWarning("Did not find exact type. Assuming " + resType);
 
                 request = new BarResultRequest { Divisions = divisions, DivisionType = DivisionType.EvenlyDistributed, ResultType = resType };
             }
@@ -79,6 +81,8 @@ namespace BH.Engine.Structure
                     resType = MeshResultType.VonMises;
                 else if (type == typeof(MeshDisplacement))
                     resType = MeshResultType.Displacements;
+                else
+                    Reflection.Compute.RecordWarning("Did not find exact type. Assuming " + resType);
 
                 request = new MeshResultRequest { ResultType = resType };
 
@@ -91,6 +95,8 @@ namespace BH.Engine.Structure
                     resType = GlobalResultType.Reactions;
                 else if (type == typeof(ModalDynamics))
                     resType = GlobalResultType.ModalDynamics;
+                else
+                    Reflection.Compute.RecordWarning("Did not find exact type. Assuming " + resType);
 
                 request = new GlobalResultRequest { ResultType = resType };
             }
@@ -106,6 +112,8 @@ namespace BH.Engine.Structure
                     resType = NodeResultType.NodeAcceleration;
                 else if (type == typeof(NodeVelocity))
                     resType = NodeResultType.NodeVelocity;
+                else
+                    Reflection.Compute.RecordWarning("Did not find exact type. Assuming " + resType);
 
                 request = new NodeResultRequest { ResultType = resType };
             }

--- a/Structure_Engine/Create/IResultRequest.cs
+++ b/Structure_Engine/Create/IResultRequest.cs
@@ -46,7 +46,7 @@ namespace BH.Engine.Structure
         [Input("cases", "Cases to extract results for")]
         [Input("divisions", "Only used for bar results. Sets how many points should be looked at for the result extraction")]
         [Output("resultRequest", "A resultRequest matching the inputs provided")]
-        public static IResultRequest IResultRequest(Type type, IList ids = null, IList cases = null, int divisions = 5)
+        public static IResultRequest IResultRequest(Type type, IEnumerable<object> ids = null, IEnumerable<object> cases = null, int divisions = 5)
         {
             IResultRequest request = null;
 
@@ -116,10 +116,10 @@ namespace BH.Engine.Structure
 
 
             if (ids != null)
-                request.ObjectIds = ids.Cast<object>().ToList();
+                request.ObjectIds = ids.ToList();
 
             if (cases != null)
-                request.Cases = cases.Cast<object>().ToList();
+                request.Cases = cases.ToList();
 
             return request;
 

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Convert\ToFramingElement.cs" />
     <Compile Include="Create\ConstantFramingProperty.cs" />
     <Compile Include="Create\FEMesh.cs" />
+    <Compile Include="Create\IResultRequest.cs" />
     <Compile Include="Create\MaterialFragment.cs" />
     <Compile Include="Modify\SetMaterial.cs" />
     <Compile Include="Modify\SetStructuralFragment.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1347 

<!-- Add short description of what has been fixed -->

Add method to turn type to appropriate IResultRequest. Main reason behind method is to be used by adapters to turn a simple filterRequest of a result type into the appropriate IResultRequest.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Structure_Engine/Issues/Issue1347-ResultRequestFromType?csf=1&e=kR4Rdb
### Additional comments
<!-- As required -->

Will need this to be able to make significant cleanups of the structural adapters for result extraction, so would be nice to get this reviewed as soon as possible! Thanks!