### PR TITLE
Programming_Engine: Adding Initial code

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@
 /MEP_Engine @kayleighhoude @FraserGreenroyd
 /Physical_Engine @al-fisher @rwemay @IsakNaslundBh @FraserGreenroyd
 /Planning_Engine @rwemay @al-fisher
+/Programming_Engine @adecler @FraserGreenroyd @al-fisher
 /Reflection_Engine @adecler @FraserGreenroyd @al-fisher
 /Results_Engine @IsakNaslundBh @FraserGreenroyd @rwemay
 #NEED OWNER: /SVG_Engine

--- a/BHoM_Engine.sln
+++ b/BHoM_Engine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Express 14 for Windows Desktop
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.757
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Acoustic_Engine", "Acoustic_Engine\Acoustic_Engine.csproj", "{68300030-BC17-49BD-A363-CFCD3828E812}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -54,6 +54,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MEP_Engine", "MEP_Engine\MEP_Engine.csproj", "{69E79860-3ADE-4279-AEC4-DE336F7F3F23}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Graphics_Engine", "Graphics_Engine\Graphics_Engine.csproj", "{D5C7704D-F59A-4FC6-8D1E-356699A174E0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Programming_Engine", "Programming_Engine\Programming_Engine.csproj", "{BDE4A84F-5672-41B6-834B-6139C32C3560}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -232,6 +234,14 @@ Global
 		{D5C7704D-F59A-4FC6-8D1E-356699A174E0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D5C7704D-F59A-4FC6-8D1E-356699A174E0}.Release|x86.ActiveCfg = Release|Any CPU
 		{D5C7704D-F59A-4FC6-8D1E-356699A174E0}.Release|x86.Build.0 = Release|Any CPU
+		{BDE4A84F-5672-41B6-834B-6139C32C3560}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDE4A84F-5672-41B6-834B-6139C32C3560}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDE4A84F-5672-41B6-834B-6139C32C3560}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BDE4A84F-5672-41B6-834B-6139C32C3560}.Debug|x86.Build.0 = Debug|Any CPU
+		{BDE4A84F-5672-41B6-834B-6139C32C3560}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDE4A84F-5672-41B6-834B-6139C32C3560}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDE4A84F-5672-41B6-834B-6139C32C3560}.Release|x86.ActiveCfg = Release|Any CPU
+		{BDE4A84F-5672-41B6-834B-6139C32C3560}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Programming_Engine/Compute/PopulateTypes.cs
+++ b/Programming_Engine/Compute/PopulateTypes.cs
@@ -1,0 +1,163 @@
+﻿using BH.oM.Programming;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Programming
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Interface Methods                         ****/
+        /***************************************************/
+
+        public static INode IPopulateTypes(this INode node)
+        {
+            return PopulateTypes(node as dynamic);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static ClusterContent PopulateTypes(this ClusterContent content)
+        {
+            if (content == null)
+                return content;
+
+            content.InternalNodes = content.InternalNodes.Select(x => x.IPopulateTypes()).ToList();
+
+            // Collect the types
+            Dictionary<Guid, Type> nodeTypes = content.DataTypePerParam();
+
+            // Assign the types to the inputs
+            foreach (DataParam input in content.Inputs)
+            {
+                if (input.TargetIds.Count > 0 && nodeTypes.ContainsKey(input.TargetIds[0]))
+                    input.DataType = nodeTypes[input.TargetIds[0]];
+            }
+
+            // Assign the types to the outputs
+            foreach (ReceiverParam output in content.Outputs)
+            {
+                if (nodeTypes.ContainsKey(output.SourceId))
+                    output.DataType = nodeTypes[output.SourceId];
+            }
+
+            return content;
+        }
+
+        /***************************************************/
+
+        public static MethodNode PopulateTypes(this MethodNode node)
+        {
+            if (node == null || node.Method == null)
+                return node;
+
+            ParameterInfo[] methodParams = node.Method.GetParameters();
+            if (node.Inputs.Count != methodParams.Length)
+                return node;
+
+            for (int i = 0; i < methodParams.Length; i++)
+            {
+                node.Inputs[i].DataType = methodParams[i].ParameterType;
+                if (methodParams[i].HasDefaultValue)
+                    node.Inputs[i].DefaultValue = methodParams[i].DefaultValue;
+            }
+                
+
+            if (node.Outputs.Count == 1)
+                node.Outputs[0].DataType = node.Method.ReturnType;
+            else if (node.Outputs.Count > 1 && node.Method.ReturnType is oM.Reflection.Interface.IOutput)
+            {
+                Type[] types = node.Method.ReturnType.GetGenericArguments();
+                if (types.Length == node.Outputs.Count)
+                {
+                    for (int i = 0; i < types.Length; i++)
+                        node.Outputs[i].DataType = types[i];
+                }
+            }
+
+            return node;
+        }
+
+        /***************************************************/
+
+        public static ConstructorNode PopulateTypes(this ConstructorNode node)
+        {
+            if (node == null || node.Constructor == null)
+                return node;
+
+            ParameterInfo[] methodParams = node.Constructor.GetParameters();
+            if (node.Inputs.Count != methodParams.Length)
+                return node;
+
+            for (int i = 0; i < methodParams.Length; i++)
+            {
+                node.Inputs[i].DataType = methodParams[i].ParameterType;
+                if (methodParams[i].HasDefaultValue)
+                    node.Inputs[i].DefaultValue = methodParams[i].DefaultValue;
+            }
+
+
+            if (node.Outputs.Count > 0)
+                node.Outputs[0].DataType = node.Constructor.DeclaringType;
+
+            return node;
+        }
+
+        /***************************************************/
+
+        public static InitialiserNode PopulateTypes(this InitialiserNode node)
+        {
+            if (node == null || node.ObjectType == null)
+                return node;
+
+            PropertyInfo[] properties = node.ObjectType.GetProperties();
+            object instance = Activator.CreateInstance(node.ObjectType);
+
+            foreach (ReceiverParam input in node.Inputs)
+            {
+                PropertyInfo match = properties.FirstOrDefault(x => x.Name == input.Name);
+                if (match != null)
+                {
+                    input.DataType = match.PropertyType;
+                    input.DefaultValue = match.GetValue(instance);
+                }
+            }
+
+            if (node.Outputs.Count > 0)
+                node.Outputs[0].DataType = node.ObjectType;
+
+            return node;
+        }
+
+        /***************************************************/
+
+        public static TypeNode PopulateTypes(this TypeNode node)
+        {
+            if (node == null || node.Type == null)
+                return node;
+
+            foreach (DataParam param in node.Outputs)
+                param.DataType = typeof(Type);
+
+            return node;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        public static INode PopulateTypes(this INode node)
+        {
+            return node;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Programming_Engine/Compute/PopulateTypes.cs
+++ b/Programming_Engine/Compute/PopulateTypes.cs
@@ -1,6 +1,30 @@
-﻿using BH.oM.Programming;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Programming;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -14,6 +38,9 @@ namespace BH.Engine.Programming
         /**** Interface Methods                         ****/
         /***************************************************/
 
+        [Description("Automatically set the DataType and default value of all parameters of the input syntax node.")]
+        [Input("node", "syntax node to modify")]
+        [Output("Modified node")]
         public static INode IPopulateTypes(this INode node)
         {
             return PopulateTypes(node as dynamic);
@@ -24,6 +51,9 @@ namespace BH.Engine.Programming
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Automatically set the DataType and default value of all parameters of the syntax nodes inside the cluster.")]
+        [Input("content", "cluster content to modify")]
+        [Output("Modified node")]
         public static ClusterContent PopulateTypes(this ClusterContent content)
         {
             if (content == null)
@@ -53,6 +83,9 @@ namespace BH.Engine.Programming
 
         /***************************************************/
 
+        [Description("Automatically set the DataType and default value of all parameters of the input method node.")]
+        [Input("node", "method node to modify")]
+        [Output("Modified node")]
         public static MethodNode PopulateTypes(this MethodNode node)
         {
             if (node == null || node.Method == null)
@@ -87,6 +120,9 @@ namespace BH.Engine.Programming
 
         /***************************************************/
 
+        [Description("Automatically set the DataType and default value of all parameters of the input constructor node.")]
+        [Input("node", "constructor node to modify")]
+        [Output("Modified node")]
         public static ConstructorNode PopulateTypes(this ConstructorNode node)
         {
             if (node == null || node.Constructor == null)
@@ -112,6 +148,9 @@ namespace BH.Engine.Programming
 
         /***************************************************/
 
+        [Description("Automatically set the DataType and default value of all parameters of the input initialiser node.")]
+        [Input("node", "initialiser node to modify")]
+        [Output("Modified node")]
         public static InitialiserNode PopulateTypes(this InitialiserNode node)
         {
             if (node == null || node.ObjectType == null)
@@ -138,6 +177,9 @@ namespace BH.Engine.Programming
 
         /***************************************************/
 
+        [Description("Automatically set the DataType and default value of all parameters of the input type node.")]
+        [Input("node", "type node to modify")]
+        [Output("Modified node")]
         public static TypeNode PopulateTypes(this TypeNode node)
         {
             if (node == null || node.Type == null)
@@ -153,7 +195,7 @@ namespace BH.Engine.Programming
         /**** Private Methods                           ****/
         /***************************************************/
 
-        public static INode PopulateTypes(this INode node)
+        private static INode PopulateTypes(this INode node)
         {
             return node;
         }

--- a/Programming_Engine/Programming_Engine.csproj
+++ b/Programming_Engine/Programming_Engine.csproj
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BDE4A84F-5672-41B6-834B-6139C32C3560}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.Engine.Programming</RootNamespace>
+    <AssemblyName>Programming_Engine</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BHoM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\BHoM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Programming_oM">
+      <HintPath>..\..\BHoM\Build\Programming_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Reflection_oM, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Compute\PopulateTypes.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Query\DataTypePerParam.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj">
+      <Project>{1ad45c88-dd54-48e5-951f-55edfeb70e35}</Project>
+      <Name>BHoM_Engine</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\Reflection_Engine\Reflection_Engine.csproj">
+      <Project>{b0154405-9390-472d-9b5c-a2280823b18d}</Project>
+      <Name>Reflection_Engine</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Convert\" />
+    <Folder Include="Create\" />
+    <Folder Include="Modify\" />
+    <Folder Include="Objects\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Programming_Engine/Properties/AssemblyInfo.cs
+++ b/Programming_Engine/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Programming_Engine")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Programming_Engine")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("bde4a84f-5672-41b6-834b-6139c32c3560")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.1.0.0")]

--- a/Programming_Engine/Query/DataTypePerParam.cs
+++ b/Programming_Engine/Query/DataTypePerParam.cs
@@ -1,0 +1,68 @@
+﻿using BH.oM.Programming;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Programming
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Interface Methods                         ****/
+        /***************************************************/
+
+        public static Dictionary<Guid, Type> IDataTypePerParam(this INode node)
+        {
+            return DataTypePerParam(node as dynamic);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static Dictionary<Guid, Type> DataTypePerParam(this ClusterContent content)
+        {
+            Dictionary<Guid, Type> types = new Dictionary<Guid, Type>();
+            if (content == null)
+                return types;
+
+            content.InternalNodes = content.InternalNodes.Select(x => x.IPopulateTypes()).ToList();
+
+            foreach (DataParam input in content.Inputs)
+                types[input.BHoM_Guid] = input.DataType;
+
+            foreach (ReceiverParam output in content.Outputs)
+                types[output.BHoM_Guid] = output.DataType;
+
+            foreach (INode child in content.InternalNodes)
+            {
+                Dictionary<Guid, Type> childTypes = child.IDataTypePerParam();
+                foreach (KeyValuePair<Guid, Type> kvp in childTypes)
+                    types[kvp.Key] = kvp.Value;
+            }
+
+            return types;
+        }
+
+        /***************************************************/
+
+        public static Dictionary<Guid, Type> DataTypePerParam(this INode node)
+        {
+            Dictionary<Guid, Type> types = new Dictionary<Guid, Type>();
+
+            foreach (ReceiverParam input in node.Inputs)
+                types[input.BHoM_Guid] = input.DataType;
+
+            foreach (DataParam output in node.Outputs)
+                types[output.BHoM_Guid] = output.DataType;
+
+            return types;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Programming_Engine/Query/DataTypePerParam.cs
+++ b/Programming_Engine/Query/DataTypePerParam.cs
@@ -1,6 +1,30 @@
-﻿using BH.oM.Programming;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Programming;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -14,6 +38,9 @@ namespace BH.Engine.Programming
         /**** Interface Methods                         ****/
         /***************************************************/
 
+        [Description("Collect the data type for each parameter in the input syntax node.")]
+        [Input("node", "syntax node to extract data types from")]
+        [Output("Dictionary with parameter ids as keys and their type as value")]
         public static Dictionary<Guid, Type> IDataTypePerParam(this INode node)
         {
             return DataTypePerParam(node as dynamic);
@@ -24,6 +51,9 @@ namespace BH.Engine.Programming
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Collect the data type for each parameter of each syntax node inside the cluster.")]
+        [Input("content", "cluster content to extract data types from")]
+        [Output("Dictionary with parameter ids as keys and their type as value")]
         public static Dictionary<Guid, Type> DataTypePerParam(this ClusterContent content)
         {
             Dictionary<Guid, Type> types = new Dictionary<Guid, Type>();
@@ -48,9 +78,12 @@ namespace BH.Engine.Programming
             return types;
         }
 
+
+        /***************************************************/
+        /**** Private Methods                           ****/
         /***************************************************/
 
-        public static Dictionary<Guid, Type> DataTypePerParam(this INode node)
+        private static Dictionary<Guid, Type> DataTypePerParam(this INode node)
         {
             Dictionary<Guid, Type> types = new Dictionary<Guid, Type>();
 


### PR DESCRIPTION

### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/682

   
Provides the Engine for the task covered by this PR: https://github.com/BHoM/Grasshopper_Toolkit/pull/447

This effectively removes the dependency of Grasshopper with the Node2Code toolkit. It is critical to do so since some of the code in GH related to Node2Code will later be migrated to BHoM_UI.

In term of review, this is mainly a question of testing that the Grasshopper PR still works the same ways now that the oM has been migrated.

### Additional comments
This is simply a migration of the code from https://github.com/BHoM/Node2Code_Toolkit/pull/2 with no change other than the namespace