### PR TITLE
Geometry_Engine: Missing FitPlane methods added

### DIFF
--- a/Geometry_Engine/Compute/FitPlane.cs
+++ b/Geometry_Engine/Compute/FitPlane.cs
@@ -114,17 +114,23 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static Plane FitPlane(this Ellipse curve, double tolerance = Tolerance.Distance)
+        {
+            return new Plane { Origin = curve.Centre, Normal = curve.Axis1.CrossProduct(curve.Axis2).Normalise() };
+        }
+
+        /***************************************************/
+
         public static Plane FitPlane(this Line curve, double tolerance = Tolerance.Distance)
         {
             return null;
         }
 
         /***************************************************/
-
-        [NotImplemented]
+        
         public static Plane FitPlane(this NurbsCurve curve, double tolerance = Tolerance.Distance)
         {
-            throw new NotImplementedException();
+            return curve.ControlPoints.FitPlane();
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1357 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1357%2DAddMissingFitPlaneMethods).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.Geometry.Compute.FitPlane` methods added for `BH.oM.Geometry.NurbsCurve` and `BH.oM.Geometry.Ellipse`


### Additional comments
`FitPlane` for `NurbsCurve` is simply fitting a plane into curve's control points, without taking into account curve's degree, point weights etc. - issue to be raised after this PR gets merged.