### PR TITLE
Geometry_Engine: IsPeriodic added and IsClosed fixed for NurbsCurve

### DIFF
--- a/Geometry_Engine/Query/IsClosed.cs
+++ b/Geometry_Engine/Query/IsClosed.cs
@@ -67,8 +67,7 @@ namespace BH.Engine.Geometry
             if (curve == null || curve.ControlPoints == null || curve.ControlPoints.Count < 2)
                 return false;
 
-            // TODO: This does not take into account periodic curves
-            return curve.ControlPoints.First() == curve.ControlPoints.Last();
+            return curve.ControlPoints.First().SquareDistance(curve.ControlPoints.Last()) <= tolerance * tolerance || curve.IsPeriodic();
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/IsPeriodic.cs
+++ b/Geometry_Engine/Query/IsPeriodic.cs
@@ -31,6 +31,18 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
+        public static bool IsPeriodic(this NurbsCurve curve)
+        {
+            int multiplicity = 1;
+
+            while (curve.Knots[multiplicity - 1] == curve.Knots[multiplicity])
+                multiplicity++;
+
+            return (multiplicity != curve.Degree());
+        }
+
+        /***************************************************/
+        
         public static bool IsPeriodic(this NurbsSurface surface)
         {
             int uMultiplicity = 1;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1359
Closes #1361 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Uploaded to SharePoint [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1359%2DAddIsPeriodicForNurbsCurve) and [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1361%2DIsClosedNurbsCurve).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.Geometry.Query.IsPeriodic` method added for `BH.oM.Geometry.NurbsCurve`

