### PR TITLE
Structure_Engine: Split FeMesh.Geometry() into three methods

### DIFF
--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -154,7 +154,7 @@ namespace BH.Engine.Structure
         [Description("Gets the geometry of a collection of FEMeshFaces as a geometrical Mesh's Faces. A geometrical mesh face only supports 3 and 4 nodes faces, while a FEMeshFace does not have this limitation. For FEMeshFaces with more than 4 nodes or less than 3 this operation is therefore not possible. Method required for automatic display in UI packages.")]
         [Input("feFaces", "FEMeshFaces to get the mesh faces geometry from.")]
         [Output("faces", "The geometry of the FEMeshFaces as geometrical Mesh Faces.")]
-        private static IEnumerable<Face> Geometry(this IEnumerable<FEMeshFace> feFaces)
+        public static IEnumerable<Face> Geometry(this IEnumerable<FEMeshFace> feFaces)
         {
             List<Face> result = new List<Face>();
             foreach (FEMeshFace feFace in feFaces)
@@ -171,7 +171,7 @@ namespace BH.Engine.Structure
         [Description("Gets the geometry of a FEMeshFace as a geometrical Mesh's Face. A geometrical mesh face only supports 3 and 4 nodes faces, while a FEMeshFace does not have this limitation. For FEMeshFaces with more than 4 nodes or less than 3 this operation is therefore not possible. Method required for automatic display in UI packages.")]
         [Input("feFace", "FEMeshFace to get the mesh face geometry from.")]
         [Output("face", "The geometry of the FEMeshFace as geometrical Mesh Face.")]
-        private static Face Geometry(this FEMeshFace feFace)
+        public static Face Geometry(this FEMeshFace feFace)
         {
 
             if (feFace.NodeListIndices.Count < 3)

--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -137,7 +137,7 @@ namespace BH.Engine.Structure
 
         [Description("Gets the geometry of a FEMesh as a geometrical Mesh. A geometrical mesh only supports 3 and 4 nodes faces, while a FEMesh does not have this limitation. For FEMeshFaces with more than 4 nodes or less than 3 this operation is therefore not possible. Method required for automatic display in UI packages.")]
         [Input("feMesh", "FEMesh to get the mesh geometry from.")]
-        [Output("lines", "The geometry of the FEMesh as a geometrical Mesh.")]
+        [Output("mesh", "The geometry of the FEMesh as a geometrical Mesh.")]
         public static Mesh Geometry(this FEMesh feMesh)
         {
             Mesh mesh = new Mesh();

--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -144,33 +144,59 @@ namespace BH.Engine.Structure
 
             mesh.Vertices = feMesh.Nodes.Select(x => x.Position).ToList();
 
-            foreach (FEMeshFace feFace in feMesh.Faces)
-            {
-                if (feFace.NodeListIndices.Count < 3)
-                {
-                    Reflection.Compute.RecordError("Insuffiecient node indices");
-                    continue;
-                }
-                if (feFace.NodeListIndices.Count > 4)
-                {
-                    Reflection.Compute.RecordError("To high number of node indices. Can only handle triangular and quads");
-                    continue;
-                }
-
-                Face face = new Face();
-
-                face.A = feFace.NodeListIndices[0];
-                face.B = feFace.NodeListIndices[1];
-                face.C = feFace.NodeListIndices[2];
-
-                if (feFace.NodeListIndices.Count == 4)
-                    face.D = feFace.NodeListIndices[3];
-
-                mesh.Faces.Add(face);
-            }
+            mesh.Faces.AddRange(feMesh.Faces.Geometry());
 
             return mesh;
         }
+
+        /***************************************************/
+
+        [Description("Gets the geometry of a collection of FEMeshFaces as a geometrical Mesh's Faces. A geometrical mesh face only supports 3 and 4 nodes faces, while a FEMeshFace does not have this limitation. For FEMeshFaces with more than 4 nodes or less than 3 this operation is therefore not possible. Method required for automatic display in UI packages.")]
+        [Input("feFaces", "FEMeshFaces to get the mesh faces geometry from.")]
+        [Output("faces", "The geometry of the FEMeshFaces as geometrical Mesh Faces.")]
+        private static IEnumerable<Face> Geometry(this IEnumerable<FEMeshFace> feFaces)
+        {
+            List<Face> result = new List<Face>();
+            foreach (FEMeshFace feFace in feFaces)
+            {
+                Face face = Geometry(feFace);
+                if (face != null)
+                    result.Add(face);
+            }
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Gets the geometry of a FEMeshFace as a geometrical Mesh's Face. A geometrical mesh face only supports 3 and 4 nodes faces, while a FEMeshFace does not have this limitation. For FEMeshFaces with more than 4 nodes or less than 3 this operation is therefore not possible. Method required for automatic display in UI packages.")]
+        [Input("feFace", "FEMeshFace to get the mesh face geometry from.")]
+        [Output("face", "The geometry of the FEMeshFace as geometrical Mesh Face.")]
+        private static Face Geometry(this FEMeshFace feFace)
+        {
+
+            if (feFace.NodeListIndices.Count < 3)
+            {
+                Reflection.Compute.RecordError("Insuffiecient node indices");
+                return null;
+            }
+            if (feFace.NodeListIndices.Count > 4)
+            {
+                Reflection.Compute.RecordError("To high number of node indices. Can only handle triangular and quads");
+                return null;
+            }
+
+            Face face = new Face();
+
+            face.A = feFace.NodeListIndices[0];
+            face.B = feFace.NodeListIndices[1];
+            face.C = feFace.NodeListIndices[2];
+
+            if (feFace.NodeListIndices.Count == 4)
+                face.D = feFace.NodeListIndices[3];
+
+            return face;
+        }
+
 
         /***************************************************/
         /**** Public Methods - Interface                ****/


### PR DESCRIPTION
### Issues addressed by this PR
Closes #1381 
Splits the `FEMesh.Geometry()` method into three smaller methods:
FeMeshFace => Face
IEnumerable<FeMeshFace> => IEnumerble<Face>
FeMesh => Mesh

### Test files
<!-- Link to test files to validate the proposed changes -->

### Additional comments
What should the excact format for the Output parameter be? `line` `outline` or `face` @IsakNaslundBh  ?