### PR TITLE
Reflection_Engine: Added set property functionality for custom data

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -87,7 +87,7 @@ namespace BH.Engine.Reflection
                 IBHoMObject bhomObj = obj as IBHoMObject;
                 if (bhomObj == null) return false;
 
-                if (!(bhomObj is CustomObject))
+                if (!bhomObj.CustomData.ContainsKey(propName))
                     Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data");
 
                 bhomObj.CustomData[propName] = value;

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -93,6 +93,12 @@ namespace BH.Engine.Reflection
                 bhomObj.CustomData[propName] = value;
                 return true;
             }
+            else if (obj is IDictionary)
+            {
+                IDictionary dic = obj as IDictionary;
+                dic[propName] = value;
+                return true;
+            }
 
             return false;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1578 

Adeed dictionary functionality to set property so that custom data properties can be set.


### Test files
[SetCustomDataProperty.zip](https://github.com/BHoM/BHoM_Engine/files/4331627/SetCustomDataProperty.zip)



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->