### PR TITLE
Environment_Engine: SpaceTime create-method now assigns hour-values correctly

### DIFF
--- a/Environment_Engine/Create/SpaceTime.cs
+++ b/Environment_Engine/Create/SpaceTime.cs
@@ -102,6 +102,7 @@ namespace BH.Engine.Environment
                 Year = year,
                 Month = month,
                 Day = day,
+                Hour = hour,
                 Minute = minute,
                 Second = second,
                 Millisecond = millisecond,


### PR DESCRIPTION

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1355 

<!-- Add short description of what has been fixed -->
Hours are now assigned correctly to the SpaceTime object.



### Test files
<!-- Link to test files to validate the proposed changes -->
[SpaceTime-Hours.zip](https://github.com/BHoM/BHoM_Engine/files/3901219/SpaceTime-Hours.zip)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->