### PR TITLE
Geometry_Engine: Allow equal values for shape profiles

### DIFF
--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -345,7 +345,7 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-            if (height <= 0 || width <= 0 || cornerRadius< 0)
+            if (height <= 0 || width <= 0 || cornerRadius < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -222,13 +222,13 @@ namespace BH.Engine.Geometry
 
         public static FabricatedBoxProfile FabricatedBoxProfile(double height, double width, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
-            if (height <= topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
+            if (height < topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
             {
                 InvalidRatioError("height", "topFlangeThickness, botFlangeThickness and weldSize");
                 return null;
             }
 
-            if (width <= webThickness * 2 + 2 * Math.Sqrt(2) * weldSize)
+            if (width < webThickness * 2 + 2 * Math.Sqrt(2) * weldSize)
             {
                 InvalidRatioError("width", "webThickness and weldSize");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -274,7 +274,7 @@ namespace BH.Engine.Geometry
 
         public static KiteProfile KiteProfile(double width1, double angle1, double thickness)
         {
-            if ((width1*Math.Sin(angle1/2)/Math.Sqrt(2)) /(Math.Sin(Math.PI*0.75- (angle1/2)))<thickness)
+            if ((width1 * Math.Sin(angle1 / 2) / Math.Sqrt(2)) / (Math.Sin(Math.PI * 0.75 - (angle1 / 2))) <= thickness)
             {
                 InvalidRatioError("thickness", "width and angle1");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Geometry
 
         public static ISectionProfile ISectionProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius)
         {
-            if (height < flangeThickness * 2 + rootRadius * 2)
+            if (height < flangeThickness * 2 + rootRadius * 2 || height <= flangeThickness * 2)
             {
                 InvalidRatioError("height","flangeThickness and rootRadius");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -376,7 +376,7 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-            if (height <= 0 || width <= 0 || webthickness<= 0 || flangeThickness <= 0 || rootRadius < 0 || toeRadius < 0)
+            if (height <= 0 || width <= 0 || webthickness <= 0 || flangeThickness <= 0 || rootRadius < 0 || toeRadius < 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -294,7 +294,7 @@ namespace BH.Engine.Geometry
 
         public static FabricatedISectionProfile FabricatedISectionProfile(double height, double topFlangeWidth, double botFlangeWidth, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
-            if (height <= topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
+            if (height < topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
             {
                 InvalidRatioError("height","topFlangeThickness, botFlangeThickness and weldSize");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -73,13 +73,13 @@ namespace BH.Engine.Geometry
 
         public static BoxProfile BoxProfile(double height, double width, double thickness, double outerRadius, double innerRadius)
         {
-            if (thickness > height / 2)
+            if (thickness >= height / 2)
             {
                 InvalidRatioError("thickness", "height");
                 return null;
             }
 
-            if (thickness > width / 2)
+            if (thickness >= width / 2)
             {
                 InvalidRatioError("thickness", "width");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -300,13 +300,13 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-            if (botFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize)
+            if (botFlangeWidth < webThickness + 2 * Math.Sqrt(2) * weldSize)
             {
                 InvalidRatioError("botFlangeWidth", "webThickness and weldSize");
                 return null;
             }
 
-            if (topFlangeWidth <= webThickness + 2 * Math.Sqrt(2) * weldSize)
+            if (topFlangeWidth < webThickness + 2 * Math.Sqrt(2) * weldSize)
             {
                 InvalidRatioError("topFlangeWidth", "webThickness and weldSize");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -436,13 +436,13 @@ namespace BH.Engine.Geometry
 
         public static TubeProfile TubeProfile(double diameter, double thickness)
         {
-            if (thickness >= diameter/2)
+            if (thickness >= diameter / 2)
             {
                 InvalidRatioError("diameter", "thickness");
                 return null;
             }
 
-            if (diameter<=0 || thickness<=0)
+            if (diameter <= 0 || thickness <= 0)
             {
                 Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -394,13 +394,13 @@ namespace BH.Engine.Geometry
 
         public static GeneralisedTSectionProfile GeneralisedTSectionProfile(double height, double webThickness, double leftOutstandWidth, double leftOutstandThickness, double rightOutstandWidth, double rightOutstandThickness, bool mirrorAboutLocalY = false)
         {
-            if (height <= leftOutstandThickness)
+            if (height < leftOutstandThickness)
             {
                 InvalidRatioError("height", "leftOutstandThickness");
                 return null;
             }
 
-            if (height <= rightOutstandThickness)
+            if (height < rightOutstandThickness)
             {
                 InvalidRatioError("height", "rightOutstandThickness");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -173,7 +173,7 @@ namespace BH.Engine.Geometry
 
         public static ChannelProfile ChannelProfile(double height, double width, double webthickness, double flangeThickness, double rootRadius, double toeRadius, bool mirrorAboutLocalZ = false)
         {
-            if (height < flangeThickness * 2 + rootRadius * 2)
+            if (height < flangeThickness * 2 + rootRadius * 2 || height <= flangeThickness * 2)
             {
                 InvalidRatioError("height", "flangeThickness and rootRadius");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -222,13 +222,13 @@ namespace BH.Engine.Geometry
 
         public static FabricatedBoxProfile FabricatedBoxProfile(double height, double width, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
-            if (height < topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
+            if (height < topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize || height <= topFlangeThickness + botFlangeThickness)
             {
                 InvalidRatioError("height", "topFlangeThickness, botFlangeThickness and weldSize");
                 return null;
             }
 
-            if (width < webThickness * 2 + 2 * Math.Sqrt(2) * weldSize)
+            if (width < webThickness * 2 + 2 * Math.Sqrt(2) * weldSize || width <= webThickness * 2)
             {
                 InvalidRatioError("width", "webThickness and weldSize");
                 return null;

--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -294,7 +294,7 @@ namespace BH.Engine.Geometry
 
         public static FabricatedISectionProfile FabricatedISectionProfile(double height, double topFlangeWidth, double botFlangeWidth, double webThickness, double topFlangeThickness, double botFlangeThickness, double weldSize)
         {
-            if (height < topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize)
+            if (height < topFlangeThickness + botFlangeThickness + 2 * Math.Sqrt(2) * weldSize || height <= topFlangeThickness + botFlangeThickness)
             {
                 InvalidRatioError("height","topFlangeThickness, botFlangeThickness and weldSize");
                 return null;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1502 
Allows for dumb but valid sections
i.e. an I section can now be a rectangular section and a Generalised T section can become wider by having one of the flanges occupy the whole height 
It does still not allow for the creation of zero length polylines in the centre of sections
i.e. attempts to create a rectangular profile from a box profile

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EmcFr3JyH5FGg81281kzc9wBwUc0z-dJ4VBmljAPfECcXg?e=E927at

### Changelog

### Additional comments
<!-- As required -->