### PR TITLE
Geometry_Engine: Add last control point for Simplify

### DIFF
--- a/Geometry_Engine/Modify/Simplify.cs
+++ b/Geometry_Engine/Modify/Simplify.cs
@@ -35,7 +35,6 @@ namespace BH.Engine.Geometry
         {
             bool isClosed = polyline.IsClosed(distanceTolerance);
             List<Point> ctrlPts = polyline.DiscontinuityPoints(distanceTolerance, angleTolerance);
-            List<Point> newPts = new List<Point>(ctrlPts);
 
             for (int i = 1; i < ctrlPts.Count - 1; i++)
             {
@@ -50,6 +49,9 @@ namespace BH.Engine.Geometry
 
             if (ctrlPts.Count < 2)
                 return polyline;
+
+            if (isClosed)
+                ctrlPts.Add(ctrlPts[0]);
 
             return new Polyline { ControlPoints = ctrlPts };
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1602 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Add a control point if the curve is closed.

### Additional comments
<!-- As required -->