### PR TITLE
Serialiser_Engine: Add tools necessary to perform serialisation validation 

### DIFF
--- a/Reflection_Engine/Compute/DummyObject.cs
+++ b/Reflection_Engine/Compute/DummyObject.cs
@@ -199,7 +199,6 @@ namespace BH.Engine.Reflection
                     Type tupleType = Type.GetType("System.Tuple`" + keys.Length);
                     Type constructedType = tupleType.MakeGenericType(keys);
                     return Activator.CreateInstance(constructedType, keys.Select(x => GetValue(x, depth + 1)).ToArray());
-
                 }
                 else if (type.Name == "IDictionary`2")
                 {

--- a/Reflection_Engine/Compute/DummyObject.cs
+++ b/Reflection_Engine/Compute/DummyObject.cs
@@ -1,0 +1,346 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Debugging;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static object DummyObject(Type type)
+        {
+            if (m_ImplementingTypes.Count == 0)
+                LinkInterfaces(Query.BHoMTypeList());
+
+            return InitialiseObject(type, 0);
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static object InitialiseObject(Type type, int depth = 0)
+        {
+            try
+            {
+                // Create object
+                object obj;
+                if (type.GetInterface("IImmutable") != null)
+                    return CreateImmutable(type, depth);
+                else if (type.IsGenericType)
+                {
+                    type = GetType(type);
+                    obj = Activator.CreateInstance(type);
+                }
+                else if (type.IsEnum)
+                {
+                    Array values = Enum.GetValues(type);
+                    return values.GetValue(values.Length - 1);
+                }
+                else
+                    obj = Activator.CreateInstance(type);
+
+                // Set its public properties
+                foreach (PropertyInfo prop in type.GetProperties())
+                {
+                    if (prop.CanWrite && prop.SetMethod.GetParameters().Count() == 1)
+                        prop.SetValue(obj, GetValue(prop.PropertyType, depth));
+                }
+
+                return obj;
+            }
+            catch (Exception e)
+            {
+                Reflection.Compute.RecordWarning("Failed to generate object for type " + type.FullName);
+                return null;
+            }
+            
+        }
+
+        /*******************************************/
+
+        private static object GetValue(Type type, int depth)
+        {
+            try
+            {
+                if (type.IsPrimitive)
+                {
+                    if (type == typeof(bool))
+                        return true;
+                    else if (type == typeof(int))
+                        return 42;
+                    else if (type == typeof(double))
+                        return 42.42;
+                    else if (type == typeof(float))
+                        return 42.42f;
+                    else if (type == typeof(char))
+                        return 't';
+                    else
+                        return Activator.CreateInstance(type);
+                }
+                else if (type == typeof(decimal))
+                    return new Decimal(42.42);
+                else if (type == typeof(Guid))
+                    return Guid.NewGuid();
+                else if (type == typeof(string))
+                    return "test";
+                else if (type.IsEnum)
+                {
+                    Array values = Enum.GetValues(type);
+                    return values.GetValue(values.Length - 1);
+                }
+                else if (type == typeof(System.Drawing.Color))
+                    return System.Drawing.Color.FromArgb(1, 2, 3, 4);
+                else if (type == typeof(System.Drawing.Bitmap))
+                    return new System.Drawing.Bitmap(10, 10);
+                else if (type == typeof(System.Data.DataTable))
+                {
+                    System.Data.DataTable table = new System.Data.DataTable("test");
+                    table.Columns.AddRange(new System.Data.DataColumn[] {
+                        new System.Data.DataColumn("col1", typeof(int)),
+                        new System.Data.DataColumn("col2", typeof(string))
+                    });
+                    System.Data.DataRow row = table.NewRow();
+                    row[0] = 4;
+                    row[1] = "test";
+                    table.Rows.Add(row);
+                    return table;
+                }
+                else if (typeof(IDictionary).IsAssignableFrom(type))
+                {
+                    IDictionary dic = Activator.CreateInstance(GetType(type)) as IDictionary;
+                    Type[] typeArguments = type.GetGenericArguments();
+                    object key = GetValue(typeArguments[0], depth + 1);
+                    object val = GetValue(typeArguments[1], depth + 1);
+                    if (key != null && val != null)
+                        dic.Add(key, val);
+                    return dic;
+                }
+                else if (type.IsArray)
+                {
+                    ConstructorInfo constructor = type.GetConstructors().First();
+                    object[] dims = constructor.GetParameters().Select(x => (object)1).ToArray();
+                    Array array = constructor.Invoke(dims) as Array;
+
+                    if (dims.Length == 1)
+                    {
+                        object val = GetValue(type.GetElementType(), depth + 1);
+                        if (val != null)
+                            array.SetValue(val, 0);
+                    }
+                    else if (dims.Length == 2)
+                    {
+                        object val = GetValue(type.GetElementType(), depth + 1);
+                        if (val != null)
+                            array.SetValue(val, 0, 0);
+                    }
+                    return array;
+                }
+                else if (typeof(IList).IsAssignableFrom(type))
+                {
+                    if (type == typeof(FragmentSet))
+                    {
+                        return new FragmentSet();
+                    }
+                    else if (type.Name == "ReadOnlyCollection`1")
+                    {
+                        Type listType = typeof(List<>).MakeGenericType(type.GetGenericArguments());
+                        IList list = Activator.CreateInstance(listType) as IList;
+                        object val = GetValue(type.GetGenericArguments()[0], depth + 1);
+                        if (val != null)
+                            list.Add(val);
+                        return type.GetConstructors().First().Invoke(new object[] { list });
+                    }
+                    {
+                        IList list = Activator.CreateInstance(GetType(type)) as IList;
+                        object val = GetValue(type.GetGenericArguments()[0], depth + 1);
+                        if (val != null)
+                            list.Add(val);
+                        return list;
+                    }
+                }
+                else if (type.Name == "HashSet`1")
+                {
+                    return Activator.CreateInstance(GetType(type));
+                }
+                else if (type.Name.StartsWith("Tuple`"))
+                {
+                    Type[] keys = type.GetGenericArguments();
+                    Type tupleType = Type.GetType("System.Tuple`" + keys.Length);
+                    Type constructedType = tupleType.MakeGenericType(keys);
+                    return Activator.CreateInstance(constructedType, keys.Select(x => GetValue(x, depth + 1)).ToArray());
+
+                }
+                else if (type.Name == "IDictionary`2")
+                {
+                    var itemTypes = type.GetGenericArguments();
+                    var dicType = typeof(Dictionary<,>);
+                    var constructedDicType = dicType.MakeGenericType(itemTypes);
+                    IDictionary dic = Activator.CreateInstance(constructedDicType) as IDictionary;
+                    object key = GetValue(itemTypes[0], depth + 1);
+                    object value = GetValue(itemTypes[1], depth + 1);
+                    if (key != null && value != null)
+                        dic.Add(key, value);
+                    return dic;
+                }
+                else if (type.Name == "IEnumerable`1" || type.Name == "IList`1")
+                {
+                    var itemType = GetType(type.GetGenericArguments()[0]);
+                    var listType = typeof(List<>);
+                    var constructedListType = listType.MakeGenericType(itemType);
+                    IList list = Activator.CreateInstance(constructedListType) as IList;
+                    object val = GetValue(itemType, depth + 1);
+                    if (val != null)
+                        list.Add(val);
+                    return list;
+                }
+                else if (typeof(IEnumerable).IsAssignableFrom(type))
+                {
+                    return Activator.CreateInstance(type);
+                }
+                else if (type == typeof(object))
+                {
+                    return new BHoMObject { Name = "test" };
+                }
+                else if (type == typeof(Type))
+                {
+                    return typeof(BHoMObject);
+                }
+                else if (type == typeof(MethodBase))
+                {
+                    return typeof(BH.Engine.Reflection.Query).GetMethods().First();
+                }
+                else if (type.IsInterface || type.IsAbstract)
+                {
+                    if (depth > 50 || !m_ImplementingTypes.ContainsKey(type))
+                        return null;
+                    else
+                        return GetValue(m_ImplementingTypes[type], depth + 1);
+                }
+                else if (type == typeof(DateTimeOffset))
+                {
+                    return new DateTimeOffset(636694884850000000, new TimeSpan());
+                }
+                else
+                {
+                    if (depth > 20) return null;
+                    return InitialiseObject(type, depth + 1);
+                }
+            }
+            catch (Exception e)
+            {
+                Reflection.Compute.RecordWarning("Failed to generate value for type " + type.FullName);
+                return null;
+            }
+        }
+
+        /***************************************************/
+
+        private static object CreateImmutable(Type type, int depth)
+        {
+            ConstructorInfo ctor = type.GetConstructors().OrderByDescending(x => x.GetParameters().Count()).First();
+            object[] parameters = ctor.GetParameters().Select(x => GetValue(x.ParameterType, depth)).ToArray();
+            return ctor.Invoke(parameters);
+        }
+
+        /***************************************************/
+
+        private static Type GetType(Type type)
+        {
+            try
+            {
+                if (type.Name.StartsWith("IComparable`1"))
+                    return typeof(int);
+                else if (type.IsInterface || type.IsAbstract)
+                    return m_ImplementingTypes[type];
+                else if (type.ContainsGenericParameters)
+                {
+                    List<Type> actuals = new List<Type>();
+                    foreach (Type generic in type.GetGenericArguments())
+                    {
+                        if (generic.GetGenericParameterConstraints().Count() > 0)
+                            actuals.Add(GetType(generic.GetGenericParameterConstraints()[0]));
+                        else
+                            actuals.Add(typeof(object));
+                    }
+
+                    return type.MakeGenericType(actuals.ToArray());
+                }
+                else
+                    return type;
+            }
+            catch (Exception e)
+            {
+                throw e;
+            }
+        }
+
+        /***************************************************/
+
+        private static void LinkInterfaces(List<Type> types)
+        {
+            foreach (Type type in types)
+            {
+                try
+                {
+                    if (!type.IsAbstract && !type.IsInterface && !type.IsEnum)
+                    {
+                        foreach (Type inter in type.GetInterfaces())
+                        {
+                            if (!m_ImplementingTypes.ContainsKey(inter))
+                                m_ImplementingTypes[inter] = type;
+                        }
+
+                        Type baseType = type.BaseType;
+                        if (baseType != null && !m_ImplementingTypes.ContainsKey(baseType))
+                            m_ImplementingTypes[baseType] = type;
+                    }
+                }
+                catch (Exception e)
+                {
+                    throw e;
+                }
+            }
+        }
+
+
+        /*******************************************/
+        /**** Private fields                    ****/
+        /*******************************************/
+
+        private static Dictionary<Type, Type> m_ImplementingTypes = new Dictionary<Type, Type>();
+
+        /***************************************************/
+    }
+}
+

