### PR TITLE
Environment_Engine: SetRoofPanels to set ceilings and internalfloor between spaces

### DIFF
--- a/Environment_Engine/Modify/SetPanelType.cs
+++ b/Environment_Engine/Modify/SetPanelType.cs
@@ -174,11 +174,13 @@ namespace BH.Engine.Environment
             foreach (Panel panel in clones)
             {
                 if (panel.MinimumLevel() == panel.MaximumLevel())
+                {
                     minZ = Math.Min(minZ, panel.MinimumLevel());
                     maxZ = Math.Max(maxZ, panel.MaximumLevel());
+                }
             }
 
-            List<Panel> roofPanels = clones.Where(x => ((x.MaximumLevel() != minZ) && (Math.Round(x.Tilt()) >= 92 || Math.Round(x.Tilt()) <= 88))).ToList(); //&& x.ConnectedSpaces.ToList().Count == 1).ToList();
+            List<Panel> roofPanels = clones.Where(x => ((x.MaximumLevel() != minZ) && (Math.Round(x.Tilt()) >= 92 || Math.Round(x.Tilt()) <= 88))).ToList();
 
             foreach (Panel panel in roofPanels)
             {

--- a/Environment_Engine/Modify/SetPanelType.cs
+++ b/Environment_Engine/Modify/SetPanelType.cs
@@ -176,12 +176,14 @@ namespace BH.Engine.Environment
                     minZ = Math.Min(minZ, panel.MinimumLevel());
             }
 
-            List<Panel> roofPanels = clones.Where(x => ((x.MaximumLevel() != minZ) && (Math.Round(x.Tilt()) >= 92 || Math.Round(x.Tilt()) <= 88)) && x.ConnectedSpaces.ToList().Count == 1).ToList();
+            List<Panel> roofPanels = clones.Where(x => ((x.MaximumLevel() != minZ) && (Math.Round(x.Tilt()) >= 92 || Math.Round(x.Tilt()) <= 88))).ToList(); //&& x.ConnectedSpaces.ToList().Count == 1).ToList();
 
             foreach (Panel panel in roofPanels)
             {
                 if (panel.ConnectedSpaces.Where(x => x != "-1").ToList().Count == 1)
                     panel.Type = PanelType.Roof;
+                else if (panel.ConnectedSpaces.Where(x => x != "-1").ToList().Count == 2)
+                    panel.Type = PanelType.Ceiling;
             }
 
             return roofPanels;

--- a/Environment_Engine/Modify/SetPanelType.cs
+++ b/Environment_Engine/Modify/SetPanelType.cs
@@ -170,10 +170,12 @@ namespace BH.Engine.Environment
 
             //Find the panel(s) that are at the highest point of the space...
             double minZ = 1e10;
+            double maxZ = -1e10;
             foreach (Panel panel in clones)
             {
                 if (panel.MinimumLevel() == panel.MaximumLevel())
                     minZ = Math.Min(minZ, panel.MinimumLevel());
+                    maxZ = Math.Max(maxZ, panel.MaximumLevel());
             }
 
             List<Panel> roofPanels = clones.Where(x => ((x.MaximumLevel() != minZ) && (Math.Round(x.Tilt()) >= 92 || Math.Round(x.Tilt()) <= 88))).ToList(); //&& x.ConnectedSpaces.ToList().Count == 1).ToList();
@@ -184,6 +186,12 @@ namespace BH.Engine.Environment
                     panel.Type = PanelType.Roof;
                 else if (panel.ConnectedSpaces.Where(x => x != "-1").ToList().Count == 2)
                     panel.Type = PanelType.Ceiling;
+            }
+
+            foreach (Panel panel in roofPanels)
+            {
+                if (panel.Type == PanelType.Ceiling && panel.MaximumLevel() != maxZ)
+                    panel.Type = PanelType.FloorInternal;
             }
 
             return roofPanels;


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Fixes #1422 

<!-- Add short description of what has been fixed -->
Fixes to internalFloors that where not at the lowest point of the space. 
Finds ceilings and internal floors between two spaces.

### Test files

Test script in issue


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->