### PR TITLE
Library_Engine: Added partial match method

### DIFF
--- a/Library_Engine/Query/Match.cs
+++ b/Library_Engine/Query/Match.cs
@@ -61,11 +61,8 @@ namespace BH.Engine.Library
 
         /***************************************************/
 
-        public static List<IBHoMObject> Match(string libraryName, string objectName, bool removeWhiteSpace = true, bool ignoreCase = true, bool partialMatch = true)
+        public static List<IBHoMObject> PartialMatch(string libraryName, string objectName, bool removeWhiteSpace = true, bool ignoreCase = true)
         {
-
-            if (partialMatch)
-            {
                 objectName = removeWhiteSpace ? objectName.Replace(" ", "") : objectName;
                 objectName = ignoreCase ? objectName.ToLower() : objectName;
 
@@ -78,22 +75,6 @@ namespace BH.Engine.Library
                 };
 
                 return Library(libraryName).Where(conditionalMatch).ToList();
-            }
-            else
-            {
-                objectName = removeWhiteSpace ? objectName.Replace(" ", "") : objectName;
-                objectName = ignoreCase ? objectName.ToLower() : objectName;
-
-                Func<IBHoMObject, bool> conditionalMatch = delegate (IBHoMObject x)
-                {
-                    string name = x.Name;
-                    name = removeWhiteSpace ? name.Replace(" ", "") : name;
-                    name = ignoreCase ? name.ToLower() : name;
-                    return name == objectName;
-                };
-
-                return Library(libraryName).Where(conditionalMatch).ToList();
-            }
         }
 
         /***************************************************/

--- a/Library_Engine/Query/Match.cs
+++ b/Library_Engine/Query/Match.cs
@@ -61,6 +61,43 @@ namespace BH.Engine.Library
 
         /***************************************************/
 
+        public static List<IBHoMObject> Match(string libraryName, string objectName, bool removeWhiteSpace = true, bool ignoreCase = true, bool partialMatch = true)
+        {
+
+            if (partialMatch)
+            {
+                objectName = removeWhiteSpace ? objectName.Replace(" ", "") : objectName;
+                objectName = ignoreCase ? objectName.ToLower() : objectName;
+
+                Func<IBHoMObject, bool> conditionalMatch = delegate (IBHoMObject x)
+                {
+                    string name = x.Name;
+                    name = removeWhiteSpace ? name.Replace(" ", "") : name;
+                    name = ignoreCase ? name.ToLower() : name;
+                    return name.Contains(objectName);
+                };
+
+                return Library(libraryName).Where(conditionalMatch).ToList();
+            }
+            else
+            {
+                objectName = removeWhiteSpace ? objectName.Replace(" ", "") : objectName;
+                objectName = ignoreCase ? objectName.ToLower() : objectName;
+
+                Func<IBHoMObject, bool> conditionalMatch = delegate (IBHoMObject x)
+                {
+                    string name = x.Name;
+                    name = removeWhiteSpace ? name.Replace(" ", "") : name;
+                    name = ignoreCase ? name.ToLower() : name;
+                    return name == objectName;
+                };
+
+                return Library(libraryName).Where(conditionalMatch).ToList();
+            }
+        }
+
+        /***************************************************/
+
         //TODO: Move this extension method to somewhere else. Reflection_Engine/BHoM_Engine
         public static List<IBHoMObject> StringMatch(this List<IBHoMObject> objects, string propertyName, string value)
         {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
Closes #1425 


Adds partial match method for returning all library objects that contain input string.


### Test files
[Test Script](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Library%20Engine/Issue1425-Partial%20Match?csf=1&e=Jw5CVY)
