### PR TITLE
Library_Engine: Only pick up exact path for library search strings once

### DIFF
--- a/Library_Engine/Query/Datasets.cs
+++ b/Library_Engine/Query/Datasets.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Library
         [Output("dataset", "The datasets extracted from the library")]
         public static List<Dataset> Datasets(string libraryName)
         {
-            List<string> keys;
+            HashSet<string> keys;
             if (!LibraryPaths().TryGetValue(libraryName, out keys))
                 return new List<Dataset>();
 

--- a/Library_Engine/Query/Libraries.cs
+++ b/Library_Engine/Query/Libraries.cs
@@ -149,7 +149,7 @@ namespace BH.Engine.Library
 
         /***************************************************/
 
-        private static Dictionary<string, List<string>> LibraryPaths()
+        private static Dictionary<string, HashSet<string>> LibraryPaths()
         {
             if (m_libraryPaths.Count < 1)
                 RefreshLibraries();
@@ -202,7 +202,7 @@ namespace BH.Engine.Library
                 m_libraryPaths[folderName].Add(dictionaryPath);
             else
             {
-                m_libraryPaths[folderName] = new List<string>();
+                m_libraryPaths[folderName] = new HashSet<string>();
                 m_libraryPaths[folderName].Add(dictionaryPath);
             }
 
@@ -213,7 +213,7 @@ namespace BH.Engine.Library
                     m_libraryPaths[path].Add(dictionaryPath);
                 else
                 {
-                    m_libraryPaths[path] = new List<string>();
+                    m_libraryPaths[path] = new HashSet<string>();
                     m_libraryPaths[path].Add(dictionaryPath);
                 }
             }
@@ -234,7 +234,7 @@ namespace BH.Engine.Library
         private static Dictionary<string, List<Tuple<BH.oM.Reflection.Debugging.EventType, string>>> m_deserialisationEvents = new Dictionary<string, List<Tuple<oM.Reflection.Debugging.EventType, string>>>();
 
         private static Dictionary<string, string[]> m_libraryStrings = new Dictionary<string, string[]>();
-        private static Dictionary<string, List<string>> m_libraryPaths = new Dictionary<string, List<string>>();
+        private static Dictionary<string, HashSet<string>> m_libraryPaths = new Dictionary<string, HashSet<string>>();
         private static Tree<string> m_dbTree = new Tree<string>();
 
         /***************************************************/

--- a/Library_Engine/Query/RefreshLibraries.cs
+++ b/Library_Engine/Query/RefreshLibraries.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Library
 
         public static void RefreshLibraries()
         {
-            m_libraryPaths = new Dictionary<string, List<string>>();
+            m_libraryPaths = new Dictionary<string, HashSet<string>>();
             m_libraryStrings = new Dictionary<string, string[]>();
             m_datasets = new Dictionary<string, Dataset>();
             m_deserialisationEvents = new Dictionary<string, List<Tuple<oM.Reflection.Debugging.EventType, string>>>();


### PR DESCRIPTION
### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1379 

<!-- Add short description of what has been fixed -->

Fixing making sure library paths are only stored once for each guide path. Before identical filename and folder name could lead to the same library being picked up multiple times.

This should not have any effect at all on the dropdown component as it always works with full paths.

### Test files
<!-- Link to test files to validate the proposed changes -->

Extract the zip file, including folder, and place it in appdata/BHoM/Datasets
[TestSameName.zip](https://github.com/BHoM/BHoM_Engine/files/4338445/TestSameName.zip)

And run this testfile:
https://burohappold.sharepoint.com/:f:/s/BHoM/Es5sBsBXc1RHsI9x7JMI70gB-qrRj_Px_P39kf_ZYjX0ww?e=jjIs97

The dataset contains two dummy bars. Without this change the testscript returns both of them 2 times (resulting in 4 Bars) as the library is being picked up twice.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->