### PR TITLE
Geometry_Engine: Add RoundCoordinates

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Modify\CollapseToPolyline.cs" />
     <Compile Include="Modify\RemoveLeastSignificantVertices.cs" />
     <Compile Include="Modify\RemoveShortSegments.cs" />
+    <Compile Include="Modify\RoundCoordinates.cs" />
     <Compile Include="Modify\RoundPoint.cs" />
     <Compile Include="Modify\SetGeometry.cs" />
     <Compile Include="Modify\Simplify.cs" />

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Geometry
         /**** Interface Methods                         ****/
         /***************************************************/
 
-        [Description("Modifies a BHoM IGeometry's Points' coordinates to be rounded to the number of provided decimal places.")]
+        [Description("Modifies a BHoM IGeometry's coordinates to be rounded to the number of provided decimal places.")]
         [Input("geometry", "The BHoM IGeometry to modify.")]
         [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
         [Output("geometry", "The modified BHoM IGeometry.")]
@@ -47,7 +47,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [Description("Modifies a BHoM ICurve's Points coordinates to be rounded to the number of provided decimal places.")]
+        [Description("Modifies a BHoM ICurve's coordinates to be rounded to the number of provided decimal places.")]
         [Input("curve", "The BHoM ICurve to modify.")]
         [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
         [Output("curve", "The modified BHoM ICurve.")]
@@ -77,7 +77,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [Description("Modifies a BHoM Geometry Line's end points to be rounded to the number of provided decimal places.")]
+        [Description("Modifies a BHoM Geometry Line's points to be rounded to the number of provided decimal places.")]
         [Input("line", "The BHoM Geometry Line to modify.")]
         [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
         [Output("line", "The modified BHoM Geometry Line.")]
@@ -92,7 +92,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [Description("Modifies a BHoM Geometry Arc's end points to be rounded to the number of provided decimal places.")]
+        [Description("Modifies a BHoM Geometry Arc's start and end coordinates to be rounded to the number of provided decimal places.")]
         [Input("arc", "The BHoM Geometry Arc to modify.")]
         [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
         [Output("curve", "The modified BHoM Geometry Arc. As Line if zero length.")]

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -77,6 +77,37 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [Description("Modifies a BHoM Geometry Vector to be rounded to the number of provided decimal places.")]
+        [Input("vector", "The BHoM Geometry Vector to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("vector", "The modified BHoM Geometry Vector.")]
+        public static Vector RoundCoordinates(this Vector vector, int decimalPlaces = 6)
+        {
+            return new Vector
+            {
+                X = Math.Round(vector.X, decimalPlaces),
+                Y = Math.Round(vector.Y, decimalPlaces),
+                Z = Math.Round(vector.Z, decimalPlaces),
+            };
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry Plane's Origin and Normal to be rounded to the number of provided decimal places.")]
+        [Input("plane", "The BHoM Geometry Plane to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("plane", "The modified BHoM Geometry Plane.")]
+        public static Plane RoundCoordinates(this Plane plane, int decimalPlaces = 6)
+        {
+            return new Plane()
+            {
+                Origin = plane.Origin.RoundCoordinates(decimalPlaces),
+                Normal = plane.Normal.RoundCoordinates(decimalPlaces),
+            };
+        }
+
+        /***************************************************/
+
         [Description("Modifies a BHoM Geometry Line's points to be rounded to the number of provided decimal places.")]
         [Input("line", "The BHoM Geometry Line to modify.")]
         [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -297,10 +297,11 @@ namespace BH.Engine.Geometry
                 Math.Abs(Math.Abs(normal.Y) - 1) < Tolerance.Angle ||
                 Math.Abs(Math.Abs(normal.Z) - 1) < Tolerance.Angle)
             {
-                ICurve externalBoundery = planarSurface.ExternalBoundary.IRoundCoordinates(decimalPlaces);
-                List<ICurve> internalBounderies = planarSurface.InternalBoundaries.Select(x => x.IRoundCoordinates(decimalPlaces)).ToList();
+                Plane plane = new Plane() { Origin = planarSurface.ExternalBoundary.IStartPoint().RoundCoordinates(decimalPlaces), Normal = normal.RoundCoordinates(0) };
+                ICurve externalBoundary = planarSurface.ExternalBoundary.IProject(plane).IRoundCoordinates(decimalPlaces);
+                List<ICurve> internalBoundaries = planarSurface.InternalBoundaries.Select(x => x.IProject(plane).IRoundCoordinates(decimalPlaces)).ToList();
 
-                return Create.PlanarSurface(externalBoundery, internalBounderies);
+                return Create.PlanarSurface(externalBoundary, internalBoundaries);
             }
 
             Reflection.Compute.RecordWarning("Rounding the coordinates of a non-Axis-aligned planar surface while maintaining planarity needs to be done manually. No action has been taken.");

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -286,7 +286,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Modifies a BHoM Geometry PlanarSurface's defining curves to be rounded to the number of provided decimal places.")]
-        [Input("nurbscurve", "The BHoM Geometry PlanarSurface to modify.")]
+        [Input("planarSurface", "The BHoM Geometry PlanarSurface to modify.")]
         [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
         [Output("surface", "The modified BHoM Geometry PlanarSurface.")]
         public static PlanarSurface RoundCoordinates(this PlanarSurface planarSurface, int decimalPlaces = 6)

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -153,25 +153,26 @@ namespace BH.Engine.Geometry
             //      Consider a equal legged triangle with endpoints at the arc's endpoints
             //      we know the "top" angle and the "base" length and are solving for the last two sides length
             double radius = Math.Sqrt(
-                Math.Pow(dist / (2 * Math.Tan(angle / 2)), 2) + // "Heigth"
+                Math.Pow(dist / (2 * Math.Tan(angle / 2)), 2) + // "Height"
                 Math.Pow(dist / 2, 2)   // "half the base"
                 );
 
-            //double radius = arc.Radius;
-            
             Circle startCircle = new Circle() { Normal = normal, Centre = start, Radius = radius };
             Circle endCircle = new Circle() { Normal = normal, Centre = end, Radius = radius };
 
             List<Point> intersections = startCircle.CurveIntersections(endCircle).OrderBy(x => x.SquareDistance(arc.CoordinateSystem.Origin)).ToList();
 
             Point newOrigin = null;
+
             // 180degrees arc where the points got rounded away from eachother
             if (intersections.Count == 0)
             {
                 newOrigin = (start + end) / 2;
                 radius = newOrigin.Distance(start);
-            } else
+            }
+            else
             {
+                // Ensure that the new centre is at the same side of the start/end points
                 Vector unitNormal = normal.Normalise();
                 foreach (Point pt in intersections)
                 {
@@ -185,7 +186,6 @@ namespace BH.Engine.Geometry
             }
             
             Vector newX = (start - newOrigin).Normalise();
-
             oM.Geometry.CoordinateSystem.Cartesian coordClone = Create.CartesianCoordinateSystem(newOrigin, newX, Query.CrossProduct(normal, newX));
 
             double endAngle = (start - newOrigin).Angle(end - newOrigin);

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -304,7 +304,7 @@ namespace BH.Engine.Geometry
                 return Create.PlanarSurface(externalBoundary, internalBoundaries);
             }
 
-            Reflection.Compute.RecordWarning("Rounding the coordinates of a non-Axis-aligned planar surface while maintaining planarity needs to be done manually. No action has been taken.");
+            Reflection.Compute.RecordWarning("Rounding the coordinates of a planar surface that is not aligned with the global coordinate system cannot be achieved without risk of losing planarity. No action has been taken.");
             return planarSurface;
         }
 

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -1,0 +1,215 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Base;
+using BH.oM.Geometry;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Interface Methods                         ****/
+        /***************************************************/
+
+        [Description("Modifies a BHoM IGeometry's Points' coordinates to be rounded to the number of provided decimal places.")]
+        [Input("geometry", "The BHoM IGeometry to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("geometry", "The modified BHoM IGeometry.")]
+        public static IGeometry IRoundCoordinates(this IGeometry geometry, int decimalPlaces = 6)
+        {
+            return RoundCoordinates(geometry as dynamic, decimalPlaces);
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM ICurve's Points coordinates to be rounded to the number of provided decimal places.")]
+        [Input("curve", "The BHoM ICurve to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("curve", "The modified BHoM ICurve.")]
+        public static ICurve IRoundCoordinates(this ICurve curve, int decimalPlaces = 6)
+        {
+            return RoundCoordinates(curve as dynamic, decimalPlaces);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry Point to be rounded to the number of provided decimal places.")]
+        [Input("point", "The BHoM Geometry Point to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("point", "The modified BHoM Geometry Point.")]
+        public static Point RoundCoordinates(this Point point, int decimalPlaces = 6)
+        {
+            return new Point
+            {
+                X = Math.Round(point.X, decimalPlaces),
+                Y = Math.Round(point.Y, decimalPlaces),
+                Z = Math.Round(point.Z, decimalPlaces),
+            };
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry Line's end points to be rounded to the number of provided decimal places.")]
+        [Input("line", "The BHoM Geometry Line to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("line", "The modified BHoM Geometry Line.")]
+        public static Line RoundCoordinates(this Line line, int decimalPlaces = 6)
+        {
+            return new Line()
+            {
+                Start = line.Start.RoundCoordinates(decimalPlaces),
+                End = line.End.RoundCoordinates(decimalPlaces)
+            };
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry Arc's end points to be rounded to the number of provided decimal places.")]
+        [Input("arc", "The BHoM Geometry Arc to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("curve", "The modified BHoM Geometry Arc. As Line if zero length.")]
+        public static ICurve RoundCoordinates(this Arc arc, int decimalPlaces = 6)
+        {
+            Point start = arc.StartPoint().RoundCoordinates(decimalPlaces);
+            Point end = arc.EndPoint().RoundCoordinates(decimalPlaces);
+            if (start.SquareDistance(end) == 0)
+                return new Line() { Start = start, End = end };
+
+            // ---Set start point---
+            Arc c = arc.Translate(start - arc.StartPoint());
+
+            // ---Set end point---
+            // Orient towards target (rotate)
+            Point pivot = start;
+            Point from = c.EndPoint();
+            Vector current = from - pivot;
+            Vector next = end - pivot;
+            Vector axis = current.CrossProduct(next);
+            c = c.Rotate(pivot, axis, current.SignedAngle(next, axis));
+
+            // scale to attatch to target
+            double factor = Math.Sqrt(pivot.SquareDistance(end) / pivot.SquareDistance(from));
+            Vector scaleVector = new Vector() { X = factor, Y = factor, Z = factor };
+            return c.Scale(pivot, scaleVector);
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry Circle's centre and radius to be rounded to the number of provided decimal places.")]
+        [Input("circle", "The BHoM Geometry Circle to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("curve", "The modified BHoM Geometry Circle. As Line if zero length.")]
+        public static Circle RoundCoordinates(this Circle circle, int decimalPlaces = 6)
+        {
+            return new Circle()
+            {
+                Centre = circle.Centre.RoundCoordinates(decimalPlaces),
+                Radius = Math.Round(circle.Radius, decimalPlaces),
+                Normal = circle.Normal,
+            };
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry Ellipse's centre and radius to be rounded to the number of provided decimal places.")]
+        [Input("ellipse", "The BHoM Geometry Ellipse to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("curve", "The modified BHoM Geometry Ellipse. As Line if zero length.")]
+        public static Ellipse RoundCoordinates(this Ellipse ellipse, int decimalPlaces = 6)
+        {
+            return new Ellipse()
+            {
+                Centre = ellipse.Centre.RoundCoordinates(decimalPlaces),
+                Radius1 = Math.Round(ellipse.Radius1, decimalPlaces),
+                Radius2 = Math.Round(ellipse.Radius2, decimalPlaces),
+                Axis1 = ellipse.Axis1,
+                Axis2 = ellipse.Axis2
+            };
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry Polyline's control points to be rounded to the number of provided decimal places.")]
+        [Input("polyline", "The BHoM Geometry Polyline to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("curve", "The modified BHoM Geometry Polyline.")]
+        public static Polyline RoundCoordinates(this Polyline polyline, int decimalPlaces = 6)
+        {
+            return new Polyline()
+            {
+                ControlPoints = polyline.ControlPoints.Select(x => x.RoundCoordinates(decimalPlaces)).ToList()
+            };
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry PolyCurve's curves to be rounded to the number of provided decimal places.")]
+        [Input("polycurve", "The BHoM Geometry PolyCurve to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("curve", "The modified BHoM Geometry PolyCurve.")]
+        public static PolyCurve RoundCoordinates(this PolyCurve polycurve, int decimalPlaces = 6)
+        {
+            return new PolyCurve()
+            {
+                Curves = polycurve.Curves.Select(x => x.IRoundCoordinates(decimalPlaces)).ToList()
+            };
+        }
+
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry NurbsCurve's control points to be rounded to the number of provided decimal places.")]
+        [Input("nurbscurve", "The BHoM Geometry NurbsCurve to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("curve", "The modified BHoM Geometry NurbsCurve.")]
+        public static NurbsCurve RoundCoordinates(this NurbsCurve nurbscurve, int decimalPlaces = 6)
+        {
+            return new NurbsCurve()
+            {
+                ControlPoints = nurbscurve.ControlPoints.Select(x => x.RoundCoordinates(decimalPlaces)).ToList(),
+                Knots = nurbscurve.Knots.ToList(),
+                Weights = nurbscurve.Weights.ToList()
+            };
+        }
+
+
+        /***************************************************/
+        /**** Private Fallback Methods                  ****/
+        /***************************************************/
+
+        private static IGeometry RoundCoordinates(this IGeometry geometry, int decimalPlaces = 6)
+        {
+            throw new NotImplementedException("IGeometry of type: " + geometry.GetType().Name + " is not implemented for RoundCoordinates.");
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -293,9 +293,9 @@ namespace BH.Engine.Geometry
         {
             Vector normal = planarSurface.Normal().Normalise();
 
-            if (Math.Abs(Math.Abs(normal.X) - 1) < Tolerance.Distance ||
-                Math.Abs(Math.Abs(normal.Y) - 1) < Tolerance.Distance ||
-                Math.Abs(Math.Abs(normal.Z) - 1) < Tolerance.Distance)
+            if (Math.Abs(Math.Abs(normal.X) - 1) < Tolerance.Angle ||
+                Math.Abs(Math.Abs(normal.Y) - 1) < Tolerance.Angle ||
+                Math.Abs(Math.Abs(normal.Z) - 1) < Tolerance.Angle)
             {
                 ICurve externalBoundery = planarSurface.ExternalBoundary.IRoundCoordinates(decimalPlaces);
                 List<ICurve> internalBounderies = planarSurface.InternalBoundaries.Select(x => x.IRoundCoordinates(decimalPlaces)).ToList();

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -287,10 +287,20 @@ namespace BH.Engine.Geometry
         [Output("surface", "The modified BHoM Geometry PlanarSurface.")]
         public static PlanarSurface RoundCoordinates(this PlanarSurface planarSurface, int decimalPlaces = 6)
         {
-            ICurve externalBoundery = planarSurface.ExternalBoundary.IRoundCoordinates(decimalPlaces);
-            List<ICurve> internalBounderies = planarSurface.InternalBoundaries.Select(x => x.IRoundCoordinates(decimalPlaces)).ToList();
+            Vector normal = planarSurface.Normal().Normalise();
 
-            return Create.PlanarSurface(externalBoundery, internalBounderies);
+            if (Math.Abs(Math.Abs(normal.X) - 1) < Tolerance.Distance ||
+                Math.Abs(Math.Abs(normal.Y) - 1) < Tolerance.Distance ||
+                Math.Abs(Math.Abs(normal.Z) - 1) < Tolerance.Distance)
+            {
+                ICurve externalBoundery = planarSurface.ExternalBoundary.IRoundCoordinates(decimalPlaces);
+                List<ICurve> internalBounderies = planarSurface.InternalBoundaries.Select(x => x.IRoundCoordinates(decimalPlaces)).ToList();
+
+                return Create.PlanarSurface(externalBoundery, internalBounderies);
+            }
+
+            Reflection.Compute.RecordWarning("Rounding the coordinates of a non-Axis-aligned planar surface while maintaining planarity needs to be done manually. No action has been taken.");
+            return planarSurface;
         }
 
 

--- a/Geometry_Engine/Modify/RoundCoordinates.cs
+++ b/Geometry_Engine/Modify/RoundCoordinates.cs
@@ -199,6 +199,20 @@ namespace BH.Engine.Geometry
             };
         }
 
+        /***************************************************/
+
+        [Description("Modifies a BHoM Geometry PlanarSurface's defining curves to be rounded to the number of provided decimal places.")]
+        [Input("nurbscurve", "The BHoM Geometry PlanarSurface to modify.")]
+        [Input("decimalPlaces", "The number of decimal places to round to, default 6.")]
+        [Output("surface", "The modified BHoM Geometry PlanarSurface.")]
+        public static PlanarSurface RoundCoordinates(this PlanarSurface planarSurface, int decimalPlaces = 6)
+        {
+            ICurve externalBoundery = planarSurface.ExternalBoundary.IRoundCoordinates(decimalPlaces);
+            List<ICurve> internalBounderies = planarSurface.InternalBoundaries.Select(x => x.IRoundCoordinates(decimalPlaces)).ToList();
+
+            return Create.PlanarSurface(externalBoundery, internalBounderies);
+        }
+
 
         /***************************************************/
         /**** Private Fallback Methods                  ****/

--- a/Geometry_Engine/Modify/RoundPoint.cs
+++ b/Geometry_Engine/Modify/RoundPoint.cs
@@ -34,18 +34,14 @@ namespace BH.Engine.Geometry
 {
     public static partial class Modify
     {
+        [Deprecated("3.2", "Renamed to RoundCoordinates and expanded for other Geometry", null, "BH.Engine.Geometry.Modify.RoundCoordinates")]
         [Description("Modifies a BHoM Geometry Point to be rounded to the number of provided decimal places")]
         [Input("point", "The BHoM Geometry Point to modify")]
         [Input("decimalPlaces", "The number of decimal places to round to, default 6")]
         [Output("point", "The modified BHoM Geometry Point")]
         public static Point RoundPoint(this Point point, int decimalPlaces = 6)
         {
-            return new Point
-            {
-                X = Math.Round(point.X, decimalPlaces),
-                Y = Math.Round(point.Y, decimalPlaces),
-                Z = Math.Round(point.Z, decimalPlaces),
-            };
+            return RoundCoordinates(point, decimalPlaces);
         }
     }
 }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1675 
Adds `RoundCoordinates` which rounds the coordinates of a `IGeometry`, currently supports `ICurves`
<!-- Add short description of what has been fixed -->
#1676 will be addressed once Spatial_Engine clears up

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EeDbV5uQCIFEgOxEzGM3FuUBey_qVsrbuNa4JPjrtGpV0g?e=KPhnSe

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Deprecates `RoundPoint`

### Additional comments
<!-- As required -->