### PR TITLE
Structure_Engine: Adding comparers for Contraints4DOF and 6DOF from Robot_Toolkit

### DIFF
--- a/Structure_Engine/Objects/EqualityComparers/Constraint4DOFComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/Constraint4DOFComparer.cs
@@ -1,0 +1,77 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using BH.oM.Structure.Constraints;
+using System.Collections.Generic;
+using System;
+
+namespace BH.Engine.Structure
+{
+    public class Constraint4DOFComparer : IEqualityComparer<Constraint4DOF>
+    {
+        /***************************************************/
+        /****           Public Methods                  ****/
+        /***************************************************/
+
+        public bool Equals(Constraint4DOF linearRelease1, Constraint4DOF linearRelease2)
+        {
+            //Check whether the compared objects reference the same data.
+            if (Object.ReferenceEquals(linearRelease1, linearRelease2))
+                return true;
+
+            //Check whether any of the compared objects is null.
+            if (Object.ReferenceEquals(linearRelease1, null) || Object.ReferenceEquals(linearRelease2, null))
+                return false;
+
+            //Check if the GUIDs are the same
+            if (linearRelease1.BHoM_Guid == linearRelease2.BHoM_Guid)
+                return true;
+
+            if (linearRelease1.Name == linearRelease2.Name &&
+                linearRelease1.TranslationX == linearRelease2.TranslationX &&
+                linearRelease1.TranslationY == linearRelease2.TranslationY &&
+                linearRelease1.TranslationZ == linearRelease2.TranslationZ &&
+                linearRelease1.RotationX == linearRelease2.RotationX &&
+                linearRelease1.TranslationalStiffnessX == linearRelease2.TranslationalStiffnessX &&
+                linearRelease1.TranslationalStiffnessY == linearRelease2.TranslationalStiffnessY &&
+                linearRelease1.TranslationalStiffnessZ == linearRelease2.TranslationalStiffnessZ &&
+                linearRelease1.RotationalStiffnessX == linearRelease2.RotationalStiffnessX)
+                return true;
+
+            return false;
+        }
+
+        /***************************************************/
+
+        public int GetHashCode(Constraint4DOF obj)
+        {
+            //Check whether the object is null
+            if (Object.ReferenceEquals(obj, null)) return 0;
+
+            return obj.Name == null ? 0 : obj.Name.GetHashCode();
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Structure_Engine/Objects/EqualityComparers/Constraint6DOFComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/Constraint6DOFComparer.cs
@@ -1,0 +1,80 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using BH.oM.Structure.Constraints;
+using System.Collections.Generic;
+using System;
+
+namespace BH.Engine.Structure
+{
+    public class Constraint6DOFComparer : IEqualityComparer<Constraint6DOF>
+    {
+        /***************************************************/
+        /****           Public Methods                  ****/
+        /***************************************************/
+
+        public bool Equals(Constraint6DOF support1, Constraint6DOF support2)
+        {
+            //Check whether the compared objects reference the same data.
+            if (Object.ReferenceEquals(support1, support2))
+                return true;
+
+            //Check whether any of the compared objects is null.
+            if (Object.ReferenceEquals(support1, null) || Object.ReferenceEquals(support2, null))
+                return false;
+
+            //Check if the GUIDs are the same
+            if (support1.BHoM_Guid == support2.BHoM_Guid)
+                return true;
+
+            if (support1.Name == support2.Name &&
+                support1.TranslationX == support2.TranslationX &&
+                support1.TranslationY == support2.TranslationY &&
+                support1.TranslationZ == support2.TranslationZ &&
+                support1.RotationX == support2.RotationX &&
+                support1.RotationY == support2.RotationY &&
+                support1.RotationZ == support2.RotationZ &&
+                support1.TranslationalStiffnessX == support2.TranslationalStiffnessX &&
+                support1.TranslationalStiffnessY == support2.TranslationalStiffnessY &&
+                support1.TranslationalStiffnessZ == support2.TranslationalStiffnessZ &&
+                support1.RotationalStiffnessX == support2.RotationalStiffnessX &&
+                support1.RotationalStiffnessY == support2.RotationalStiffnessY &&
+                support1.RotationalStiffnessZ == support2.RotationalStiffnessZ)
+                return true;
+            return false;
+        }
+
+        /***************************************************/
+
+        public int GetHashCode(Constraint6DOF obj)
+        {
+            //Check whether the object is null
+            if (Object.ReferenceEquals(obj, null)) return 0;
+
+            return obj.Name == null ? 0 : obj.Name.GetHashCode();
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -121,6 +121,8 @@
     <Compile Include="Modify\AddReinforcement.cs" />
     <Compile Include="Modify\SetMaterial.cs" />
     <Compile Include="Modify\SetStructuralFragment.cs" />
+    <Compile Include="Objects\EqualityComparers\Constraint4DOFComparer.cs" />
+    <Compile Include="Objects\EqualityComparers\Constraint6DOFComparer.cs" />
     <Compile Include="Objects\EqualityComparers\NameOrDescriptionComparer.cs" />
     <Compile Include="Query\AllEdgeCurves.cs" />
     <Compile Include="Query\AverageThickness.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1688

<!-- Add short description of what has been fixed -->

Migrating full comparers for Constraint4DOF and Constraint6DOF from Robot_Toolkit to Structure_Engine

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->