### PR TITLE
Structure_Engine: Extension Methods for IElementM

### DIFF
--- a/Structure_Engine/Query/Area.cs
+++ b/Structure_Engine/Query/Area.cs
@@ -71,6 +71,16 @@ namespace BH.Engine.Structure
         }
 
         /***************************************************/
+
+        [Description("Calculates the area of a Surface based on the area of the geometrical surface stored in Extents.")]
+        [Input("mesh", "The Surface to calculate the area for.")]
+        [Output("area", "The area of the Surface.", typeof(Area))]
+        public static double Area(this Surface surface)
+        {
+            return surface.Extents.IArea();
+        }
+
+        /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 

--- a/Structure_Engine/Query/Area.cs
+++ b/Structure_Engine/Query/Area.cs
@@ -73,7 +73,7 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Calculates the area of a Surface based on the area of the geometrical surface stored in Extents.")]
-        [Input("mesh", "The Surface to calculate the area for.")]
+        [Input("surface", "The Surface to calculate the area for.")]
         [Output("area", "The area of the Surface.", typeof(Area))]
         public static double Area(this Surface surface)
         {

--- a/Structure_Engine/Query/AverageThickness.cs
+++ b/Structure_Engine/Query/AverageThickness.cs
@@ -39,6 +39,9 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Gets the average thickness of the property as if it was applied to an infinite plane.")]
+        [Input("property", "The property to evaluate the average thickness of.")]
+        [Output("averageThickness", "the average thickness of the property as if it was applied to an infinite plane.", typeof(Length))]
         public static double AverageThickness(ConstantThickness property)
         {
             return property.Thickness;
@@ -46,6 +49,9 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Gets the average thickness of the property as if it was applied to an infinite plane.")]
+        [Input("property", "The property to evaluate the average thickness of.")]
+        [Output("averageThickness", "the average thickness of the property as if it was applied to an infinite plane.", typeof(Length))]
         public static double AverageThickness(Ribbed property)
         {
             if (property.StemWidth == 0 || property.Spacing < property.StemWidth ||
@@ -60,6 +66,9 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Gets the average thickness of the property as if it was applied to an infinite plane.")]
+        [Input("property", "The property to evaluate the average thickness of.")]
+        [Output("averageThickness", "the average thickness of the property as if it was applied to an infinite plane.", typeof(Length))]
         public static double AverageThickness(Waffle property)
         {
             if (property.StemWidthX == 0 || property.SpacingX < property.StemWidthX ||
@@ -81,6 +90,9 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Gets the average thickness of the property as if it was applied to an infinite plane.")]
+        [Input("property", "The property to evaluate the average thickness of.")]
+        [Output("averageThickness", "the average thickness of the property as if it was applied to an infinite plane.", typeof(Length))]
         public static double AverageThickness(LoadingPanelProperty property)
         {
             Reflection.Compute.RecordWarning("Structural IAreaElements are defined without volume.");
@@ -92,6 +104,9 @@ namespace BH.Engine.Structure
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
         
+        [Description("Gets the average thickness of the property as if it was applied to an infinite plane.")]
+        [Input("property", "The property to evaluate the average thickness of.")]
+        [Output("averageThickness", "the average thickness of the property as if it was applied to an infinite plane.", typeof(Length))]
         public static double IAverageThickness(this ISurfaceProperty property)
         {
             return AverageThickness(property as dynamic);

--- a/Structure_Engine/Query/AverageThickness.cs
+++ b/Structure_Engine/Query/AverageThickness.cs
@@ -1,0 +1,116 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.oM.Geometry;
+using BH.oM.Structure.Elements;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Quantities.Attributes;
+using System.ComponentModel;
+using BH.oM.Structure.SurfaceProperties;
+using System;
+
+namespace BH.Engine.Structure
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static double AverageThickness(ConstantThickness property)
+        {
+            return property.Thickness;
+        }
+
+        /***************************************************/
+
+        public static double AverageThickness(Ribbed property)
+        {
+            if (property.StemWidth == 0 || property.Spacing < property.StemWidth ||
+                property.TotalDepth < property.Thickness)
+            {
+                Reflection.Compute.RecordError("Invalid Ribbed slab, returning null.");
+                return double.NaN;
+            }
+            double avrageThicknessLower = (property.TotalDepth - property.Thickness) * (property.StemWidth / property.Spacing);
+            return property.Thickness + avrageThicknessLower;
+        }
+
+        /***************************************************/
+
+        public static double AverageThickness(Waffle property)
+        {
+            if (property.StemWidthX == 0 || property.SpacingX < property.StemWidthX ||
+                property.StemWidthY == 0 || property.SpacingY < property.StemWidthY ||
+                property.TotalDepthX < property.Thickness || property.TotalDepthY < property.Thickness)
+            {
+                Reflection.Compute.RecordError("Invalid Waffle slab, returning null.");
+                return double.NaN;
+            }
+
+            double avrageThicknessLowerX = (property.TotalDepthX - property.Thickness) * (property.StemWidthX / property.SpacingX);
+            double avrageThicknessLowerY = (property.TotalDepthY - property.Thickness) * (property.StemWidthY / property.SpacingY);
+
+            double theExtraVolume = Math.Min(property.TotalDepthX - property.Thickness, property.TotalDepthY - property.Thickness) *
+                                    (property.StemWidthX * property.StemWidthY) / (property.SpacingX * property.SpacingY);
+
+            return property.Thickness + avrageThicknessLowerX + avrageThicknessLowerY - theExtraVolume;
+        }
+
+        /***************************************************/
+
+        public static double AverageThickness(LoadingPanelProperty property)
+        {
+            Reflection.Compute.RecordWarning("Structural IAreaElements are defined without volume.");
+            return 0;
+        }
+        
+
+        /***************************************************/
+        /**** Public Methods - Interfaces               ****/
+        /***************************************************/
+        
+        public static double IAverageThickness(this ISurfaceProperty property)
+        {
+            return AverageThickness(property as dynamic);
+        }
+
+
+        /***************************************************/
+        /**** Private Methods - Fallbacks               ****/
+        /***************************************************/
+
+        private static double AverageThickness(this ISurfaceProperty property)
+        {
+            Reflection.Compute.RecordError(property.GetType().Name + " does not have an implementation for AverageThickness. Returning NaN.");
+            return double.NaN;
+        }
+
+        /***************************************************/
+
+    }
+
+}
+

--- a/Structure_Engine/Query/MaterialComposition.cs
+++ b/Structure_Engine/Query/MaterialComposition.cs
@@ -51,7 +51,24 @@ namespace BH.Engine.Structure
             Material mat = Physical.Create.Material(bar.SectionProperty.Material);
             return (MaterialComposition)mat;
         }
-        
+
         /***************************************************/
+
+        [Description("Returns a areaElement's homogeneous MaterialComposition.")]
+        [Input("areaElement", "The areaElement to material from")]
+        [Output("materialComposition", "The kind of matter the areaElement is composed of.")]
+        public static MaterialComposition MaterialComposition(this IAreaElement areaElement)
+        {   
+                if (areaElement.Property == null || areaElement.Property.Material == null)
+            {
+                Engine.Reflection.Compute.RecordError("The areaElements MaterialComposition could not be calculated as no Material has been assigned.");
+                return null;
+            }
+            Material mat = Physical.Create.Material(areaElement.Property.Material);
+            return (MaterialComposition)mat;
+        }
+
+        /***************************************************/
+        
     }
 }

--- a/Structure_Engine/Query/SolidVolume.cs
+++ b/Structure_Engine/Query/SolidVolume.cs
@@ -29,6 +29,7 @@ using BH.oM.Structure.Elements;
 using System.Collections.Generic;
 using System;
 using BH.oM.Physical.Materials;
+using BH.oM.Structure.SurfaceProperties;
 
 namespace BH.Engine.Structure
 {
@@ -50,7 +51,27 @@ namespace BH.Engine.Structure
             }
             return bar.SectionProperty.Area * bar.Length();
         }
-        
+
         /***************************************************/
+
+        [Description("Returns a IAreaElement's solid volume based on its Surface Property and the Area.")]
+        [Input("areaElement", "The IAreaElement to get the volume from")]
+        [Output("volume", "The IAreaElement solid material volume.", typeof(Volume))]
+        public static double SolidVolume(this IAreaElement areaElement)
+        {
+            if (areaElement.Property == null)
+            {
+                Engine.Reflection.Compute.RecordError("The IAreaElements Solid Volume could not be calculated as no surface property has been assigned. Returning zero volume.");
+                return 0;
+            }
+
+            double area = areaElement.IArea();
+            double thickness = areaElement.Property.IAverageThickness();
+
+            return area * thickness;
+        }
+
+        /***************************************************/
+
     }
 }

