### PR TITLE
Diffing_Engine: SHA hashing: add support for any object; DiffHash: add support for IObject

### DIFF
--- a/Diffing_Engine/Compute/DiffingHash.cs
+++ b/Diffing_Engine/Compute/DiffingHash.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Diffing
         [Description("Computes the hash code required for the Diffing.")]
         [Input("objects", "Objects the hash code should be calculated for")]
         [Input("diffConfig", "Sets configs for the hash calculation, such as properties to be ignored.")]
-        public static string DiffingHash(this IBHoMObject obj, DiffConfig diffConfig)
+        public static string DiffingHash(this IObject obj, DiffConfig diffConfig)
         {
             return Compute.SHA256Hash(obj, diffConfig.PropertiesToIgnore);
         }

--- a/Diffing_Engine/Compute/DiffingHash.cs
+++ b/Diffing_Engine/Compute/DiffingHash.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Diffing
         ///***************************************************/
 
         [Description("Computes the hash code required for the Diffing.")]
-        [Input("objects", "Objects the hash code should be calculated for")]
+        [Input("obj", "Objects the hash code should be calculated for")]
         [Input("diffConfig", "Sets configs for the hash calculation, such as properties to be ignored.")]
         public static string DiffingHash(this IObject obj, DiffConfig diffConfig)
         {

--- a/Diffing_Engine/Compute/SHA256Hash.cs
+++ b/Diffing_Engine/Compute/SHA256Hash.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Diffing
         [Description("Computes the a SHA 256 hash code representing the object.")]
         [Input("objects", "Object the hash code should be calculated for")]
         [Input("exceptions", "List of strings specifying the names of the properties that should be ignored in the calculation, e.g. 'BHoM_Guid'")]
-        public static string SHA256Hash(this IBHoMObject obj, List<string> exceptions = null)
+        public static string SHA256Hash(this object obj, List<string> exceptions = null)
         {
             return SHA256Hash(obj.ToDiffingByteArray(exceptions));
         }

--- a/Diffing_Engine/Compute/SHA256Hash.cs
+++ b/Diffing_Engine/Compute/SHA256Hash.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Diffing
         ///***************************************************/
 
         [Description("Computes the a SHA 256 hash code representing the object.")]
-        [Input("objects", "Object the hash code should be calculated for")]
+        [Input("obj", "Object the hash code should be calculated for")]
         [Input("exceptions", "List of strings specifying the names of the properties that should be ignored in the calculation, e.g. 'BHoM_Guid'")]
         public static string SHA256Hash(this object obj, List<string> exceptions = null)
         {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1466 

Removes the limitations on the inputs of two methods: SHA256 and DiffHash. More consistent with the rest.

Note that the branch name is defined like that for development need (CI on Speckle_Toolkit)

### Test files
<!-- Link to test files to validate the proposed changes -->
No test needed.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

