### PR TITLE
BHoM_Engine: Update CI file to check if path already exists

### DIFF
--- a/.ci/CloneTest.ps1
+++ b/.ci/CloneTest.ps1
@@ -12,7 +12,12 @@ $slnPath = "$ENV:BUILD_SOURCESDIRECTORY\$repo\$repo.sln"
 
 # **** Cloning Repo ****
 Write-Output ("BHoM Cloning " + $repo + " to " + $ENV:BUILD_SOURCESDIRECTORY + "\" + $repo)
-git clone -q --branch=master https://github.com/BHoM/$repo.git  $ENV:BUILD_SOURCESDIRECTORY\$repo
+
+If(!(test-path $ENV:BUILD_SOURCESDIRECTORY\$repo))
+{
+	git clone -q --branch=master https://github.com/BHoM/$repo.git  $ENV:BUILD_SOURCESDIRECTORY\$repo
+}
+
 $cwd = Get-Location
 Set-Location $ENV:BUILD_SOURCESDIRECTORY\$repo
 


### PR DESCRIPTION
Updates the `CloneTest` file to only clone `BHoM` if it is not already cloned as a failsafe. Related to #1452 