--- a/Structure_Engine/Query/SolidVolume.cs
+++ b/Structure_Engine/Query/SolidVolume.cs
@@ -54,7 +54,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Returns a IAreaElement's solid volume based on its Surface Property and the Area.")]
+        [Description("Returns a IAreaElement's solid volume as the area of the element times the average thickness of its SurfaceProperty. The average thickness is evaluated as if it was applied to an infinite plane.")]
         [Input("areaElement", "The IAreaElement to get the volume from")]
         [Output("volume", "The IAreaElement solid material volume.", typeof(Volume))]
         public static double SolidVolume(this IAreaElement areaElement)

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Modify\SetStructuralFragment.cs" />
     <Compile Include="Objects\EqualityComparers\NameOrDescriptionComparer.cs" />
     <Compile Include="Query\AllEdgeCurves.cs" />
+    <Compile Include="Query\AverageThickness.cs" />
     <Compile Include="Query\CoordinateSystem.cs" />
     <Compile Include="Query\DescriptionOrName.cs" />
     <Compile Include="Query\Description.cs" />


### PR DESCRIPTION

### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/814
   
### Issues addressed by this PR

Closes https://github.com/BHoM/BHoM/issues/809
Adds `SolidVolume()` and `MaterialComposition()` for `IAreaElements`
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EihNne-QqplJjKE8p_V7pqAB0hbwPNDVLGRzbVR-Y59d8g?e=50JAKv

### Changelog

- Added `SolidVolume()` for `IAreaElement`
- Added `MaterialComposition()` for `IAreaElement`
- Added `AverageThickness()` for `ISurfaceProperty`
- Support for `Surface` in Structure_Engine's `Area()` method

### Additional comments
<!-- As required -->