### PR TITLE
Geometry_Engine: Clarify input naming in CollapseToScaledPolyline.cs

### DIFF
--- a/Geometry_Engine/Compute/CollapseToScaledPolyline.cs
+++ b/Geometry_Engine/Compute/CollapseToScaledPolyline.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Geometry
 
         [Description("Collapses a PolyCurve to a polyline where curved segments are split into Polyline segments for computations. Where their partitioning is based on both their curvature and size, ergo; shorter segment less partitions, very curved segment more partitions")]
         [Input("curve", "The curve to collapse")]
-        [Input("relativeAngleTolerance", "relativeAngleTolerance is the angleTolerance for a unit circle, the tolerance value will vary by: toleranceGrowth over curvature")]
+        [Input("relativeAngleTolerance", "relativeAngleTolerance is the angleTolerance for a unit circle, the tolerance value will vary by: toleranceScaleFactor over curvature")]
         [Input("toleranceScaleFactor", "toleranceScaleFactor is the value that decides how much the angleTolerance varies due to curvature")]
         [Input("maxDivisionsPerSegment", "The maximum number of segment each sub-curve can be broken into")]
         [Input("scale", "the radius of a baseline circle for the angle tolerance, smaller circles will have less segments and bigger more. Default of 0 means the program will determine an appropriate radius for the PolyCurve")]

--- a/Geometry_Engine/Compute/CollapseToScaledPolyline.cs
+++ b/Geometry_Engine/Compute/CollapseToScaledPolyline.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Geometry
         [Input("maxDivisionsPerSegment", "The maximum number of segment each sub-curve can be broken into")]
         [Input("scale", "the radius of a baseline circle for the angle tolerance, smaller circles will have less segments and bigger more. Default of 0 means the program will determine an appropriate radius for the PolyCurve")]
         [Output("C", "A polyline approximating the provided curve")]
-        public static Polyline CollapseToScaledPolyline(this PolyCurve curve, double tolerance = 0.04, double toleranceGrowth = 0.001, int maxDivisionsPerSegment = 200, double scale = 0)
+        public static Polyline CollapseToScaledPolyline(this PolyCurve curve, double tolerance, double toleranceGrowth = 0.001, int maxDivisionsPerSegment = 200, double scale = 0)
         {
             if (tolerance <= 0)
                 return null;


### PR DESCRIPTION
### Issues addressed by this PR
Closes #1631

### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed, and only code implementation was in structures where the tolerance value was defined, doubt it has gotten mush use elsewhere.

### Changelog

### Additional comments
<!-- As required -->