### PR TITLE
Geometry Engine: fix Offset(PolyCurve) Arcs bug

### DIFF
--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -587,8 +587,10 @@ namespace BH.Engine.Geometry
             if (!((curve1 is Line || curve1 is Arc) && (curve2 is Line || curve2 is Arc))) //for now works only with combinations of lines and arcs
                 throw new NotImplementedException();
 
-            if (Compute.IJoin(new List<ICurve> { curve1, curve2 }, tolerance).Count == 1)
-                return Compute.IJoin(new List<ICurve> { curve1, curve2 }, tolerance)[0];
+            List<PolyCurve> joinCurves = Compute.IJoin(new List<ICurve> { curve1, curve2 }, tolerance).ToList();
+
+            if (joinCurves.Count == 1)
+                return joinCurves[0];
 
             List<ICurve> resultCurves = new List<ICurve>();
 

--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -60,7 +60,7 @@ namespace BH.Engine.Geometry
             if (offset == 0)
                 return curve;
 
-            double radius = curve.Radius;            
+            double radius = curve.Radius;
 
             if (normal == null)
                 normal = curve.Normal();
@@ -97,7 +97,7 @@ namespace BH.Engine.Geometry
             if (offset == 0)
                 return curve;
 
-            double radius = curve.Radius;            
+            double radius = curve.Radius;
 
             if (normal == null)
                 normal = curve.Normal;
@@ -322,7 +322,7 @@ namespace BH.Engine.Geometry
             {
                 result.Curves.Add(Offset((Circle)ICrvs[0], offset, normal));
                 return result;
-            }           
+            }
 
             //First - offseting each individual element
             List<ICurve> offsetCurves = new List<ICurve>();
@@ -475,7 +475,7 @@ namespace BH.Engine.Geometry
             if (connectingError)
                 Reflection.Compute.RecordWarning("Couldn't connect offset subCurves properly.");
 
-            if (offsetCurves.Count == 0 || (isClosed && offsetCurves.Count < 3))
+            if (offsetCurves.Count == 0)
             {
                 Reflection.Compute.RecordError("Method failed to produce correct offset. Returning null.");
                 return null;
@@ -586,6 +586,9 @@ namespace BH.Engine.Geometry
 
             if (!((curve1 is Line || curve1 is Arc) && (curve2 is Line || curve2 is Arc))) //for now works only with combinations of lines and arcs
                 throw new NotImplementedException();
+
+            if (Compute.IJoin(new List<ICurve> { curve1, curve2 }, tolerance).Count == 1)
+                return Compute.IJoin(new List<ICurve> { curve1, curve2 }, tolerance)[0];
 
             List<ICurve> resultCurves = new List<ICurve>();
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Fixing a bug that occurred while offsetting a PolyCurve consisting of Arcs which were parts of one circle.

Closes #1407 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Same file](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue1407%2DOffsetArcsIntoCircleBug) that was in the issue.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Modify.Offset()` method updated in the `Geometry_Engine` for `PolyCurve` class.
- `Modify.Fillet()` private method updated in the `Geometry_Engine`. 

### Additional comments
<!-- As required -->