### PR TITLE
Geometry_Engine: WetBlanketInterpetation edge case fix

### DIFF
--- a/Geometry_Engine/Compute/WetBlanketInterpretation.cs
+++ b/Geometry_Engine/Compute/WetBlanketInterpretation.cs
@@ -26,6 +26,7 @@ using System.Linq;
 using BH.oM.Geometry;
 using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
+using BH.oM.Quantities.Attributes;
 
 namespace BH.Engine.Geometry
 {
@@ -37,6 +38,7 @@ namespace BH.Engine.Geometry
 
         [Description("Takes a List of Polylines and creates a `squished` version with the same area at every X-location, and hence the same total area as well. Required for some calculations.")]
         [Input("pLines", "the outermost Polyline must be counter-clockwise. Clockwise ones are holes within it. Both Polylines should be on the XY-plane.")]
+        [Input("tol", "The tolerance for considering two points as one. Note: resulting points will be moved to be on a multiple of the tolerance for its x-value.", typeof(Length))]
         [Output("C", "A single Polyline oriented counter clockwise with the same area as the sum of all the polylines.")]
         public static Polyline WetBlanketInterpretation(List<Polyline> pLines, double tol = Tolerance.Distance)
         {

--- a/Geometry_Engine/Compute/WetBlanketInterpretation.cs
+++ b/Geometry_Engine/Compute/WetBlanketInterpretation.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.Geometry
         [Output("C", "A single Polyline oriented counter clockwise with the same area as the sum of all the polylines.")]
         public static Polyline WetBlanketInterpretation(List<Polyline> pLines, double tol = Tolerance.Distance)
         {
-            List<Polyline> clones = pLines.Select(x => x.Clone()).ToList();
+            List<Polyline> clones = pLines.Select(x => x.RemoveShortSegments(tol, tol)).ToList();
 
             int digits = (int)Math.Floor(-Math.Log10(tol));
 

--- a/Geometry_Engine/Compute/WetBlanketInterpretation.cs
+++ b/Geometry_Engine/Compute/WetBlanketInterpretation.cs
@@ -144,7 +144,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Modifies a Polyline to have verticies at every xValue, i.e. lineIntersections at every x in xValues. \n" +
-                     "Also creates a separate list of every point which also stores its index on the Polyline and k")]
+                     "Also creates a separate list of every point which also stores its index on the Polyline and k.")]
         private static Polyline SplitPolylineAtXValues(Polyline pLine, ref List<Tuple<Point, int, int>> list, List<double> xValues, int k, double tol)
         {
             Polyline polyline = new Polyline();

--- a/Geometry_Engine/Compute/WetBlanketInterpretation.cs
+++ b/Geometry_Engine/Compute/WetBlanketInterpretation.cs
@@ -42,7 +42,7 @@ namespace BH.Engine.Geometry
         [Output("C", "A single Polyline oriented counter clockwise with the same area as the sum of all the polylines.")]
         public static Polyline WetBlanketInterpretation(List<Polyline> pLines, double tol = Tolerance.Distance)
         {
-            List<Polyline> clones = pLines.Select(x => x.RemoveShortSegments(tol, tol)).ToList();
+            List<Polyline> clones = pLines.Select(x => x.RemoveShortSegments(tol, tol).Clone()).ToList();
 
             int digits = (int)Math.Floor(-Math.Log10(tol));
 

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -44,6 +44,10 @@
       <HintPath>..\..\BHoM\Build\Geometry_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Quantities_oM">
+      <HintPath>..\..\BHoM\Build\Quantities_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\BHoM\Build\Reflection_oM.dll</HintPath>


### PR DESCRIPTION
### Issues addressed by this PR
Closes #1503 
As discovered through the use of PlasticModulus, `WetBlanketInterpetation` does not work for `Polylines` with segments shorter than the tolerance.

I have hence added `RemoveShortSegments` to the beginning of `WetBlanketInterpetation`

### Test files
#1505 needed to see the change in the test file
see issue

### Additional comments
Expanded my description with some Quantities which did touch the `.csproj`