### PR TITLE
Serialiser_Engine: Fix deserialisation of string when top object

### DIFF
--- a/Serialiser_Engine/Convert/Bson.cs
+++ b/Serialiser_Engine/Convert/Bson.cs
@@ -68,6 +68,10 @@ namespace BH.Engine.Serialiser
             if (!m_TypesRegistered)
                 RegisterTypes();
 
+            // Patch for handling the case where a string is a top object - will need proper review in next quarter
+            if (bson.Contains("_t") && bson["_t"] == "System.String" && bson.Contains("_v"))
+                return bson["_v"].AsString;
+
             bson.Remove("_id");
             object obj = BsonSerializer.Deserialize(bson, typeof(object));
             if (obj is ExpandoObject)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1618 

<!-- Add short description of what has been fixed -->


### Test files
Two things to test:
- Convert a string to Json and then back using `FromJson`. The result should be a string and not a custom object.
- For the dataset component, just create any data component using teh ctrl-shift-b menu. For example, search for `CHS`.

### Additional comments
- It is important to note that, this close to the creation of the installer, I have prioritised the minimisation of risk. One could argue that the proper way to handle deserialisation of the string is to Create a string serialiser and to register it with `BsonSerializer`. But making sure there is no undesirable side-effect is way more difficult that way. 
- My key concern is the fact that the data component is not created properly through the ctrl-shit-B menu. This should be, in my opinion, the deciding factor for merging this PR before or after teh creation of the installer.
- I cannot think of any side effect of the code I have added since it takes care of a very specific bug and is not called in any other case than for a string as top object. If any of you can still see a risk of merging now, please flag it up.