### PR TITLE
Geometry_Engine: Implemented Normal, IsPlanar and FitPlane for PlanarSurface

### DIFF
--- a/Geometry_Engine/Compute/FitPlane.cs
+++ b/Geometry_Engine/Compute/FitPlane.cs
@@ -149,6 +149,16 @@ namespace BH.Engine.Geometry
 
 
         /***************************************************/
+        /**** Public Methods - Surfaces                 ****/
+        /***************************************************/
+
+        public static Plane FitPlane(this PlanarSurface surface, double tolerance = Tolerance.Distance)
+        {
+            return IFitPlane(surface.ExternalBoundary, tolerance);
+        }
+
+
+        /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 

--- a/Geometry_Engine/Query/IsPlanar.cs
+++ b/Geometry_Engine/Query/IsPlanar.cs
@@ -107,7 +107,14 @@ namespace BH.Engine.Geometry
 
 
         /***************************************************/
-        /**** Public Methods - Surfaces                ****/
+        /**** Public Methods - Surfaces                 ****/
+        /***************************************************/
+
+        public static bool IsPlanar(this PlanarSurface surface, double tolerance = Tolerance.Distance)
+        {
+            return true;
+        }
+
         /***************************************************/
 
         public static bool IsPlanar(this Extrusion surface, double tolerance = Tolerance.Distance)

--- a/Geometry_Engine/Query/IsPlanar.cs
+++ b/Geometry_Engine/Query/IsPlanar.cs
@@ -112,7 +112,18 @@ namespace BH.Engine.Geometry
 
         public static bool IsPlanar(this PlanarSurface surface, double tolerance = Tolerance.Distance)
         {
-            return true;
+            if (tolerance == Tolerance.Distance)
+                return true;
+            else
+            {
+                List<Point> controlPoints = surface.ExternalBoundary.IControlPoints();
+                foreach (ICurve outline in surface.InternalBoundaries)
+                {
+                    controlPoints.AddRange(outline.IControlPoints());
+                }
+
+                return controlPoints.IsCoplanar(tolerance);
+            }
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -258,6 +258,7 @@ namespace BH.Engine.Geometry
             return surface.ExternalBoundary.INormal();
         }
 
+
         /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -247,7 +247,17 @@ namespace BH.Engine.Geometry
         {
             throw new NotImplementedException();
         }
-        
+
+
+        /***************************************************/
+        /**** Public Methods - Surfaces                 ****/
+        /***************************************************/
+
+        public static Vector Normal(this PlanarSurface surface)
+        {
+            return surface.ExternalBoundary.INormal();
+        }
+
         /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1428

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
No test files as the methods are mere wrappers of others. One thing that came across my mind: should we implement explicit `IsPlanar` check for `PlanarSurface`, or is it OK to _assume_ that it has been constructed correctly (current approach, returning `true` without any computations)?


### Changelog
- `IsPlanar`, `FitPlane` and `Normal` methods have been implemented for `BH.oM.Geometry.PlanarSurface`

