### PR TITLE
Physical_Geometry_Engine: Add `Normal` method for IFramingElement

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -171,6 +171,7 @@
     <Compile Include="Query\Integration.cs" />
     <Compile Include="Query\InternalEdges.cs" />
     <Compile Include="Query\Length.cs" />
+    <Compile Include="Query\ElementNormal.cs" />
     <Compile Include="Query\Normal.cs" />
     <Compile Include="Compute\FitPlane.cs" />
     <Compile Include="Query\ParameterAtPoint.cs" />

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Query\IsPolylinear.cs" />
     <Compile Include="Query\IsQuad.cs" />
     <Compile Include="Query\IsSelfIntersecting.cs" />
+    <Compile Include="Query\IsVertical.cs" />
     <Compile Include="Query\MeshIntersections.cs" />
     <Compile Include="Query\LineIntersections.cs" />
     <Compile Include="Query\Degree.cs" />

--- a/Geometry_Engine/Query/ElementNormal.cs
+++ b/Geometry_Engine/Query/ElementNormal.cs
@@ -60,9 +60,11 @@ namespace BH.Engine.Geometry
             }
             else if (curve.IIsPlanar())
             {
-                Vector tan = curve.IStartDir();   // Is this how we should define it?
+                Engine.Reflection.Compute.RecordError("The normal for non-linear elements is not implemented");
+                return null;
+                //Vector tan = curve.IStartDir();   // Is this how we should define it?
                 //Vector tan = framingElement.Location.IEndPoint() - framingElement.Location.IStartPoint();
-                return curve.IFitPlane().Normal.Rotate(orientationAngle, tan);    // The normal could potentially flip by moving some control points
+                //return curve.IFitPlane().Normal.Rotate(orientationAngle, tan);    // Warning: The normal can flip by moving some control points
             }
             else
             {

--- a/Geometry_Engine/Query/ElementNormal.cs
+++ b/Geometry_Engine/Query/ElementNormal.cs
@@ -24,6 +24,7 @@ using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Engine.Geometry
@@ -34,7 +35,10 @@ namespace BH.Engine.Geometry
         /*** Public Methods -One dimentional Element Normal*/
         /***************************************************/
 
-        public static Vector Normal(this ICurve curve, double orientationAngle)
+        [Description("Gets the Normal/local Z-axis from a element")]
+        [Input("curve","The curve to evaluate the Normal from")]
+        [Input("orientationAngle", "How much the normal is rotated about the curves axis in radians")]
+        public static Vector ElementNormal(this ICurve curve, double orientationAngle)
         {
             if (curve.IIsLinear())
             {

--- a/Geometry_Engine/Query/ElementNormal.cs
+++ b/Geometry_Engine/Query/ElementNormal.cs
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /*** Public Methods -One dimentional Element Normal*/
+        /***************************************************/
+
+        public static Vector Normal(this ICurve curve, double orientationAngle)
+        {
+            if (curve.IIsLinear())
+            {
+                Point p1 = curve.IStartPoint();
+                Point p2 = curve.IEndPoint();
+
+                Vector tan = (p2 - p1).Normalise();
+                Vector normal;
+
+                if (!IsVertical(p1, p2))
+                {
+                    normal = Vector.ZAxis;
+                    normal = (normal - tan.DotProduct(normal) * tan).Normalise();
+                }
+                else
+                {
+                    Vector locY = Vector.YAxis;
+                    locY = (locY - tan.DotProduct(locY) * tan).Normalise();
+                    normal = tan.CrossProduct(locY);
+                }
+
+                return normal.Rotate(orientationAngle, tan);
+            }
+            else if (curve.IIsPlanar())
+            {
+                Vector tan = curve.IStartDir();   // Is this how we should define it?
+                //Vector tan = framingElement.Location.IEndPoint() - framingElement.Location.IStartPoint();
+                return curve.IFitPlane().Normal.Rotate(orientationAngle, tan);    // The normal could potentially flip by moving some control points
+            }
+            else
+            {
+                Engine.Reflection.Compute.RecordError("The normal for non-planar elements is not implemented");
+                return null;
+            }
+
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+        
+        private static bool IsVertical(Point p1, Point p2)
+        {
+            double dx = p1.X - p2.X;
+            double dy = p1.Y - p2.Y;
+
+            return Math.Sqrt(dx * dx + dy * dy) < 0.0001;
+        }
+
+        /***************************************************/
+
+    }
+}
+

--- a/Geometry_Engine/Query/ElementNormal.cs
+++ b/Geometry_Engine/Query/ElementNormal.cs
@@ -67,9 +67,6 @@ namespace BH.Engine.Geometry
             {
                 Engine.Reflection.Compute.RecordError("The normal for non-linear elements is not implemented");
                 return null;
-                //Vector tan = curve.IStartDir();   // Is this how we should define it?
-                //Vector tan = framingElement.Location.IEndPoint() - framingElement.Location.IStartPoint();
-                //return curve.IFitPlane().Normal.Rotate(orientationAngle, tan);    // Warning: The normal can flip by moving some control points
             }
             else
             {

--- a/Geometry_Engine/Query/ElementNormal.cs
+++ b/Geometry_Engine/Query/ElementNormal.cs
@@ -36,8 +36,9 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Gets the Normal/local Z-axis from a element")]
-        [Input("curve","The curve to evaluate the Normal from")]
+        [Input("curve", "The curve to evaluate the Normal from")]
         [Input("orientationAngle", "How much the normal is rotated about the curves axis in radians")]
+        [Output("elementNormal", "The Normal/local Z-axis of a element")]
         public static Vector ElementNormal(this ICurve curve, double orientationAngle)
         {
             if (curve.IIsLinear())

--- a/Geometry_Engine/Query/ElementNormal.cs
+++ b/Geometry_Engine/Query/ElementNormal.cs
@@ -73,19 +73,7 @@ namespace BH.Engine.Geometry
             }
 
         }
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
         
-        private static bool IsVertical(Point p1, Point p2)
-        {
-            double dx = p1.X - p2.X;
-            double dy = p1.Y - p2.Y;
-
-            return Math.Sqrt(dx * dx + dy * dy) < 0.0001;
-        }
-
         /***************************************************/
 
     }

--- a/Geometry_Engine/Query/IsVertical.cs
+++ b/Geometry_Engine/Query/IsVertical.cs
@@ -21,16 +21,21 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System;
+using System.ComponentModel;
 
 namespace BH.Engine.Geometry
 {
     public static partial class Query
     {
         /***************************************************/
-        /**** Private Methods                           ****/
+        /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Evaluates whether a line is vertical from its start- and endpoints projected 2d-distance")]
+        [Input("line", "The line to determine the verticality of")]
+        [Output("isVertical", "If it is vertical")]
         public static bool IsVertical(this Line line)
         {
             return IsVertical(line.Start, line.End);

--- a/Geometry_Engine/Query/IsVertical.cs
+++ b/Geometry_Engine/Query/IsVertical.cs
@@ -1,6 +1,6 @@
 /*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -21,46 +21,34 @@
  */
 
 using BH.oM.Geometry;
-using BH.oM.Structure.Elements;
-using BH.Engine.Geometry;
 using System;
-using System.Linq;
-using System.ComponentModel;
-using BH.oM.Reflection.Attributes;
 
-namespace BH.Engine.Structure
+namespace BH.Engine.Geometry
 {
     public static partial class Query
     {
         /***************************************************/
-        /**** Public Methods                            ****/
+        /**** Private Methods                           ****/
         /***************************************************/
 
-        [Description("Returns the bars local Z-axis")]
-        [Input("bar","The relevant Bar")]
-        [Output("normal","Vector representing the bars local Z-axis")]
-        public static Vector Normal(this Bar bar)
+        public static bool IsVertical(this Line line)
         {
-            return bar.Centreline().Normal(bar.OrientationAngle);
+            return IsVertical(line.Start, line.End);
         }
 
         /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
 
-        public static Vector Normal(this Panel panel)
+        private static bool IsVertical(Point p1, Point p2)
         {
-            return panel.AllEdgeCurves().SelectMany(x => x.IControlPoints()).ToList().FitPlane().Normal;
+            double dx = p1.X - p2.X;
+            double dy = p1.Y - p2.Y;
+
+            return Math.Sqrt(dx * dx + dy * dy) < 0.0001;
         }
 
-        /***************************************************/
-        /**** Public Methods - Interface methods        ****/
-        /***************************************************/
-
-        public static Vector INormal(this IAreaElement areaElement)
-        {
-            return Normal(areaElement as dynamic);
-        }
 
         /***************************************************/
-
     }
 }

--- a/Geometry_Engine/Query/IsVertical.cs
+++ b/Geometry_Engine/Query/IsVertical.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Geometry
 
         [Description("Evaluates whether a line is vertical from its start- and endpoints projected 2d-distance")]
         [Input("line", "The line to determine the verticality of")]
-        [Output("isVertical", "If it is vertical")]
+        [Output("isVertical", "If it is vertical, as defined in the wiki: https://github.com/BHoM/documentation/wiki/BHoM-Structural-Conventions")]
         public static bool IsVertical(this Line line)
         {
             return IsVertical(line.Start, line.End);

--- a/Physical_Engine/Physical_Engine.csproj
+++ b/Physical_Engine/Physical_Engine.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Modify\AddMaterialProperties.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\Construction.cs" />
+    <Compile Include="Query\Normal.cs" />
     <Compile Include="Query\Doors.cs" />
     <Compile Include="Query\Floors.cs" />
     <Compile Include="Query\Geometry.cs" />

--- a/Physical_Engine/Query/Normal.cs
+++ b/Physical_Engine/Query/Normal.cs
@@ -79,7 +79,8 @@ namespace BH.Engine.Physical
             } else if (framingElement.Location.IIsPlanar())
             {
                 Vector tan = framingElement.Location.IStartDir();   // Is this how we should define it?
-                return framingElement.Location.IFitPlane().Normal.Rotate(orientationAngle, tan);
+                //Vector tan = framingElement.Location.IEndPoint() - framingElement.Location.IStartPoint();
+                return framingElement.Location.IFitPlane().Normal.Rotate(orientationAngle, tan);    // The normal could potentially flip by moving some control points
             }
             else
             {

--- a/Physical_Engine/Query/Normal.cs
+++ b/Physical_Engine/Query/Normal.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.Physical
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns the normal of a FramingElement, which would be the Y-axis in the local coordinate syetem")]
+        [Description("Returns the normal of a FramingElement, which would be the Z-axis in the local coordinate syetem")]
         [Input("framingElement", "A FramingElement")]
         [Output("normal", "The FramingElements normal vector")]
         public static Vector Normal(this IFramingElement framingElement)

--- a/Physical_Engine/Query/Normal.cs
+++ b/Physical_Engine/Query/Normal.cs
@@ -41,15 +41,14 @@ namespace BH.Engine.Physical
         /***************************************************/
 
         [Description("Returns the normal of a FramingElement, which would be the Z-axis in the local coordinate syetem")]
-        [Input("framingElement", "A FramingElement")]
+        [Input("framingElement", "The FramingElement to evaluate the normal of")]
         [Output("normal", "The FramingElements normal vector")]
         public static Vector Normal(this IFramingElement framingElement)
         {
-            double orientationAngle;
+            double orientationAngle = 0;
             if (!(framingElement.Property is ConstantFramingProperty))
             {
                 Reflection.Compute.RecordWarning("No ConstantFramingProperty found, OrientationAngle set as 0");
-                orientationAngle = 0;
             } else
             {
                 orientationAngle = (framingElement.Property as ConstantFramingProperty).OrientationAngle;

--- a/Physical_Engine/Query/Normal.cs
+++ b/Physical_Engine/Query/Normal.cs
@@ -1,0 +1,105 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Physical.Elements;
+using BH.oM.Base;
+
+using BH.Engine.Base;
+using BH.oM.Geometry;
+using BH.Engine.Geometry;
+using BH.oM.Physical.FramingProperties;
+using System;
+
+namespace BH.Engine.Physical
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Returns the normal of a FramingElement, which would be the Y-axis in the local coordinate syetem")]
+        [Input("framingElement", "A FramingElement")]
+        [Output("normal", "The FramingElements normal vector")]
+        public static Vector Normal(this IFramingElement framingElement)
+        {
+            double orientationAngle;
+            if (!(framingElement.Property is ConstantFramingProperty))
+            {
+                Reflection.Compute.RecordWarning("No ConstantFramingProperty found, OrientationAngle set as 0");
+                orientationAngle = 0;
+            } else
+            {
+                orientationAngle = (framingElement.Property as ConstantFramingProperty).OrientationAngle;
+            }
+
+            if (framingElement.Location.IIsLinear())
+            {
+                Point p1 = framingElement.Location.IStartPoint();
+                Point p2 = framingElement.Location.IEndPoint();
+
+                Vector tan = (p2 - p1).Normalise();
+                Vector normal;
+
+                if (!IsVertical(p1, p2))
+                {
+                    normal = Vector.ZAxis;
+                    normal = (normal - tan.DotProduct(normal) * tan).Normalise();
+                }
+                else
+                {
+                    Vector locY = Vector.YAxis;
+                    locY = (locY - tan.DotProduct(locY) * tan).Normalise();
+                    normal = tan.CrossProduct(locY);
+                }
+
+                return normal.Rotate(orientationAngle, tan);
+            } else if (framingElement.Location.IIsPlanar())
+            {
+                Vector tan = framingElement.Location.IStartDir();
+                return framingElement.Location.IFitPlane().Normal.Rotate(orientationAngle, tan);
+            }
+            else
+            {
+                Engine.Reflection.Compute.RecordError("The normal for non-planar framing elements is not implemented");
+                return null;
+            }
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static bool IsVertical(Point p1, Point p2)
+        {
+            double dx = p1.X - p2.X;
+            double dy = p1.Y - p2.Y;
+
+            return Math.Sqrt(dx * dx + dy * dy) < 0.0001;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Physical_Engine/Query/Normal.cs
+++ b/Physical_Engine/Query/Normal.cs
@@ -55,7 +55,7 @@ namespace BH.Engine.Physical
                 orientationAngle = (framingElement.Property as ConstantFramingProperty).OrientationAngle;
             }
 
-            return framingElement.Location.Normal(orientationAngle);
+            return framingElement.Location.ElementNormal(orientationAngle);
         }
 
         /***************************************************/

--- a/Physical_Engine/Query/Normal.cs
+++ b/Physical_Engine/Query/Normal.cs
@@ -55,50 +55,7 @@ namespace BH.Engine.Physical
                 orientationAngle = (framingElement.Property as ConstantFramingProperty).OrientationAngle;
             }
 
-            if (framingElement.Location.IIsLinear())
-            {
-                Point p1 = framingElement.Location.IStartPoint();
-                Point p2 = framingElement.Location.IEndPoint();
-
-                Vector tan = (p2 - p1).Normalise();
-                Vector normal;
-
-                if (!IsVertical(p1, p2))
-                {
-                    normal = Vector.ZAxis;
-                    normal = (normal - tan.DotProduct(normal) * tan).Normalise();
-                }
-                else
-                {
-                    Vector locY = Vector.YAxis;
-                    locY = (locY - tan.DotProduct(locY) * tan).Normalise();
-                    normal = tan.CrossProduct(locY);
-                }
-
-                return normal.Rotate(orientationAngle, tan);
-            } else if (framingElement.Location.IIsPlanar())
-            {
-                Vector tan = framingElement.Location.IStartDir();   // Is this how we should define it?
-                //Vector tan = framingElement.Location.IEndPoint() - framingElement.Location.IStartPoint();
-                return framingElement.Location.IFitPlane().Normal.Rotate(orientationAngle, tan);    // The normal could potentially flip by moving some control points
-            }
-            else
-            {
-                Engine.Reflection.Compute.RecordError("The normal for non-planar framing elements is not implemented");
-                return null;
-            }
-        }
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
-
-        private static bool IsVertical(Point p1, Point p2)
-        {
-            double dx = p1.X - p2.X;
-            double dy = p1.Y - p2.Y;
-
-            return Math.Sqrt(dx * dx + dy * dy) < 0.0001;
+            return framingElement.Location.Normal(orientationAngle);
         }
 
         /***************************************************/

--- a/Physical_Engine/Query/Normal.cs
+++ b/Physical_Engine/Query/Normal.cs
@@ -78,7 +78,7 @@ namespace BH.Engine.Physical
                 return normal.Rotate(orientationAngle, tan);
             } else if (framingElement.Location.IIsPlanar())
             {
-                Vector tan = framingElement.Location.IStartDir();
+                Vector tan = framingElement.Location.IStartDir();   // Is this how we should define it?
                 return framingElement.Location.IFitPlane().Normal.Rotate(orientationAngle, tan);
             }
             else

--- a/Structure_Engine/Query/IsVertical.cs
+++ b/Structure_Engine/Query/IsVertical.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Structure
 
         public static bool IsVertical(this Bar bar)
         {
-            return IsVertical(bar.StartNode.Position(), bar.EndNode.Position());
+            return Engine.Geometry.Query.IsVertical(bar.Centreline());
         }
 
         /***************************************************/
@@ -45,29 +45,10 @@ namespace BH.Engine.Structure
         [Deprecated("2.3", "Methods replaced with methods targeting BH.oM.Physical.Elements.IFramingElement")]
         public static bool IsVertical(this FramingElement element)
         {
-            return IsVertical(element.LocationCurve.IStartPoint(), element.LocationCurve.IEndPoint()); //TODO: is this correct? what is the framing element is curved?
+            return Engine.Geometry.Query.IsVertical(new Line() { Start = element.LocationCurve.IStartPoint(), End = element.LocationCurve.IEndPoint() } ); //TODO: is this correct? what is the framing element is curved?
         }
 
         /***************************************************/
 
-        public static bool IsVertical(this Line line)
-        {
-            return IsVertical(line.Start, line.End);
-        }
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
-
-        private static bool IsVertical(Point p1, Point p2)
-        {
-            double dx = p1.X - p2.X;
-            double dy = p1.Y - p2.Y;
-
-            return Math.Sqrt(dx * dx + dy * dy) < 0.0001;
-        }
-
-
-        /***************************************************/
     }
 }

--- a/Structure_Engine/Query/IsVertical.cs
+++ b/Structure_Engine/Query/IsVertical.cs
@@ -42,6 +42,14 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Deprecated("3.1", "Moved to Geometry_Engine")]
+        public static bool IsVertical(this Line line)
+        {
+            return Engine.Geometry.Query.IsVertical(line);
+        }
+
+        /***************************************************/
+
         [Deprecated("2.3", "Methods replaced with methods targeting BH.oM.Physical.Elements.IFramingElement")]
         public static bool IsVertical(this FramingElement element)
         {

--- a/Structure_Engine/Query/Normal.cs
+++ b/Structure_Engine/Query/Normal.cs
@@ -37,8 +37,8 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Returns the bars local Z-axis")]
-        [Input("bar","The relevant Bar")]
-        [Output("normal","Vector representing the bars local Z-axis")]
+        [Input("bar", "The Bar to evaluate the normal of")]
+        [Output("normal", "Vector representing the bars local Z-axis")]
         public static Vector Normal(this Bar bar)
         {
             return bar.Centreline().ElementNormal(bar.OrientationAngle);

--- a/Structure_Engine/Query/Normal.cs
+++ b/Structure_Engine/Query/Normal.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Structure
         [Output("normal","Vector representing the bars local Z-axis")]
         public static Vector Normal(this Bar bar)
         {
-            return bar.Centreline().Normal(bar.OrientationAngle);
+            return bar.Centreline().ElementNormal(bar.OrientationAngle);
         }
 
         /***************************************************/

--- a/Structure_Engine/Query/Normal.cs
+++ b/Structure_Engine/Query/Normal.cs
@@ -36,27 +36,7 @@ namespace BH.Engine.Structure
 
         public static Vector Normal(this Bar bar)
         {
-
-            Point p1 = bar.StartNode.Position();
-            Point p2 = bar.EndNode.Position();
-
-            Vector tan = (p2 - p1).Normalise();
-            Vector normal;
-
-            if (!IsVertical(p1, p2))
-            {
-                normal = Vector.ZAxis;              
-                normal = (normal - tan.DotProduct(normal) * tan).Normalise();
-            }
-            else
-            {
-                Vector locY = Vector.YAxis;
-                locY = (locY - tan.DotProduct(locY) * tan).Normalise();
-                normal = tan.CrossProduct(locY);
-            }
-
-
-            return normal.Rotate(bar.OrientationAngle, tan);
+            return bar.Centreline().Normal(bar.OrientationAngle);
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
Closes #1401 
Adds a method for getting the Normal (Z-axis) of a IFramingElement and a central method in the Geometry_Engine which mirrors the existing one in the Structure_Engine.

#### Current snags:
Named the file in Geometry_Engine `ElementNormal` since it already existed a `Normal.cs` with other kinds of normal, but it still doesn't feel like the right place for it.

The `orientationAngle` should rotate the default normal around an axis, and for a curved element, is that the initial direction, start/end point or something else? Almost feels like one would like to be able to query the normal at every point of the element.

A very low amount of change to a curved element can flip the default normal:
![image](https://user-images.githubusercontent.com/53530468/71907981-16ab3b80-3165-11ea-8519-e89c7261080f.png)
@IsakNaslundBh That feels very unsafe, it is however technically not a problem yet because... (turns out I forgot `PolyCurves` which will also have this problem)

For some reason `FitPlane()` works fine for `NurbCurve`, but `IsLinear()` and `IsPlanar()` it is'nt implemented. (It is also not implemented for `IStartDir()` which is more understandable, so that would also be an hold-up if we go with that route), so this method will not run with `NurbCurve`. Is this a case of not sure of how to solve it right or haven't done it yet @pawelbaran 

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EWDDw9vvDOBPmkDCdsU_ZEUBlqbWmfcoJymc3IVqkTBehg?e=JysInw

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Adds `Normal(ICurve curve, double orientationAngle)` in the Geometry_Engine

### Additional comments
<!-- As required -->