--- a/Reflection_Engine/Query/IsEqual.cs
+++ b/Reflection_Engine/Query/IsEqual.cs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Reflection;
+using KellermanSoftware.CompareNetObjects;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static bool IsEqual(this object a, object b)
+        {
+            if (a.GetType() != b.GetType())
+                return false;
+
+            return m_EqualityComparer.Compare(a, b).AreEqual;
+        }
+
+        /***************************************************/
+        /**** Private Static Fields                     ****/
+        /***************************************************/
+
+        private static CompareLogic m_EqualityComparer = new CompareLogic();
+
+        /***************************************************/
+    }
+}
+

--- a/Reflection_Engine/Query/TypeList.cs
+++ b/Reflection_Engine/Query/TypeList.cs
@@ -124,7 +124,7 @@ namespace BH.Engine.Reflection
                             if (type.Namespace != null && type.Namespace.StartsWith("BH.oM"))
                             {
                                 AddBHoMTypeToDictionary(type.FullName, type);
-                                if (!type.IsInterface)
+                                if (!type.IsInterface && !(type.IsAbstract && type.IsSealed)) // Avoid interfaces and static classes
                                     m_BHoMTypeList.Add(type);
                                 else
                                     m_InterfaceList.Add(type);

--- a/Reflection_Engine/Reflection_Engine.csproj
+++ b/Reflection_Engine/Reflection_Engine.csproj
@@ -47,6 +47,9 @@
       <HintPath>..\packages\ICSharpCode.Decompiler.3.1.0.3652\lib\net45\ICSharpCode.Decompiler.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="KellermanSoftware.Compare-NET-Objects, Version=4.65.0.0, Culture=neutral, PublicKeyToken=d970ace04cc85217, processorArchitecture=MSIL">
+      <HintPath>..\packages\CompareNETObjects.4.65.0\lib\net452\KellermanSoftware.Compare-NET-Objects.dll</HintPath>
+    </Reference>
     <Reference Include="Mono.Cecil, Version=0.10.0.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.10.0\lib\net40\Mono.Cecil.dll</HintPath>
       <Private>True</Private>
@@ -80,7 +83,9 @@
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.3.0\lib\portable-net40+sl4+win8+wp8\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
@@ -93,6 +98,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\DummyObject.cs" />
     <Compile Include="Compute\MakeGenericFromInputs.cs" />
     <Compile Include="Compute\DeepDependencies.cs" />
     <Compile Include="Compute\OpenHelpPage.cs" />
@@ -118,6 +124,7 @@
     <Compile Include="Query\ImplementingTypes.cs" />
     <Compile Include="Query\Count.cs" />
     <Compile Include="Query\IsExposed.cs" />
+    <Compile Include="Query\IsEqual.cs" />
     <Compile Include="Query\Item.cs" />
     <Compile Include="Query\NestedMethods.cs" />
     <Compile Include="Query\OutputType.cs" />

--- a/Reflection_Engine/packages.config
+++ b/Reflection_Engine/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="CompareNETObjects" version="4.65.0" targetFramework="net452" />
   <package id="Humanizer.Core" version="2.2.0" targetFramework="net452" />
   <package id="ICSharpCode.Decompiler" version="3.1.0.3652" targetFramework="net452" />
   <package id="Mono.Cecil" version="0.10.0" targetFramework="net452" />


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1642 

See changelog


### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Serializer_Engine/Serialiser_Engine-Issue1642-SerialiserValidation.gh?csf=1&web=1&e=L7IzcC

This file eliminate types that might not be on your computer so you might have to tweak it to get to the same result. I'll List the things I have found already in #1620 .


### Changelog
- Added new method to generate a dummy object of a given type
- Added new method to test if two objects are equal (works for any type)
- Removed static classes from `BHoMTypeList`

### Additional comments
The `DummyObject` method certainly needs some refactoring. But it does the job for now.