### PR TITLE
Fix issue with Deprecated classes still showing up

### DIFF
--- a/Reflection_Engine/Query/IsDeprecated.cs
+++ b/Reflection_Engine/Query/IsDeprecated.cs
@@ -51,34 +51,14 @@ namespace BH.Engine.Reflection
 
         public static bool IsDeprecated(this MethodBase method)
         {
-            if (method is MethodInfo)
-                return IsDeprecated((MethodInfo)method);
-            else if (method is ConstructorInfo)
-                return IsDeprecated((ConstructorInfo)method);
-            return false;
-        }
-
-        /***************************************************/
-
-        public static bool IsDeprecated(this MethodInfo method)
-        {
             DeprecatedAttribute attribute = method.GetCustomAttribute<DeprecatedAttribute>();
             if (attribute != null)
                 return true;
-
-            return false;
-        }
-
-        /***************************************************/
-
-        public static bool IsDeprecated(this ConstructorInfo method)
-        {
-            DeprecatedAttribute attribute = method.GetCustomAttribute<DeprecatedAttribute>();
-            if (attribute != null)
-                return true;
-
-            if (method.DeclaringType.Name.StartsWith("BH.") && method.DeclaringType.IsDeprecated())
-                return true;
+   
+            if (method is ConstructorInfo)
+            {
+                return method.DeclaringType.IsDeprecated();
+            }
 
             return false;
         }

--- a/Reflection_Engine/Query/IsDeprecated.cs
+++ b/Reflection_Engine/Query/IsDeprecated.cs
@@ -51,17 +51,41 @@ namespace BH.Engine.Reflection
 
         public static bool IsDeprecated(this MethodBase method)
         {
-            DeprecatedAttribute attribute = method.GetCustomAttribute<DeprecatedAttribute>();
-            if (attribute != null)
-                return true;
-            else
-                return false;
+            if (method is MethodInfo)
+                return IsDeprecated((MethodInfo)method);
+            else if (method is ConstructorInfo)
+                return IsDeprecated((ConstructorInfo)method);
+            return false;
         }
-
 
         /***************************************************/
 
-        public static bool IsDeprecated(this Type type) 
+        public static bool IsDeprecated(this MethodInfo method)
+        {
+            DeprecatedAttribute attribute = method.GetCustomAttribute<DeprecatedAttribute>();
+            if (attribute != null)
+                return true;
+
+            return false;
+        }
+
+        /***************************************************/
+
+        public static bool IsDeprecated(this ConstructorInfo method)
+        {
+            DeprecatedAttribute attribute = method.GetCustomAttribute<DeprecatedAttribute>();
+            if (attribute != null)
+                return true;
+
+            if (method.DeclaringType.Name.StartsWith("BH.") && method.DeclaringType.IsDeprecated())
+                return true;
+
+            return false;
+        }
+
+        /***************************************************/
+
+        public static bool IsDeprecated(this Type type)
         {
             DeprecatedAttribute attribute = type.GetCustomAttribute<DeprecatedAttribute>();
             if (attribute != null)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

Following https://github.com/BHoM/BHoM_Engine/pull/1373
that had to be reverted, due to a missed bug, with https://github.com/BHoM/BHoM_Engine/pull/1377

### Issues addressed by this PR
Closes https://github.com/BHoM/BHoM_Engine/issues/1372

### Test procedure
<!-- Link to test files to validate the proposed changes -->
1. Create a grasshopper file that has a a SocketAdapter in it.
1. Compile the current branch of the BHoM_Engine and the BHoM_UI
1. Open the Socket_Toolkit, and and the `Deprecated` attribute to the `SocketAdapter` class
1.  Reopen the file you created at 1.
1. Check that it has the "OLD" label on it.

### Changelog
- `Engine.Reflection.IsDeprecated(MethodBase)` now also checks if the class is deprecated
