### PR TITLE
Structure_Engine: Create Section from TaperedProfile fix

### DIFF
--- a/Structure_Engine/Compute/Integrate.cs
+++ b/Structure_Engine/Compute/Integrate.cs
@@ -51,6 +51,41 @@ namespace BH.Engine.Structure
         {
             Dictionary<string, object> results = new Dictionary<string, object>();
 
+            if (curves.Count == 0)
+            {
+                #region assing zero to everything
+                results["Area"] = 0;
+
+                results["CentreZ"] = 0;
+                results["CentreY"] = 0;
+
+                results["TotalWidth"] = 0;
+                results["TotalDepth"] = 0;
+
+                results["Iy"] = 0;
+                results["Iz"] = 0;
+
+                results["Wply"] = 0;
+                results["Wplz"] = 0;
+
+                results["Rgy"] = 0;
+                results["Rgz"] = 0;
+
+                results["Vy"] = 0;
+                results["Vpy"] = 0;
+                results["Vz"] = 0;
+                results["Vpz"] = 0;
+
+                results["Welz"] = 0;
+                results["Wely"] = 0;
+
+                results["Asy"] = 0;
+                results["Asz"] = 0;
+
+                #endregion 
+                return results;
+            }
+
             BoundingBox box = Geometry.Query.Bounds(curves.Select(x => x.IBounds()).ToList());
 
             Point min = box.Min;

--- a/Structure_Engine/Compute/IntegrateSection.cs
+++ b/Structure_Engine/Compute/IntegrateSection.cs
@@ -48,6 +48,41 @@ namespace BH.Engine.Structure
         {
             Dictionary<string, double> results = new Dictionary<string, double>();
 
+            if (curves.Count == 0)
+            {
+                #region assing zero to everything
+                results["Area"] = 0;
+
+                results["CentreZ"] = 0;
+                results["CentreY"] = 0;
+
+                results["TotalWidth"] = 0;
+                results["TotalDepth"] = 0;
+
+                results["Iy"] = 0;
+                results["Iz"] = 0;
+
+                results["Wply"] = 0;
+                results["Wplz"] = 0;
+
+                results["Rgy"] = 0;
+                results["Rgz"] = 0;
+
+                results["Vy"] = 0;
+                results["Vpy"] = 0;
+                results["Vz"] = 0;
+                results["Vpz"] = 0;
+
+                results["Welz"] = 0;
+                results["Wely"] = 0;
+
+                results["Asy"] = 0;
+                results["Asz"] = 0;
+
+                #endregion 
+                return results;
+            }
+
             List<PolyCurve> curvesZ = Geometry.Compute.IJoin(curves);
 
             foreach (PolyCurve c in curvesZ)


### PR DESCRIPTION

### Issues addressed by this PR
Closes #1669 
The integration returned a hard error if no curves were provided, which made creating things like Tapered Sections impossible

So does now return zero for everything for zero curves

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/ESlszk2mhYVAga4AeAk4IFQB08YBzdVounGwriiWumASkw?e=6TdCb1

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->