### PR TITLE
Structure_Engine: Add comparer for name or description for IProperty

### DIFF
--- a/Structure_Engine/Objects/EqualityComparers/NameOrDescriptionComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/NameOrDescriptionComparer.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using BH.oM.Structure;
+
+namespace BH.Engine.Structure
+{
+    public class NameOrDescriptionComparer : IEqualityComparer<IProperty>
+    {
+        /***************************************************/
+        /**** Constructors                              ****/
+        /***************************************************/
+
+        public NameOrDescriptionComparer()
+        {
+
+        }
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public bool Equals(IProperty prop1, IProperty prop2)
+        {
+            //Check whether the compared objects reference the same data.
+            if (Object.ReferenceEquals(prop1, prop2)) return true;
+
+            //Check whether any of the compared objects is null.
+            if (Object.ReferenceEquals(prop1, null) || Object.ReferenceEquals(prop2, null))
+                return false;
+
+            //Return true if name or description string for both objects are the same
+            return prop1.DescriptionOrName() == prop2.DescriptionOrName();
+        }
+
+        /***************************************************/
+
+        public int GetHashCode(IProperty prop)
+        {
+            //Check whether the object is null
+            if (Object.ReferenceEquals(prop, null)) return 0;
+
+            return prop.DescriptionOrName().GetHashCode();
+
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Structure_Engine/Objects/EqualityComparers/NameOrDescriptionComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/NameOrDescriptionComparer.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Structure
             if (Object.ReferenceEquals(prop1, prop2)) return true;
 
             //Check whether any of the compared objects is null.
-            if (Object.ReferenceEquals(prop1, null) || Object.ReferenceEquals(prop2, null))
+            if (prop1 == null || prop2 == null)
                 return false;
 
             //Return true if name or description string for both objects are the same

--- a/Structure_Engine/Query/Description.cs
+++ b/Structure_Engine/Query/Description.cs
@@ -355,11 +355,38 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Generates a default description for the BarRelease as 'StartReleaseNameOrDesc - EndReleaseNameOrDesc'.")]
-        [Input("release", "The Constraint6DOF to get a default description for.")]
-        [Output("desc", "The generated description for the constraint.")]
+        [Input("release", "The BarRelease to get a default description for.")]
+        [Output("desc", "The generated description for the BarRelease.")]
         public static string Description(this BarRelease release)
         {
             return release.StartRelease.DescriptionOrName() + " - " + release.EndRelease.DescriptionOrName();
+        }
+
+        /***************************************************/
+
+        [Description("Generates a default description for the LinkConstraint based on its fixities where x denoted fixed and f denotes free.")]
+        [Input("release", "The LinkConstraint to get a default description for.")]
+        [Output("desc", "The generated description for the LinkConstraint.")]
+        public static string Description(this LinkConstraint constraint)
+        {
+            string desc = constraint.XtoX ? "x" : "f";
+            desc += constraint.YtoY ? "x" : "f";
+            desc += constraint.ZtoZ ? "x" : "f";
+
+            desc += constraint.XXtoXX ? "x" : "f";
+            desc += constraint.YYtoYY ? "x" : "f";
+            desc += constraint.ZZtoZZ ? "x" : "f";
+
+            desc += constraint.XtoYY ? "x" : "f";
+            desc += constraint.XtoZZ ? "x" : "f";
+
+            desc += constraint.YtoXX ? "x" : "f";
+            desc += constraint.YtoZZ ? "x" : "f";
+
+            desc += constraint.ZtoXX ? "x" : "f";
+            desc += constraint.ZtoYY ? "x" : "f";
+
+            return desc;
         }
 
         /***************************************************/

--- a/Structure_Engine/Query/Description.cs
+++ b/Structure_Engine/Query/Description.cs
@@ -365,7 +365,7 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Generates a default description for the LinkConstraint based on its fixities where x denoted fixed and f denotes free.")]
-        [Input("release", "The LinkConstraint to get a default description for.")]
+        [Input("constraint", "The LinkConstraint to get a default description for.")]
         [Output("desc", "The generated description for the LinkConstraint.")]
         public static string Description(this LinkConstraint constraint)
         {

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Modify\AddReinforcement.cs" />
     <Compile Include="Modify\SetMaterial.cs" />
     <Compile Include="Modify\SetStructuralFragment.cs" />
+    <Compile Include="Objects\EqualityComparers\NameOrDescriptionComparer.cs" />
     <Compile Include="Query\AllEdgeCurves.cs" />
     <Compile Include="Query\CoordinateSystem.cs" />
     <Compile Include="Query\DescriptionOrName.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1398 

<!-- Add short description of what has been fixed -->

Adding a new comparer making use of the DescriptionOrName method, that first checks for the name, and if empty, uses the autogenerated description.

To be used across most structural adapters for Property type obejcts.

Also added missing description for LinkConstraint

### Test files
<!-- Link to test files to validate the proposed changes -->

See test case for method here https://github.com/BHoM/Robot_Toolkit/pull/353

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->