### PR TITLE
Serialiser_Engine: Fix bug for deserialisation of List<IBHoMObject> containing CustomObjects

### DIFF
--- a/Serialiser_Engine/Convert/Bson.cs
+++ b/Serialiser_Engine/Convert/Bson.cs
@@ -170,7 +170,8 @@ namespace BH.Engine.Serialiser
 
                 BsonDefaults.DynamicDocumentSerializer = new CustomObjectSerializer();
 
-                BsonSerializer.RegisterDiscriminatorConvention(typeof(object), new GenericDiscriminatorConvention());
+                BsonSerializer.RegisterDiscriminatorConvention(typeof(IBHoMObject), new BHoMObjectDiscriminatorConvention());
+                BsonSerializer.RegisterDiscriminatorConvention(typeof(IObject), new BHoMObjectDiscriminatorConvention());
             }
             catch (Exception)
             {

--- a/Serialiser_Engine/Objects/MemberMapConventions/BHoMObjectDiscriminatorConvention.cs
+++ b/Serialiser_Engine/Objects/MemberMapConventions/BHoMObjectDiscriminatorConvention.cs
@@ -1,0 +1,86 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Reflection;
+using BH.oM.Base;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Conventions;
+using MongoDB.Bson.Serialization.Serializers;
+
+namespace BH.Engine.Serialiser.Objects.MemberMapConventions
+{
+    /// <summary>
+    /// Represents the object discriminator convention.
+    /// </summary>
+    public class BHoMObjectDiscriminatorConvention : IDiscriminatorConvention
+    {
+        /***************************************************/
+        /**** Properties                                ****/
+        /***************************************************/
+
+        public string ElementName { get { return "_t"; } }
+
+
+        /***************************************************/
+        /**** Interface Methods                         ****/
+        /***************************************************/
+
+        public Type GetActualType(IBsonReader bsonReader, Type nominalType)
+        {
+            // the BsonReader is sitting at the value whose actual type needs to be found
+            var bsonType = bsonReader.GetCurrentBsonType();
+
+            if (bsonType == BsonType.Document)
+            {
+                var bookmark = bsonReader.GetBookmark();
+                bsonReader.ReadStartDocument();
+                var actualType = nominalType;
+                if (bsonReader.FindElement(ElementName))
+                {
+                    var context = BsonDeserializationContext.CreateRoot(bsonReader);
+                    var discriminator = BsonValueSerializer.Instance.Deserialize(context);
+                    actualType = BsonSerializer.LookupActualType(nominalType, discriminator);
+                }
+                else
+                    actualType = typeof(CustomObject);
+
+                bsonReader.ReturnToBookmark(bookmark);
+                return actualType;
+            }
+
+            return nominalType;
+        }
+
+        /***************************************************/
+
+        public BsonValue GetDiscriminator(Type nominalType, Type actualType)
+        {
+            return TypeNameDiscriminator.GetDiscriminator(actualType);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Serialiser_Engine/Serialiser_Engine.csproj
+++ b/Serialiser_Engine/Serialiser_Engine.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Objects\MemberMapConventions\ImmutableTypeClassMapConventionFixed.cs" />
     <Compile Include="Objects\MemberMapConventions\ImmutableBHoMClassMapConvention.cs" />
     <Compile Include="Objects\MemberMapConventions\ImmutableBHoMCreatorMapConvention.cs" />
+    <Compile Include="Objects\MemberMapConventions\BHoMObjectDiscriminatorConvention.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\TaggedName.cs" />
   </ItemGroup>


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1500

Here's what was happening in term of teh code side:
- The `Dataset` class has property of type List<IBHoMObject>
- Mongo Bson automatically generate a deserialiser for `Dataset`
- When that deserialiser tries to figure out the type of the objects inside the list (yes, generics again), it fails because custom objects don't have a "_t" value provided.
- The same would have happen for a list of IObject but not for list of objects (as we already cover that last case).

So the trick here was to add a discriminator on interfaces that can cover CustomObject to make sure `CustomObject` is returned when no "_t" value is found 


### Test files
https://burohappold.sharepoint.com/:u:/s/BHoM/EXSqZLG23OJOnS30i215tE8BqHhmzwfMwyL75z3NIChj_Q?e=4Chz65

I have updated the file provided in the issue so it also tests for a few more case (e.g. List<object> containing custom objects)
