### PR TITLE
Physical_Engine: Correct area for SolidVolume

### DIFF
--- a/Physical_Engine/Query/SolidVolume.cs
+++ b/Physical_Engine/Query/SolidVolume.cs
@@ -73,16 +73,9 @@ namespace BH.Engine.Physical
             if (surface.Offset != Offset.Centre && !surface.Location.IIsPlanar())
                 Reflection.Compute.RecordWarning("The SolidVolume for non-Planar ISurfaces with offsets other than Centre is approxamite at best");
 
-            // Temp, remove when Geometry_Engine implements IArea for PlanarSurface
-            if (!(surface.Location is PlanarSurface))
-            {
-                Engine.Reflection.Compute.RecordError("No area methods for non-PlanarSurface");
-                return 0;
-            }
-            PlanarSurface p = surface.Location as PlanarSurface;
-            double area = p.ExternalBoundary.IArea();
-            area -= p.InternalBoundaries.Sum(x => x.IArea());
-
+            double area = surface.Location.IArea();
+            area -= surface.Openings.Sum(x => x.Location.IArea());
+            
             return area * surface.Construction.IThickness();
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
Closes #1627 
Had a home-brewed area calculation (which was wrong as I missed the physical openings).
Exchanged for calculating it with the Geometry_Engine methods, adding the locations area and removing the openings ones.

### Test files
https://burohappold.sharepoint.com/:f:/s/BHoM/EuMPZj-GEMNKhjpnmGLko4UBUSEhwIdWfJzUUlfLMTf_ag?e=TypUUi

### Changelog

### Additional comments
<!-- As required -->