### PR TITLE
Structure_Engine: Plastic modulus, SplitAtX fix

### DIFF
--- a/Structure_Engine/Compute/PlasticModulus.cs
+++ b/Structure_Engine/Compute/PlasticModulus.cs
@@ -390,8 +390,13 @@ namespace BH.Engine.Structure
                 line.Start.X > x + tol && line.End.X < x - tol)
             {
                 Point ptOn = Geometry.Query.PointAtX(line.Start, line.End, x);
-                results.Add(new Line() { Start = line.Start, End = ptOn });
-                results.Add(new Line() { Start = ptOn, End = line.End });
+                if (ptOn != null)
+                {
+                    results.Add(new Line() { Start = line.Start, End = ptOn });
+                    results.Add(new Line() { Start = ptOn, End = line.End });
+                }
+                else
+                    results.Add(line.Clone());
             }
             else
                 results.Add(line.Clone());


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1490 
Added proper tolerance handling for `SplitAtX`, and a null check after `PointAtX`

also makes `SplitAtX(PolyLine)` call `SplitAtX(PolyCurve)` 

and fixes the edge cases by splitting up the splitting process in splitting for values on the curves and splitting for values on the endpoints
### Test files
change `SplitAtX` to public for the extra bits
https://burohappold.sharepoint.com/:f:/s/BHoM/EnhPFd09iDdJuT6hVgP7iAsB76qsXiyjHSqTGNhrNQfhXQ?e=HCMaQm