### PR TITLE
BHoM_Engine: Instantiating new FragmentSet in ShallowClone method

### DIFF
--- a/BHoM_Engine/Query/ShallowClone.cs
+++ b/BHoM_Engine/Query/ShallowClone.cs
@@ -63,7 +63,7 @@ namespace BH.Engine.Base
             else
                 clone.Tags = new HashSet<string>();
 
-            if (bhomObject.Fragments != null)
+            if (bhomObject.Fragments != null && bhomObject.Fragments.Count > 0)
                 clone.Fragments = new FragmentSet(bhomObject.Fragments);
             else
                 clone.Fragments = new FragmentSet();

--- a/BHoM_Engine/Query/ShallowClone.cs
+++ b/BHoM_Engine/Query/ShallowClone.cs
@@ -63,6 +63,11 @@ namespace BH.Engine.Base
             else
                 clone.Tags = new HashSet<string>();
 
+            if (bhomObject.Fragments != null)
+                clone.Fragments = new FragmentSet(bhomObject.Fragments);
+            else
+                clone.Fragments = new FragmentSet();
+
             if (newGuid)
                 clone.BHoM_Guid = Guid.NewGuid();
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1419 

<!-- Add short description of what has been fixed -->

Creating a new `FragmentSet` when object is being cloned using `ShallowClone`

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->