### PR TITLE
BHoM_Engine: RemoveFragment returns the same BHoMObject if the given fragment is not found

### DIFF
--- a/BHoM_Engine/Modify/RemoveFragment.cs
+++ b/BHoM_Engine/Modify/RemoveFragment.cs
@@ -39,21 +39,22 @@ namespace BH.Engine.Base
         [Input("fragment", "Any fragment object implementing the IBHoMFragment interface to append to the object")]
         [Input("replace", "If set to true and the object already contains a fragment of the type being added, the fragment will be replaced by this instance")]
         [Output("iBHoMObject", "The BHoM object with the added fragment")]
-        public static IBHoMObject RemoveFragment(this IBHoMObject iBHoMObject, Type fragmentType)
+        public static IBHoMObject RemoveFragment(this IBHoMObject iBHoMObject, Type fragmentType = null)
         {
+            if (fragmentType == null) return iBHoMObject;
             if (iBHoMObject == null) return null;
             IBHoMObject o = iBHoMObject.DeepClone();
 
             if (!typeof(IBHoMFragment).IsAssignableFrom(fragmentType))
             {
                 Reflection.Compute.RecordError("Provided input in fragmentType is not a Fragment type (does not implement IBHoMFragment interface).");
-                return null;
+                return iBHoMObject;
             }
 
             if (!iBHoMObject.Fragments.Contains(fragmentType))
             {
-                Reflection.Compute.RecordWarning("iBHoMObject does not contain any fragment of the provided fragmentType.");
-                return null;
+                Reflection.Compute.RecordWarning($"{iBHoMObject.GetType().Name} does not contain any `{fragmentType.Name}` fragment.");
+                return iBHoMObject;
             }
 
             o.Fragments.Remove(fragmentType);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1479

<!-- Add short description of what has been fixed -->
Makes the behaviour of `RemoveFragment` more as it could be expected from an User point of view.

### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

