### PR TITLE
Structure_Engine: Enable the use of Green's Therom for Section Integration

### DIFF
--- a/Structure_Engine/Compute/Integrate.cs
+++ b/Structure_Engine/Compute/Integrate.cs
@@ -95,16 +95,16 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        public static Output<IProfile, Dictionary<string, object>> Integrate(IProfile profile, double tolerance = Tolerance.Distance)
+        public static Output<IProfile, Dictionary<string, double>> Integrate(IProfile profile, double tolerance = Tolerance.Distance)
         {
-            Dictionary<string, object> results = Integrate(profile.Edges.ToList(), tolerance);
+            Dictionary<string, double> results = IntegrateSection(profile.Edges.ToList(), tolerance);
 
-            Vector adjustment = new Vector() { X = -(double)results["CentreY"], Y = -(double)results["CentreZ"], Z = 0 };
+            Vector adjustment = new Vector() { X = -results["CentreY"], Y = -results["CentreZ"], Z = 0 };
 
             results["CentreY"] = 0.0d;
             results["CentreZ"] = 0.0d;
 
-            return new Output<IProfile, Dictionary<string, object>> { Item1 = AdjustCurves(profile, adjustment), Item2 = results };
+            return new Output<IProfile, Dictionary<string, double>> { Item1 = AdjustCurves(profile, adjustment), Item2 = results };
         }
 
         /***************************************************/

--- a/Structure_Engine/Compute/IntegrateSection.cs
+++ b/Structure_Engine/Compute/IntegrateSection.cs
@@ -44,9 +44,9 @@ namespace BH.Engine.Structure
         [Input("curves", "Non-intersecting edge curves that make up the section.")]
         [Input("tolerance", "The angleTolerance for dividing the section curves.")]
         [Output("V", "Dictionary containing the section properties for the X and Y axis.")]
-        public static Dictionary<string, object> IntegrateSection(List<ICurve> curves, double tolerance = 0.04)
+        public static Dictionary<string, double> IntegrateSection(List<ICurve> curves, double tolerance = 0.04)
         {
-            Dictionary<string, object> results = new Dictionary<string, object>();
+            Dictionary<string, double> results = new Dictionary<string, double>();
 
             List<PolyCurve> curvesZ = Geometry.Compute.IJoin(curves);
 
@@ -154,16 +154,16 @@ namespace BH.Engine.Structure
             results["Wply"] = pLineY.PlasticModulus(curvesY, area);
             results["Wplz"] = pLineZ.PlasticModulus(curvesZ, area);
 
-            results["Rgy"] = Math.Sqrt((double)results["Iy"] / area);
-            results["Rgz"] = Math.Sqrt((double)results["Iz"] / area);
+            results["Rgy"] = Math.Sqrt(results["Iy"] / area);
+            results["Rgz"] = Math.Sqrt(results["Iz"] / area);
 
             results["Vy"] = max.X - centreY;
             results["Vpy"] = centreY - min.X;
             results["Vz"] = max.Y - centreZ;
             results["Vpz"] = centreZ - min.Y;
 
-            results["Welz"] = (double)results["Iz"] / Math.Max((double)results["Vy"], (double)results["Vpy"]);
-            results["Wely"] = (double)results["Iy"] / Math.Max((double)results["Vz"], (double)results["Vpz"]);
+            results["Welz"] = results["Iz"] / Math.Max(results["Vy"], results["Vpy"]);
+            results["Wely"] = results["Iy"] / Math.Max(results["Vz"], results["Vpz"]);
 
             if (discontinius)
             {
@@ -173,13 +173,9 @@ namespace BH.Engine.Structure
             }
             else
             {
-                results["Asy"] = pLineZ.ShearAreaPolyline((double)results["Iz"]);
-                results["Asz"] = pLineY.ShearAreaPolyline((double)results["Iy"]);
+                results["Asy"] = pLineZ.ShearAreaPolyline(results["Iz"]);
+                results["Asz"] = pLineY.ShearAreaPolyline(results["Iy"]);
             }
-
-            // For testing
-            results["pLineY"] = pLineY;
-            results["pLineZ"] = pLineZ;
 
             return results;
         }

