### PR TITLE
Versioning_Engine: Functionality for multiple instances of Rhino (or any UI)

### DIFF
--- a/Versioning_Engine/Convert/ToNewVersion.cs
+++ b/Versioning_Engine/Convert/ToNewVersion.cs
@@ -95,11 +95,15 @@ namespace BH.Engine.Versioning
             if (m_Pipes.ContainsKey(version))
                 return m_Pipes[version];
 
+            // Get the pipe name
+            int processId = Process.GetCurrentProcess().Id;
+            string pipeName = processId.ToString() + "_" + version;
+
             // Create the pipe
             NamedPipeServerStream pipe;
             try
             {
-                pipe = new NamedPipeServerStream(version, PipeDirection.InOut);
+                pipe = new NamedPipeServerStream(pipeName, PipeDirection.InOut);
             }
             catch
             {
@@ -124,7 +128,7 @@ namespace BH.Engine.Versioning
 
             // Create the process for the upgrader
             Process process = new Process();
-            process.StartInfo = new ProcessStartInfo(processFile, version);
+            process.StartInfo = new ProcessStartInfo(processFile, pipeName);
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.CreateNoWindow = true;
             bool ok = process.Start();                


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1548

I have added the PID of the program calling the upgrader in the pipeline name so multiple pipelines can be created for the same upgrader version.

