### PR TITLE
Structure_Engine: Add support for Timber, Aluminium and Generic sections

### DIFF
--- a/Structure_Engine/Create/AluminiumSection.cs
+++ b/Structure_Engine/Create/AluminiumSection.cs
@@ -39,11 +39,11 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Creates a aluminium section from any shape profile")]
-        [Input("profile", "Profile containing the geometric information to be used to create the aluminium section")]
-        [Input("material", "Aluminium material to use on the section")]
-        [Input("name", "Name of the section. If no name is provided, the name from the profile will be used")]
-        [Output("alumSec", "The created aluminium section")]
+        [Description("Generates a aluminium section based on a Profile and a material. \n This is the main create method for aluminium sections, responsible for calculating section constants etc. and is being called from all other create methods for aluminium sections")]
+        [Input("profile", "The section profile the aluminium section. All section constants are derived based on the dimensions of this")]
+        [Input("material", "aluminium material to be used on the section.")]
+        [Input("name", "Name of the aluminium section. If null or empty the name of the profile will be used")]
+        [Output("section", "The created aluminium section")]
         public static AluminiumSection AluminiumSectionFromProfile(IProfile profile, Aluminium material = null, string name = "")
         {
             //Check name

--- a/Structure_Engine/Create/AluminiumSection.cs
+++ b/Structure_Engine/Create/AluminiumSection.cs
@@ -69,9 +69,6 @@ namespace BH.Engine.Structure
                 (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
                 (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
 
-            //section.CustomData["VerticalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["VerticalSlices"]);
-            //section.CustomData["HorizontalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["HorizontalSlices"]);
-
             if (material == null)
             {
                 material = Query.Default(oM.Structure.MaterialFragments.MaterialType.Aluminium) as Aluminium;

--- a/Structure_Engine/Create/AluminiumSection.cs
+++ b/Structure_Engine/Create/AluminiumSection.cs
@@ -1,0 +1,90 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Geometry.ShapeProfiles;
+using BH.oM.Geometry;
+using BH.oM.Structure.MaterialFragments;
+using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
+using System.Linq;
+using System.ComponentModel;
+
+namespace BH.Engine.Structure
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Creates a aluminium section from any shape profile")]
+        [Input("profile", "Profile containing the geometric information to be used to create the aluminium section")]
+        [Input("material", "Aluminium material to use on the section")]
+        [Input("name", "Name of the section. If no name is provided, the name from the profile will be used")]
+        [Output("alumSec", "The created aluminium section")]
+        public static AluminiumSection AluminiumSection(IProfile profile, Aluminium material = null, string name = "")
+        {
+            //Check name
+            if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
+                name = profile.Name;
+
+            //Check profile and raise warnings
+            if (profile.Edges.Count == 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
+            }
+
+            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
+
+            profile = result.Item1;
+            Dictionary<string, object> constants = result.Item2;
+
+            constants["J"] = profile.ITorsionalConstant();
+            constants["Iw"] = profile.IWarpingConstant();
+
+            AluminiumSection section = new AluminiumSection(profile,
+                (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
+                (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
+                (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
+
+            //section.CustomData["VerticalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["VerticalSlices"]);
+            //section.CustomData["HorizontalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["HorizontalSlices"]);
+
+            if (material == null)
+            {
+                material = Query.Default(oM.Structure.MaterialFragments.MaterialType.Aluminium) as Aluminium;
+            }
+
+            section.Material = material;
+            section.Name = name;
+
+
+            return section;
+
+        }
+
+        /***************************************************/
+    }
+}

--- a/Structure_Engine/Create/AluminiumSection.cs
+++ b/Structure_Engine/Create/AluminiumSection.cs
@@ -46,39 +46,18 @@ namespace BH.Engine.Structure
         [Output("section", "The created aluminium section")]
         public static AluminiumSection AluminiumSectionFromProfile(IProfile profile, Aluminium material = null, string name = "")
         {
-            //Check name
-            if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
-                name = profile.Name;
-
-            //Check profile and raise warnings
-            if (profile.Edges.Count == 0)
-            {
-                Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
-            }
-
-            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
-
-            profile = result.Item1;
-            Dictionary<string, object> constants = result.Item2;
-
-            constants["J"] = profile.ITorsionalConstant();
-            constants["Iw"] = profile.IWarpingConstant();
+            //Run pre-process for section create. Calculates all section constants and checks name of profile
+            var preProcessValues = PreProcessSectionCreate(name, profile);
+            name = preProcessValues.Item1;
+            profile = preProcessValues.Item2;
+            Dictionary<string, object> constants = preProcessValues.Item3;
 
             AluminiumSection section = new AluminiumSection(profile,
                 (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
                 (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
                 (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
 
-            if (material == null)
-            {
-                material = Query.Default(oM.Structure.MaterialFragments.MaterialType.Aluminium) as Aluminium;
-            }
-
-            section.Material = material;
-            section.Name = name;
-
-
-            return section;
+            return PostProcessSectionCreate(section, name, material, MaterialType.Aluminium);
 
         }
 

--- a/Structure_Engine/Create/AluminiumSection.cs
+++ b/Structure_Engine/Create/AluminiumSection.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Structure
         [Input("material", "Aluminium material to use on the section")]
         [Input("name", "Name of the section. If no name is provided, the name from the profile will be used")]
         [Output("alumSec", "The created aluminium section")]
-        public static AluminiumSection AluminiumSection(IProfile profile, Aluminium material = null, string name = "")
+        public static AluminiumSection AluminiumSectionFromProfile(IProfile profile, Aluminium material = null, string name = "")
         {
             //Check name
             if (string.IsNullOrWhiteSpace(name) && profile.Name != null)

--- a/Structure_Engine/Create/ConcreteSection.cs
+++ b/Structure_Engine/Create/ConcreteSection.cs
@@ -22,11 +22,13 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Structure.SectionProperties.Reinforcement;
 using BH.oM.Geometry;
 using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
 using BH.oM.Structure.MaterialFragments;
 using System.Linq;
 
@@ -67,6 +69,11 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Generates a concrete section based on a Profile and a material. \n This is the main create method for concrete sections, responsible for calculating section constants etc. and is being called from all other create methods for concrete sections")]
+        [Input("profile", "The section profile the concrete section. All section constants are derived based on the dimensions of this")]
+        [Input("material", "concrete material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the concrete section. If null or empty the name of the profile will be used")]
+        [Output("section", "The created concrete section")]
         public static ConcreteSection ConcreteSectionFromProfile(IProfile profile, Concrete material = null, string name = "", List<Reinforcement> reinforcement = null)
         {
 

--- a/Structure_Engine/Create/ConcreteSection.cs
+++ b/Structure_Engine/Create/ConcreteSection.cs
@@ -100,9 +100,6 @@ namespace BH.Engine.Structure
                 (double)constants["Wely"], (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
                 (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
 
-            //section.CustomData["VerticalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["VerticalSlices"]);
-            //section.CustomData["HorizontalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["HorizontalSlices"]);
-
             if (material == null)
             {
                 material = Query.Default(oM.Structure.MaterialFragments.MaterialType.Concrete) as Concrete;

--- a/Structure_Engine/Create/ConcreteSection.cs
+++ b/Structure_Engine/Create/ConcreteSection.cs
@@ -40,6 +40,13 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Creates a rectangular solid concrete section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Height of the section [m]")]
+        [Input("width", "Width of the section [m]")]
+        [Input("material", "Concrete material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the concrete section.")]
+        [Input("reinforcement", "Optional list of reinforcement to be applied to the section")]
+        [Output("section", "The created rectangular concrete section")]
         public static ConcreteSection ConcreteRectangleSection(double height, double width, Concrete material = null, string name = "", List<Reinforcement> reinforcement = null)
         {
             return ConcreteSectionFromProfile(Geometry.Create.RectangleProfile(height, width, 0), material, name, reinforcement);
@@ -47,6 +54,15 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a rectangular solid concrete section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Full height of the section [m]")]
+        [Input("webThickness", "Thickness of the web [m]")]
+        [Input("flangeWidth", "Width of the flange [m]")]
+        [Input("flangeThickness", "Thickness of the flange [m]")]
+        [Input("material", "Concrete material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the concrete section.")]
+        [Input("reinforcement", "Optional list of reinforcement to be applied to the section")]
+        [Output("section", "The created concrete T-section")]
         public static ConcreteSection ConcreteTSection(double height, double webThickness, double flangeWidth, double flangeThickness, Concrete material = null, string name = "", List<Reinforcement> reinforcement = null)
         {
             return ConcreteSectionFromProfile(Geometry.Create.TSectionProfile(height, flangeWidth, webThickness, flangeThickness, 0, 0), material, name, reinforcement);
@@ -55,6 +71,12 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a circular solid concrete section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("diameter", "Diameter of the section [m]")]
+        [Input("material", "Concrete material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the concrete section.")]
+        [Input("reinforcement", "Optional list of reinforcement to be applied to the section")]
+        [Output("section", "The created circular concrete section")]
         public static ConcreteSection ConcreteCircularSection(double diameter, Concrete material = null, string name = "", List<Reinforcement> reinforcement = null)
         {
             return ConcreteSectionFromProfile(Geometry.Create.CircleProfile(diameter), material, name, reinforcement);
@@ -62,6 +84,11 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a concrete freeform section based on edge curves. Please note that this type of section generally will have less support in adapters. If the type of section being created can be achieved by any other profile, aim use them instead.")]
+        [Input("edges", "Edges defining the section. Should consist of closed curve(s) in the global xy-plane")]
+        [Input("material", "Concrete material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the concrete section.")]
+        [Output("section", "The created free form concrete section")]
         public static ConcreteSection ConcreteFreeFormSection(List<ICurve> edges, Concrete material = null, string name = "", List<Reinforcement> reinforcement = null)
         {
             return ConcreteSectionFromProfile(Geometry.Create.FreeFormProfile(edges), material, name, reinforcement);

--- a/Structure_Engine/Create/ConstantFramingProperty.cs
+++ b/Structure_Engine/Create/ConstantFramingProperty.cs
@@ -45,11 +45,10 @@ namespace BH.Engine.Structure
         public static ConstantFramingProperty ConstantFramingProperty(ISectionProperty sectionProperty, double orientationAngle, string name = "")
         {
 
+
             IProfile profile = null;
-            if (sectionProperty is SteelSection)
-                profile = (sectionProperty as SteelSection).SectionProfile;
-            else if (sectionProperty is ConcreteSection)
-                profile = (sectionProperty as ConcreteSection).SectionProfile;
+            if (sectionProperty is IGeometricalSection)
+                profile = (sectionProperty as IGeometricalSection).SectionProfile;
             else
                 Reflection.Compute.RecordWarning("Was not able to extract any section profile");
 

--- a/Structure_Engine/Create/GenericSection.cs
+++ b/Structure_Engine/Create/GenericSection.cs
@@ -1,0 +1,82 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Geometry.ShapeProfiles;
+using BH.oM.Geometry;
+using BH.oM.Structure.MaterialFragments;
+using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
+using System.Linq;
+using System.ComponentModel;
+
+namespace BH.Engine.Structure
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Creates a generic section from any shape profile. Should only be used for material types not yet explicitly supported")]
+        [Input("profile", "Profile containing the geometric information to be used to create the generic section")]
+        [Input("material", "Material to use on the section")]
+        [Input("name", "Name of the section. If no name is provided, the name from the profile will be used")]
+        [Output("genericSec", "The created generic section")]
+        public static GenericSection GenericSection(IProfile profile, IMaterialFragment material = null, string name = "")
+        {
+            //Check name
+            if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
+                name = profile.Name;
+
+            //Check profile and raise warnings
+            if (profile.Edges.Count == 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
+            }
+
+            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
+
+            profile = result.Item1;
+            Dictionary<string, object> constants = result.Item2;
+
+            constants["J"] = profile.ITorsionalConstant();
+            constants["Iw"] = profile.IWarpingConstant();
+
+            GenericSection section = new GenericSection(profile,
+                (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
+                (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
+                (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
+
+            section.Material = material;
+            section.Name = name;
+
+
+            return section;
+
+        }
+
+        /***************************************************/
+    }
+}

--- a/Structure_Engine/Create/GenericSection.cs
+++ b/Structure_Engine/Create/GenericSection.cs
@@ -57,11 +57,7 @@ namespace BH.Engine.Structure
                 (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
                 (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
 
-            section.Material = material;
-            section.Name = name;
-
-
-            return section;
+            return PostProcessSectionCreate(section, name, material, MaterialType.Undefined);
 
         }
 

--- a/Structure_Engine/Create/GenericSection.cs
+++ b/Structure_Engine/Create/GenericSection.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Structure
         [Input("material", "Material to use on the section")]
         [Input("name", "Name of the section. If no name is provided, the name from the profile will be used")]
         [Output("genericSec", "The created generic section")]
-        public static GenericSection GenericSection(IProfile profile, IMaterialFragment material = null, string name = "")
+        public static GenericSection GenericSectionFromProfile(IProfile profile, IMaterialFragment material = null, string name = "")
         {
             //Check name
             if (string.IsNullOrWhiteSpace(name) && profile.Name != null)

--- a/Structure_Engine/Create/GenericSection.cs
+++ b/Structure_Engine/Create/GenericSection.cs
@@ -46,23 +46,11 @@ namespace BH.Engine.Structure
         [Output("genericSec", "The created generic section")]
         public static GenericSection GenericSectionFromProfile(IProfile profile, IMaterialFragment material = null, string name = "")
         {
-            //Check name
-            if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
-                name = profile.Name;
-
-            //Check profile and raise warnings
-            if (profile.Edges.Count == 0)
-            {
-                Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
-            }
-
-            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
-
-            profile = result.Item1;
-            Dictionary<string, object> constants = result.Item2;
-
-            constants["J"] = profile.ITorsionalConstant();
-            constants["Iw"] = profile.IWarpingConstant();
+            //Run pre-process for section create. Calculates all section constants and checks name of profile
+            var preProcessValues = PreProcessSectionCreate(name, profile);
+            name = preProcessValues.Item1;
+            profile = preProcessValues.Item2;
+            Dictionary<string, object> constants = preProcessValues.Item3;
 
             GenericSection section = new GenericSection(profile,
                 (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],

--- a/Structure_Engine/Create/SectionProperty.cs
+++ b/Structure_Engine/Create/SectionProperty.cs
@@ -1,0 +1,73 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Geometry.ShapeProfiles;
+using BH.oM.Structure.MaterialFragments;
+
+namespace BH.Engine.Structure
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Creates a Section property from a Profile and a Material. The type of section that will be created depends on the material provided. Null material or unsupported materials will return a GenericSection.")]
+        [Input("profile", "The profile of the section property")]
+        [Input("material", "The material of the section property. Used to determain which type of section that will be created. If null or a not yet explicitly supported material type, a generic section will be created.")]
+        [Input("name", "The name of the section property")]
+        [Output("section", "The created section property of a type matching the material provided.")]
+        public static IGeometricalSection SectionPropertyFromProfile(IProfile profile, IMaterialFragment material = null, string name = "")
+        {
+            MaterialType materialType = material == null ? MaterialType.Undefined : material.IMaterialType();
+
+            switch (materialType)
+            {
+                case MaterialType.Steel:
+                    return SteelSectionFromProfile(profile, material as Steel, name);
+                case MaterialType.Concrete:
+                    return ConcreteSectionFromProfile(profile, material as Concrete, name);
+                case MaterialType.Aluminium:
+                    return AluminiumSectionFromProfile(profile, material as Aluminium, name);
+                case MaterialType.Timber:
+                    return TimberSectionFromProfile(profile, material as Timber, name);
+                case MaterialType.Rebar:
+                case MaterialType.Tendon:
+                case MaterialType.Glass:
+                case MaterialType.Cable:
+                case MaterialType.Undefined:
+                default:
+                    Reflection.Compute.RecordWarning("The BHoM does not currently explicitly support sections of material type " + materialType + ". A generic section has been created with the material applied to it");
+                    return GenericSectionFromProfile(profile, material, name);
+            }
+
+        }
+
+        /***************************************************/
+    }
+}

--- a/Structure_Engine/Create/SectionProperty.cs
+++ b/Structure_Engine/Create/SectionProperty.cs
@@ -106,7 +106,7 @@ namespace BH.Engine.Structure
             name = name ?? "";
             section.Name = name;
 
-            if (material == null)
+            if (material == null && materialType != MaterialType.Undefined)
             {
                 material = Query.Default(materialType);
             }

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -40,6 +40,16 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Creates a steel I-section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Full height of the section [m]")]
+        [Input("webThickness", "Thickness of the web [m]")]
+        [Input("flangeWidth", "Width of the top and bottom flange [m]")]
+        [Input("flangeThickness", "Thickness of the top and bottom flange [m]")]
+        [Input("rootRadius", "Optional fillet radius between inner face of flange and face of web [m]")]
+        [Input("toeRadius", "Optional fillet radius at the outer edge of the flange [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created steel I-section")]
         public static SteelSection SteelISection(double height, double webThickness, double flangeWidth, double flangeThickness, double rootRadius = 0, double toeRadius = 0, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.ISectionProfile(height, flangeWidth, webThickness, flangeThickness, rootRadius, toeRadius), material, name);
@@ -47,6 +57,17 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a fabricated steel I-section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Full height of the section [m]")]
+        [Input("webThickness", "Thickness of the web [m]")]
+        [Input("topFlangeWidth", "Width of the top flange [m]")]
+        [Input("topFlangeThickness", "Thickness of the top flange [m]")]
+        [Input("botFlangeWidth", "Width of the bottom flange [m]")]
+        [Input("botFlangeThickness", "Thickness of the bottom flange [m]")]
+        [Input("weldSize", "Optional fillet weld size between web and flanges. Meassured as the distance between intersection of web and flange perpendicular to the edge of the weld [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created fabricated steel I-section")]
         public static SteelSection SteelFabricatedISection(double height, double webThickness, double topFlangeWidth, double topFlangeThickness, double botFlangeWidth, double botFlangeThickness,  double weldSize, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.FabricatedISectionProfile(height, topFlangeWidth, botFlangeWidth, webThickness, topFlangeThickness, botFlangeThickness, weldSize), material, name);
@@ -54,6 +75,15 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a steel box-section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Full height of the section [m]")]
+        [Input("width", "Full width of the section [m]")]
+        [Input("thickness", "Thickness of the webs and flanges [m]")]
+        [Input("innerRadius", "Optional inner corner radius. Commonly set equal to the thickness [m]")]
+        [Input("outerRadius", "Optional outer corner radius. Commonly set to 1.5-2 times the thickness [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created steel box-section")]
         public static SteelSection SteelBoxSection(double height, double width, double thickness, double innerRadius = 0, double outerRadius = 0, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.BoxProfile(height, width, thickness, outerRadius, innerRadius), material, name);
@@ -61,15 +91,28 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a fabricated steel box-section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Full height of the section [m]")]
+        [Input("width", "Full width of the section [m]")]
+        [Input("webThickness", "Thickness of the webs [m]")]
+        [Input("flangeThickness", "Thickness of the flanges [m]")]
+        [Input("weldSize", "Optional fillet weld size between inside of web and flanges. Meassured as the distance between intersection of web and flange perpendicular to the edge of the weld [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created fabricated steel box-section")]
         public static SteelSection FabricatedSteelBoxSection(double height, double width, double webThickness, double flangeThickness, double weldSize, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.FabricatedBoxProfile(height, width, webThickness, flangeThickness, flangeThickness, weldSize), material, name);
-
-
         }
 
         /***************************************************/
 
+        [Description("Creates a circular hollow steel section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("diameter", "Outer diameter of the section [m]")]
+        [Input("thickness", "Plate thickness of the section [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created circular hollow steel section")]
         public static SteelSection SteelTubeSection(double diameter, double thickness, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.TubeProfile(diameter, thickness), material, name);
@@ -77,13 +120,25 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        public static SteelSection SteelRectangleSection(double height, double width, double cornerRadius=0, Steel material = null, string name = null)
+        [Description("Creates a rectangular solid steel section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Height of the section [m]")]
+        [Input("width", "Width of the section [m]")]
+        [Input("cornerRadius", "Optional corner radius for the section [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created rectangular solid steel section")]
+        public static SteelSection SteelRectangleSection(double height, double width, double cornerRadius = 0, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.RectangleProfile(height, width, cornerRadius), material, name);
         }
 
         /***************************************************/
 
+        [Description("Creates a circular solid steel section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("diameter", "Diameter of the section [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created circular solid steel section")]
         public static SteelSection SteelCircularSection(double diameter, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.CircleProfile(diameter), material, name);
@@ -91,6 +146,16 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a steel T-section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Full height of the section [m]")]
+        [Input("webThickness", "Thickness of the web [m]")]
+        [Input("flangeWidth", "Width of the top and bottom flange [m]")]
+        [Input("flangeThickness", "Thickness of the top and bottom flange [m]")]
+        [Input("rootRadius", "Optional fillet radius between inner face of flange and face of web [m]")]
+        [Input("toeRadius", "Optional fillet radius at the outer edge of the flange [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created steel T-section")]
         public static SteelSection SteelTSection(double height, double webThickness, double flangeWidth, double flangeThickness,  double rootRadius = 0, double toeRadius = 0, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.TSectionProfile(height, flangeWidth, webThickness, flangeThickness, rootRadius, toeRadius), material, name);
@@ -99,6 +164,16 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a steel L-section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Full height of the section [m]")]
+        [Input("webThickness", "Thickness of the web [m]")]
+        [Input("flangeWidth", "Width of the top and bottom flange [m]")]
+        [Input("flangeThickness", "Thickness of the top and bottom flange [m]")]
+        [Input("rootRadius", "Optional fillet radius between inner face of flange and face of web [m]")]
+        [Input("toeRadius", "Optional fillet radius at the outer edge of the flange [m]")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created steel L-section")]
         public static SteelSection SteelAngleSection(double height, double webThickness, double width, double flangeThickness, double rootRadius = 0, double toeRadius = 0, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.AngleProfile(height, width, webThickness, flangeThickness, rootRadius, toeRadius), material, name);
@@ -106,6 +181,11 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Creates a steel freeform section based on edge curves. Please note that this type of section generally will have less support in adapters. If the type of section being created can be achieved by any other profile, aim use them that instead.")]
+        [Input("edges", "Edges defining the section. Should consist of closed curve(s) in the global xy-plane")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section.")]
+        [Output("section", "The created free form steel section")]
         public static SteelSection SteelFreeFormSection(List<ICurve> edges, Steel material = null, string name = null)
         {
             return SteelSectionFromProfile(Geometry.Create.FreeFormProfile(edges), material, name);

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -181,7 +181,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Creates a steel freeform section based on edge curves. Please note that this type of section generally will have less support in adapters. If the type of section being created can be achieved by any other profile, aim use them that instead.")]
+        [Description("Creates a steel freeform section based on edge curves. Please note that this type of section generally will have less support in adapters. If the type of section being created can be achieved by any other profile, aim use them instead.")]
         [Input("edges", "Edges defining the section. Should consist of closed curve(s) in the global xy-plane")]
         [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
         [Input("name", "Name of the steel section.")]

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -22,11 +22,13 @@
 
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Geometry;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
 using System.Linq;
 
 
@@ -111,6 +113,11 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Generates a steel section based on a Profile and a material. \n This is the main create method for steel sections, responsible for calculating section constants etc. and is being called from all other create methods for steel sections")]
+        [Input("profile", "The section profile the steel section. All section constants are derived based on the dimensions of this")]
+        [Input("material", "Steel material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the steel section. If null or empty the name of the profile will be used")]
+        [Output("section", "The created steel section")]
         public static SteelSection SteelSectionFromProfile(IProfile profile, Steel material = null, string name = "")
         {
             //Check name

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -200,39 +200,19 @@ namespace BH.Engine.Structure
         [Output("section", "The created steel section")]
         public static SteelSection SteelSectionFromProfile(IProfile profile, Steel material = null, string name = "")
         {
-            //Check name
-            if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
-                name = profile.Name;
-
-            //Check profile and raise warnings
-            if (profile.Edges.Count == 0)
-            {
-                Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
-            }
-
-            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
-
-            profile = result.Item1;
-            Dictionary<string, object> constants = result.Item2;
-
-            constants["J"] = profile.ITorsionalConstant();
-            constants["Iw"] = profile.IWarpingConstant();
+            //Run pre-process for section create. Calculates all section constants and checks name of profile
+            var preProcessValues = PreProcessSectionCreate(name, profile);
+            name = preProcessValues.Item1;
+            profile = preProcessValues.Item2;
+            Dictionary<string,object> constants= preProcessValues.Item3;
 
             SteelSection section = new SteelSection(profile,
                 (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
                 (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
                 (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
 
-            if (material == null)
-            {
-                material = Query.Default(oM.Structure.MaterialFragments.MaterialType.Steel) as Steel;
-            }
-
-            section.Material = material;
-            section.Name = name;
-
-
-            return section;
+            //Postprocess section. Sets default name if null, and grabs default material for section if noting is provided
+            return PostProcessSectionCreate(section, name, material, MaterialType.Steel);
 
         }
 

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -223,9 +223,6 @@ namespace BH.Engine.Structure
                 (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
                 (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
 
-            //section.CustomData["VerticalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["VerticalSlices"]);
-            //section.CustomData["HorizontalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["HorizontalSlices"]);
-
             if (material == null)
             {
                 material = Query.Default(oM.Structure.MaterialFragments.MaterialType.Steel) as Steel;

--- a/Structure_Engine/Create/TimberSection.cs
+++ b/Structure_Engine/Create/TimberSection.cs
@@ -27,7 +27,9 @@ using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Geometry;
 using BH.oM.Structure.MaterialFragments;
 using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
 using System.Linq;
+using System.ComponentModel;
 
 
 namespace BH.Engine.Structure
@@ -38,6 +40,25 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Creates a rectangular timber section")]
+        [Input("height", "Height of the section in meters [m]")]
+        [Input("width", "Width of the section in meters [m]")]
+        [Input("cornerRadius", "Optional corner radius of the section in meters [m]")]
+        [Input("material", "Timber material to use on the section")]
+        [Input("name", "Name of the section")]
+        [Output("timerSec","The created rectangular timber section")]
+        public static TimberSection TimberRectangleSection(double height, double width, double cornerRadius = 0, Timber material = null, string name = "")
+        {
+            return TimberSectionFromProfile(Geometry.Create.RectangleProfile(height, width, cornerRadius), material, name);
+        }
+
+        /***************************************************/
+
+        [Description("Creates a timber section from any shape profile")]
+        [Input("profile", "Profile containing the geometric information to be used to create the timber section")]
+        [Input("material", "Timber material to use on the section")]
+        [Input("name", "Name of the section. If no name is provided, the name from the profile will be used")]
+        [Output("timerSec", "The created timber section")]
         public static TimberSection TimberSectionFromProfile(IProfile profile, Timber material = null, string name = "")
         {
             //Check name

--- a/Structure_Engine/Create/TimberSection.cs
+++ b/Structure_Engine/Create/TimberSection.cs
@@ -1,0 +1,84 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2018, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using BH.oM.Structure.SectionProperties;
+using BH.oM.Geometry.ShapeProfiles;
+using BH.oM.Geometry;
+using BH.oM.Structure.MaterialFragments;
+using BH.oM.Reflection;
+using System.Linq;
+
+
+namespace BH.Engine.Structure
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static TimberSection TimberSectionFromProfile(IProfile profile, Timber material = null, string name = "")
+        {
+            //Check name
+            if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
+                name = profile.Name;
+
+            //Check profile and raise warnings
+            if (profile.Edges.Count == 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
+            }
+
+            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
+
+            profile = result.Item1;
+            Dictionary<string, object> constants = result.Item2;
+
+            constants["J"] = profile.ITorsionalConstant();
+            constants["Iw"] = profile.IWarpingConstant();
+
+            TimberSection section = new TimberSection(profile,
+                (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
+                (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
+                (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
+
+            //section.CustomData["VerticalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["VerticalSlices"]);
+            //section.CustomData["HorizontalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["HorizontalSlices"]);
+
+            if (material == null)
+            {
+                material = Query.Default(oM.Structure.MaterialFragments.MaterialType.Timber) as Timber;
+            }
+
+            section.Material = material;
+            section.Name = name;
+
+
+            return section;
+
+        }
+
+        /***************************************************/
+    }
+}

--- a/Structure_Engine/Create/TimberSection.cs
+++ b/Structure_Engine/Create/TimberSection.cs
@@ -40,13 +40,13 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Creates a rectangular timber section")]
-        [Input("height", "Height of the section in meters [m]")]
-        [Input("width", "Width of the section in meters [m]")]
-        [Input("cornerRadius", "Optional corner radius of the section in meters [m]")]
-        [Input("material", "Timber material to use on the section")]
-        [Input("name", "Name of the section")]
-        [Output("timerSec","The created rectangular timber section")]
+        [Description("Creates a rectangular solid timber section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
+        [Input("height", "Height of the section [m]")]
+        [Input("width", "Width of the section [m]")]
+        [Input("cornerRadius", "Optional corner radius for the section [m]")]
+        [Input("material", "Timber material to be used on the section. If null a default material will be extracted from the database")]
+        [Input("name", "Name of the timber section.")]
+        [Output("section", "The created rectangular solid timber section")]
         public static TimberSection TimberRectangleSection(double height, double width, double cornerRadius = 0, Timber material = null, string name = "")
         {
             return TimberSectionFromProfile(Geometry.Create.RectangleProfile(height, width, cornerRadius), material, name);

--- a/Structure_Engine/Create/TimberSection.cs
+++ b/Structure_Engine/Create/TimberSection.cs
@@ -54,11 +54,11 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Creates a timber section from any shape profile")]
-        [Input("profile", "Profile containing the geometric information to be used to create the timber section")]
-        [Input("material", "Timber material to use on the section")]
-        [Input("name", "Name of the section. If no name is provided, the name from the profile will be used")]
-        [Output("timerSec", "The created timber section")]
+        [Description("Generates a timber section based on a Profile and a material. \n This is the main create method for timber sections, responsible for calculating section constants etc. and is being called from all other create methods for timber sections")]
+        [Input("profile", "The section profile the timber section. All section constants are derived based on the dimensions of this")]
+        [Input("material", "timber material to be used on the section.")]
+        [Input("name", "Name of the timber section. If null or empty the name of the profile will be used")]
+        [Output("section", "The created timber section")]
         public static TimberSection TimberSectionFromProfile(IProfile profile, Timber material = null, string name = "")
         {
             //Check name

--- a/Structure_Engine/Create/TimberSection.cs
+++ b/Structure_Engine/Create/TimberSection.cs
@@ -84,9 +84,6 @@ namespace BH.Engine.Structure
                 (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
                 (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
 
-            //section.CustomData["VerticalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["VerticalSlices"]);
-            //section.CustomData["HorizontalSlices"] = new ReadOnlyCollection<IntegrationSlice>((List<IntegrationSlice>)constants["HorizontalSlices"]);
-
             if (material == null)
             {
                 material = Query.Default(oM.Structure.MaterialFragments.MaterialType.Timber) as Timber;

--- a/Structure_Engine/Query/AnalyticalBars.cs
+++ b/Structure_Engine/Query/AnalyticalBars.cs
@@ -161,7 +161,7 @@ namespace BH.Engine.Structure
                 case oM.Structure.MaterialFragments.MaterialType.Undefined:
                 default:
                     prop = Create.GenericSection(property.Profile, prop.Material, property.Name);
-                    Reflection.Compute.RecordWarning("The BHoM does not currently support sections of material type " + fragment.IMaterialType() + ". A steel section has been created with the material applied to it");
+                    Reflection.Compute.RecordWarning("The BHoM does not currently explicitly support sections of material type " + fragment.IMaterialType() + ". A generic section has been created with the material applied to it");
                     break;
             }
 

--- a/Structure_Engine/Query/AnalyticalBars.cs
+++ b/Structure_Engine/Query/AnalyticalBars.cs
@@ -140,32 +140,7 @@ namespace BH.Engine.Structure
                 fragment = material.StructuralMaterialFragment();
             }
 
-            switch (fragment.IMaterialType())
-            {
-                case oM.Structure.MaterialFragments.MaterialType.Steel:
-                    prop = Create.SteelSectionFromProfile(property.Profile, fragment as Steel, property.Name);
-                    break;
-                case oM.Structure.MaterialFragments.MaterialType.Concrete:
-                    prop = Create.ConcreteSectionFromProfile(property.Profile, fragment as Concrete, property.Name);
-                    break;
-                case oM.Structure.MaterialFragments.MaterialType.Aluminium:
-                    prop = Create.AluminiumSectionFromProfile(property.Profile, fragment as Aluminium, property.Name);
-                    break;
-                case oM.Structure.MaterialFragments.MaterialType.Timber:
-                    prop = Create.TimberSectionFromProfile(property.Profile, fragment as Timber, property.Name);
-                    break;
-                case oM.Structure.MaterialFragments.MaterialType.Rebar:
-                case oM.Structure.MaterialFragments.MaterialType.Tendon:
-                case oM.Structure.MaterialFragments.MaterialType.Glass:
-                case oM.Structure.MaterialFragments.MaterialType.Cable:
-                case oM.Structure.MaterialFragments.MaterialType.Undefined:
-                default:
-                    prop = Create.GenericSectionFromProfile(property.Profile, fragment, property.Name);
-                    Reflection.Compute.RecordWarning("The BHoM does not currently explicitly support sections of material type " + fragment.IMaterialType() + ". A generic section has been created with the material applied to it");
-                    break;
-            }
-
-            return prop;
+            return Create.SectionPropertyFromProfile(property.Profile, fragment, property.Name);
         }
 
         /***************************************************/

--- a/Structure_Engine/Query/AnalyticalBars.cs
+++ b/Structure_Engine/Query/AnalyticalBars.cs
@@ -149,7 +149,7 @@ namespace BH.Engine.Structure
                     prop = Create.ConcreteSectionFromProfile(property.Profile, fragment as Concrete, property.Name);
                     break;
                 case oM.Structure.MaterialFragments.MaterialType.Aluminium:
-                    prop = Create.AluminiumSection(property.Profile, fragment as Aluminium, property.Name);
+                    prop = Create.AluminiumSectionFromProfile(property.Profile, fragment as Aluminium, property.Name);
                     break;
                 case oM.Structure.MaterialFragments.MaterialType.Timber:
                     prop = Create.TimberSectionFromProfile(property.Profile, fragment as Timber, property.Name);
@@ -160,7 +160,7 @@ namespace BH.Engine.Structure
                 case oM.Structure.MaterialFragments.MaterialType.Cable:
                 case oM.Structure.MaterialFragments.MaterialType.Undefined:
                 default:
-                    prop = Create.GenericSection(property.Profile, prop.Material, property.Name);
+                    prop = Create.GenericSectionFromProfile(property.Profile, prop.Material, property.Name);
                     Reflection.Compute.RecordWarning("The BHoM does not currently explicitly support sections of material type " + fragment.IMaterialType() + ". A generic section has been created with the material applied to it");
                     break;
             }

--- a/Structure_Engine/Query/AnalyticalBars.cs
+++ b/Structure_Engine/Query/AnalyticalBars.cs
@@ -118,8 +118,6 @@ namespace BH.Engine.Structure
 
         private static ISectionProperty ToSectionProperty(BHP.FramingProperties.ConstantFramingProperty property)
         {
-            ISectionProperty prop = null;
-
             BHP.Materials.Material material = property.Material;
 
             IMaterialFragment fragment;

--- a/Structure_Engine/Query/AnalyticalBars.cs
+++ b/Structure_Engine/Query/AnalyticalBars.cs
@@ -126,14 +126,14 @@ namespace BH.Engine.Structure
 
             if (material == null)
             {
-                Reflection.Compute.RecordError("The FramingElement does not contain any material. An empty steel material has been used");
-                fragment = new Steel();
+                Reflection.Compute.RecordError("The FramingElement does not contain any material. An empty generic isotropic material has been used");
+                fragment = new GenericIsotropicMaterial();
             }
             else if (!material.IsValidStructural())
             {
                 string matName = material.Name ?? "";
-                Reflection.Compute.RecordWarning("The material with name " + matName + " is not a valid structural material as it does not contain exactly one structural material fragment. An empty steel material has been assumed");
-                fragment = new Steel { Name = matName };
+                Reflection.Compute.RecordWarning("The material with name " + matName + " is not a valid structural material as it does not contain exactly one structural material fragment. An empty generic isotropic material has been assumed");
+                fragment = new GenericIsotropicMaterial { Name = matName };
             }
             else
             {
@@ -160,7 +160,7 @@ namespace BH.Engine.Structure
                 case oM.Structure.MaterialFragments.MaterialType.Cable:
                 case oM.Structure.MaterialFragments.MaterialType.Undefined:
                 default:
-                    prop = Create.GenericSectionFromProfile(property.Profile, prop.Material, property.Name);
+                    prop = Create.GenericSectionFromProfile(property.Profile, fragment, property.Name);
                     Reflection.Compute.RecordWarning("The BHoM does not currently explicitly support sections of material type " + fragment.IMaterialType() + ". A generic section has been created with the material applied to it");
                     break;
             }

--- a/Structure_Engine/Query/AnalyticalBars.cs
+++ b/Structure_Engine/Query/AnalyticalBars.cs
@@ -149,15 +149,18 @@ namespace BH.Engine.Structure
                     prop = Create.ConcreteSectionFromProfile(property.Profile, fragment as Concrete, property.Name);
                     break;
                 case oM.Structure.MaterialFragments.MaterialType.Aluminium:
+                    prop = Create.AluminiumSection(property.Profile, fragment as Aluminium, property.Name);
+                    break;
                 case oM.Structure.MaterialFragments.MaterialType.Timber:
+                    prop = Create.TimberSectionFromProfile(property.Profile, fragment as Timber, property.Name);
+                    break;
                 case oM.Structure.MaterialFragments.MaterialType.Rebar:
                 case oM.Structure.MaterialFragments.MaterialType.Tendon:
                 case oM.Structure.MaterialFragments.MaterialType.Glass:
                 case oM.Structure.MaterialFragments.MaterialType.Cable:
                 case oM.Structure.MaterialFragments.MaterialType.Undefined:
                 default:
-                    prop = Create.SteelSectionFromProfile(property.Profile, null, property.Name);
-                    prop.Material = fragment;
+                    prop = Create.GenericSection(property.Profile, prop.Material, property.Name);
                     Reflection.Compute.RecordWarning("The BHoM does not currently support sections of material type " + fragment.IMaterialType() + ". A steel section has been created with the material applied to it");
                     break;
             }

--- a/Structure_Engine/Query/Default.cs
+++ b/Structure_Engine/Query/Default.cs
@@ -54,7 +54,8 @@ namespace BH.Engine.Structure
                 case oM.Structure.MaterialFragments.MaterialType.Tendon:
                 case oM.Structure.MaterialFragments.MaterialType.Glass:
                 default:
-                    break;
+                    Reflection.Compute.RecordWarning("Could not find default material of type " + materialType);
+                    return null;
             }
 
             if (matName != null)

--- a/Structure_Engine/Query/Description.cs
+++ b/Structure_Engine/Query/Description.cs
@@ -153,6 +153,27 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        public static string Description(this TimberSection section)
+        {
+            return "Timber  " + section.SectionProfile.IDescription() + " - " + CheckGetMaterialName(section.Material);
+        }
+
+        /***************************************************/
+
+        public static string Description(this AluminiumSection section)
+        {
+            return "Aluminium " + section.SectionProfile.IDescription() + " - " + CheckGetMaterialName(section.Material);
+        }
+
+        /***************************************************/
+
+        public static string Description(this GenericSection section)
+        {
+            return "Generic " + section.SectionProfile.IDescription() + " - " + CheckGetMaterialName(section.Material);
+        }
+
+        /***************************************************/
+
         public static string Description(this CableSection section)
         {
             return "Cable " + section.NumberOfCables + " x dia " + section.CableDiameter + " - " + CheckGetMaterialName(section.Material);

--- a/Structure_Engine/Query/Extrude.cs
+++ b/Structure_Engine/Query/Extrude.cs
@@ -22,6 +22,7 @@
 
 using BH.oM.Geometry;
 using BH.oM.Structure.Elements;
+using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using System.Collections.Generic;
 using System.Linq;
@@ -39,15 +40,10 @@ namespace BH.Engine.Structure
 
         public static List<IGeometry> Extrude(this Bar bar, bool simple = false)
         {
+            if (bar.SectionProperty == null || !(bar.SectionProperty is IGeometricalSection))
+                return new List<IGeometry>();
 
-            System.Reflection.PropertyInfo prop = bar.SectionProperty.GetType().GetProperty("SectionProfile");
-
-            IProfile profile;
-
-            if (prop != null)
-                profile = prop.GetValue(bar.SectionProperty) as IProfile;
-            else
-                return null;// bar.Geometry();
+            IProfile profile = (bar.SectionProperty as IGeometricalSection).SectionProfile;
 
             List<ICurve> secCurves = profile.Edges.ToList();
 

--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -89,11 +89,18 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Deprecated("3.1", "Replaced with method for base interface IGeometricalSection", typeof(Query), "Geometry(this IGeometricalSection section)")]
         public static IGeometry Geometry(this SteelSection section)
         {
             return new CompositeGeometry { Elements = section.SectionProfile.Edges.ToList<IGeometry>() };
         }
 
+        /***************************************************/
+
+        public static IGeometry Geometry(this IGeometricalSection section)
+        {
+            return new CompositeGeometry { Elements = section.SectionProfile.Edges.ToList<IGeometry>() };
+        }
 
         /***************************************************/
 

--- a/Structure_Engine/Query/MaterialType.cs
+++ b/Structure_Engine/Query/MaterialType.cs
@@ -63,6 +63,20 @@ namespace BH.Engine.Structure
         }
 
         /***************************************************/
+
+        public static MaterialType MaterialType(this GenericIsotropicMaterial materialFragment)
+        {
+            return oM.Structure.MaterialFragments.MaterialType.Undefined;
+        }
+
+        /***************************************************/
+
+        public static MaterialType MaterialType(this GenericOrthotropicMaterial materialFragment)
+        {
+            return oM.Structure.MaterialFragments.MaterialType.Undefined;
+        }
+
+        /***************************************************/
         /**** Public Methods - Interface                ****/
         /***************************************************/
 
@@ -71,6 +85,14 @@ namespace BH.Engine.Structure
             return MaterialType(materialFragment as dynamic);
         }
 
+        /***************************************************/
+        /**** Private Methods - Fallback                ****/
+        /***************************************************/
+
+        private static MaterialType MaterialType(this IMaterialFragment materialFragment)
+        {
+            return oM.Structure.MaterialFragments.MaterialType.Undefined;
+        }
         /***************************************************/
     }
 }

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Create\FEMesh.cs" />
     <Compile Include="Create\IResultRequest.cs" />
     <Compile Include="Create\MaterialFragment.cs" />
+    <Compile Include="Create\TimberSection.cs" />
     <Compile Include="Modify\SetMaterial.cs" />
     <Compile Include="Modify\SetStructuralFragment.cs" />
     <Compile Include="Query\CoordinateSystem.cs" />

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -81,8 +81,10 @@
   <ItemGroup>
     <Compile Include="Compute\Integrate.cs" />
     <Compile Include="Convert\ToFramingElement.cs" />
+    <Compile Include="Create\AluminiumSection.cs" />
     <Compile Include="Create\ConstantFramingProperty.cs" />
     <Compile Include="Create\FEMesh.cs" />
+    <Compile Include="Create\GenericSection.cs" />
     <Compile Include="Create\IResultRequest.cs" />
     <Compile Include="Create\MaterialFragment.cs" />
     <Compile Include="Create\TimberSection.cs" />

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Create\GenericSection.cs" />
     <Compile Include="Create\IResultRequest.cs" />
     <Compile Include="Create\MaterialFragment.cs" />
+    <Compile Include="Create\SectionProperty.cs" />
     <Compile Include="Create\TimberSection.cs" />
     <Compile Include="Modify\SetMaterial.cs" />
     <Compile Include="Modify\SetStructuralFragment.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/654
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1409 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/Structure_oM/Issue555-AddingTimberALuminiumAbdGenericSections?csf=1&e=HMfIUS

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Add Create methods for Aluminium, Timber and Generic sections
- Update Geometry and Extrude methods to work with new `IGeometricalSection` interface
- Adding support for new section types for converting to and From `IFramingElement`
- Adding descriptions for create methods for section properties

### Additional comments
<!-- As required -->