--- a/Structure_Engine/Create/AluminiumSection.cs
+++ b/Structure_Engine/Create/AluminiumSection.cs
@@ -50,12 +50,12 @@ namespace BH.Engine.Structure
             var preProcessValues = PreProcessSectionCreate(name, profile);
             name = preProcessValues.Item1;
             profile = preProcessValues.Item2;
-            Dictionary<string, object> constants = preProcessValues.Item3;
+            Dictionary<string, double> constants = preProcessValues.Item3;
 
             AluminiumSection section = new AluminiumSection(profile,
-                (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
-                (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
-                (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
+                constants["Area"], constants["Rgy"], constants["Rgz"], constants["J"], constants["Iy"], constants["Iz"], constants["Iw"], constants["Wely"],
+                constants["Welz"], constants["Wply"], constants["Wplz"], constants["CentreZ"], constants["CentreY"], constants["Vz"],
+                constants["Vpz"], constants["Vy"], constants["Vpy"], constants["Asy"], constants["Asz"]);
 
             return PostProcessSectionCreate(section, name, material, MaterialType.Aluminium);
 

--- a/Structure_Engine/Create/ConcreteSection.cs
+++ b/Structure_Engine/Create/ConcreteSection.cs
@@ -107,12 +107,12 @@ namespace BH.Engine.Structure
             var preProcessValues = PreProcessSectionCreate(name, profile);
             name = preProcessValues.Item1;
             profile = preProcessValues.Item2;
-            Dictionary<string, object> constants = preProcessValues.Item3;
+            Dictionary<string, double> constants = preProcessValues.Item3;
 
             ConcreteSection section = new ConcreteSection(profile,
-                (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"],
-                (double)constants["Wely"], (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
-                (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
+                constants["Area"], constants["Rgy"], constants["Rgz"], constants["J"], constants["Iy"], constants["Iz"], constants["Iw"],
+                constants["Wely"], constants["Welz"], constants["Wply"], constants["Wplz"], constants["CentreZ"], constants["CentreY"], constants["Vz"],
+                constants["Vpz"], constants["Vy"], constants["Vpy"], constants["Asy"], constants["Asz"]);
 
             //Set reinforcement if any provided
             if (reinforcement != null)

--- a/Structure_Engine/Create/GenericSection.cs
+++ b/Structure_Engine/Create/GenericSection.cs
@@ -50,12 +50,12 @@ namespace BH.Engine.Structure
             var preProcessValues = PreProcessSectionCreate(name, profile);
             name = preProcessValues.Item1;
             profile = preProcessValues.Item2;
-            Dictionary<string, object> constants = preProcessValues.Item3;
+            Dictionary<string, double> constants = preProcessValues.Item3;
 
             GenericSection section = new GenericSection(profile,
-                (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
-                (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
-                (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
+                constants["Area"], constants["Rgy"], constants["Rgz"], constants["J"], constants["Iy"], constants["Iz"], constants["Iw"], constants["Wely"],
+                constants["Welz"], constants["Wply"], constants["Wplz"], constants["CentreZ"], constants["CentreY"], constants["Vz"],
+                constants["Vpz"], constants["Vy"], constants["Vpy"], constants["Asy"], constants["Asz"]);
 
             return PostProcessSectionCreate(section, name, material, MaterialType.Undefined);
 

--- a/Structure_Engine/Create/SectionProperty.cs
+++ b/Structure_Engine/Create/SectionProperty.cs
@@ -75,7 +75,7 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Run standard pre-processing needed for all section creates. Checks name and grabs value from profile if nothing provided and calculates all section constants")]
-        private static Output<string, IProfile, Dictionary<string, object>> PreProcessSectionCreate(string name, IProfile profile)
+        private static Output<string, IProfile, Dictionary<string, double>> PreProcessSectionCreate(string name, IProfile profile)
         {
             //Check name, if nothing provided, try grabbing name from profile
             if (string.IsNullOrWhiteSpace(name) && profile.Name != null)
@@ -87,15 +87,15 @@ namespace BH.Engine.Structure
                 Engine.Reflection.Compute.RecordWarning("Profile with name " + profile.Name + " does not contain any edges. Section named " + name + " made with this profile will have 0 value sections constants");
             }
 
-            Output<IProfile, Dictionary<string, object>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
+            Output<IProfile, Dictionary<string, double>> result = Compute.Integrate(profile, Tolerance.MicroDistance);
 
             profile = result.Item1;
-            Dictionary<string, object> constants = result.Item2;
+            Dictionary<string, double> constants = result.Item2;
 
             constants["J"] = profile.ITorsionalConstant();
             constants["Iw"] = profile.IWarpingConstant();
 
-            return new Output<string, IProfile, Dictionary<string, object>> { Item1 = name, Item2 = profile, Item3 = constants };
+            return new Output<string, IProfile, Dictionary<string, double>> { Item1 = name, Item2 = profile, Item3 = constants };
         }
 
         /***************************************************/

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -204,12 +204,12 @@ namespace BH.Engine.Structure
             var preProcessValues = PreProcessSectionCreate(name, profile);
             name = preProcessValues.Item1;
             profile = preProcessValues.Item2;
-            Dictionary<string,object> constants= preProcessValues.Item3;
+            Dictionary<string,double> constants= preProcessValues.Item3;
 
             SteelSection section = new SteelSection(profile,
-                (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
-                (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
-                (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
+                constants["Area"], constants["Rgy"], constants["Rgz"], constants["J"], constants["Iy"], constants["Iz"], constants["Iw"], constants["Wely"],
+                constants["Welz"], constants["Wply"], constants["Wplz"], constants["CentreZ"], constants["CentreY"], constants["Vz"],
+                constants["Vpz"], constants["Vy"], constants["Vpy"], constants["Asy"], constants["Asz"]);
 
             //Postprocess section. Sets default name if null, and grabs default material for section if noting is provided
             return PostProcessSectionCreate(section, name, material, MaterialType.Steel);

--- a/Structure_Engine/Create/SteelSection.cs
+++ b/Structure_Engine/Create/SteelSection.cs
@@ -167,7 +167,7 @@ namespace BH.Engine.Structure
         [Description("Creates a steel L-section from input dimensions. Please note that all units are in S.I., that is meters [m]")]
         [Input("height", "Full height of the section [m]")]
         [Input("webThickness", "Thickness of the web [m]")]
-        [Input("flangeWidth", "Width of the top and bottom flange [m]")]
+        [Input("width", "Full width of the section [m]")]
         [Input("flangeThickness", "Thickness of the top and bottom flange [m]")]
         [Input("rootRadius", "Optional fillet radius between inner face of flange and face of web [m]")]
         [Input("toeRadius", "Optional fillet radius at the outer edge of the flange [m]")]

--- a/Structure_Engine/Create/TimberSection.cs
+++ b/Structure_Engine/Create/TimberSection.cs
@@ -65,12 +65,12 @@ namespace BH.Engine.Structure
             var preProcessValues = PreProcessSectionCreate(name, profile);
             name = preProcessValues.Item1;
             profile = preProcessValues.Item2;
-            Dictionary<string, object> constants = preProcessValues.Item3;
+            Dictionary<string, double> constants = preProcessValues.Item3;
 
             TimberSection section = new TimberSection(profile,
-                (double)constants["Area"], (double)constants["Rgy"], (double)constants["Rgz"], (double)constants["J"], (double)constants["Iy"], (double)constants["Iz"], (double)constants["Iw"], (double)constants["Wely"],
-                (double)constants["Welz"], (double)constants["Wply"], (double)constants["Wplz"], (double)constants["CentreZ"], (double)constants["CentreY"], (double)constants["Vz"],
-                (double)constants["Vpz"], (double)constants["Vy"], (double)constants["Vpy"], (double)constants["Asy"], (double)constants["Asz"]);
+                constants["Area"], constants["Rgy"], constants["Rgz"], constants["J"], constants["Iy"], constants["Iz"], constants["Iw"], constants["Wely"],
+                constants["Welz"], constants["Wply"], constants["Wplz"], constants["CentreZ"], constants["CentreY"], constants["Vz"],
+                constants["Vpz"], constants["Vy"], constants["Vpy"], constants["Asy"], constants["Asz"]);
 
             return PostProcessSectionCreate(section, name, material, MaterialType.Timber);
 


### PR DESCRIPTION
### Issues addressed by this PR
Closes #1482 
Enables the functionality from #1255 in the calculation of section constants for the Structure_Engine.
Also changes the output of the method to a dictionary of doubles as there no longer are any `object` outputs

### Additional comments
<!-- As required -->