### PR TITLE
Serialiser_Engine: Fix issue of failing to deserialise methods if multiple engine method matches are found

### DIFF
--- a/Reflection_Engine/Create/Type.cs
+++ b/Reflection_Engine/Create/Type.cs
@@ -92,11 +92,17 @@ namespace BH.Engine.Reflection
 
         /***************************************************/
 
-        public static List<Type> AllEngineTypes(string name)
+        public static List<Type> AllTypes(string name)
         {
-            List<Type> methodTypeList = Query.EngineTypeList();
+            List<Type> typeList = new List<Type>();
+            if (name.StartsWith("BH.Engine"))
+                typeList = Query.EngineTypeList();
+            else if (name.StartsWith("BH.Adapter"))
+                typeList = Query.AdapterTypeList();
+            else if (name.StartsWith("BH.oM"))
+                typeList = Query.BHoMTypeList();
 
-            List<Type> types = methodTypeList.Where(x => x.AssemblyQualifiedName.StartsWith(name)).ToList();
+            List<Type> types = typeList.Where(x => x.AssemblyQualifiedName.StartsWith(name)).ToList();
 
             if (types.Count != 0)
                 return types;

--- a/Reflection_Engine/Create/Type.cs
+++ b/Reflection_Engine/Create/Type.cs
@@ -80,11 +80,36 @@ namespace BH.Engine.Reflection
                         foreach (Type t in types)
                             message += "- " + t.FullName + "\n";
 
+                        message += "To get a Engine type from a specific Assembly, try adding ', NameOfTheAssmebly' at the end of the name string, or use the AllEngineTypes method to retreive all the types.";
+
                         Compute.RecordError(message);
                     }
                     return null;
                 }
                 return type;
+            }
+        }
+
+        /***************************************************/
+
+        public static List<Type> AllEngineTypes(string name)
+        {
+            List<Type> methodTypeList = Query.EngineTypeList();
+
+            List<Type> types = methodTypeList.Where(x => x.AssemblyQualifiedName.StartsWith(name)).ToList();
+
+            if (types.Count != 0)
+                return types;
+            else
+            {
+                //Unique method not found in list, check if it can be extracted using the system Type
+                Type type = System.Type.GetType(name);
+                if (type == null)
+                {
+                    Compute.RecordError($"A type corresponding to {name} cannot be found.");
+                    return new List<Type>();
+                }
+                return new List<Type> { type };
             }
         }
 

--- a/Reflection_Engine/Create/Type.cs
+++ b/Reflection_Engine/Create/Type.cs
@@ -102,7 +102,7 @@ namespace BH.Engine.Reflection
                 return types;
             else
             {
-                //Unique method not found in list, check if it can be extracted using the system Type
+                //No method found in dictionary, try System.Type
                 Type type = System.Type.GetType(name);
                 if (type == null)
                 {

--- a/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
@@ -106,7 +106,7 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 if (BsonDocument.TryParse(typeName, out typeDocument) && typeDocument.Contains("Name"))
                 {
                     typeName = typeDocument["Name"].AsString;
-                    foreach (Type type in Reflection.Create.AllEngineTypes(typeName))
+                    foreach (Type type in Reflection.Create.AllTypes(typeName))
                     {
                         method = Create.MethodBase(type, methodName, types); // type overload
                         if (method != null)

--- a/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
@@ -100,8 +100,16 @@ namespace BH.Engine.Serialiser.BsonSerializers
             try
             {
                 List<Type> types = paramTypesJson.Select(x => Convert.FromJson(x)).Cast<Type>().ToList();
-                MethodBase method = Create.MethodBase((Type)Convert.FromJson(typeName), methodName, types); // type overload
 
+                MethodBase method = null;
+
+                foreach (Type type in Reflection.Create.AllEngineTypes(typeName))
+                {
+                    method = Create.MethodBase(type, methodName, types); // type overload
+                    if (method != null)
+                        return method;
+                }
+               
                 if (method == null)
                     Reflection.Compute.RecordError("Method " + methodName + " from " + typeName + " failed to deserialise.");
                 return method;

--- a/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
@@ -102,12 +102,16 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 List<Type> types = paramTypesJson.Select(x => Convert.FromJson(x)).Cast<Type>().ToList();
 
                 MethodBase method = null;
-
-                foreach (Type type in Reflection.Create.AllEngineTypes(typeName))
+                BsonDocument typeDocument;
+                if (BsonDocument.TryParse(typeName, out typeDocument) && typeDocument.Contains("Name"))
                 {
-                    method = Create.MethodBase(type, methodName, types); // type overload
-                    if (method != null)
-                        return method;
+                    typeName = typeDocument["Name"].AsString;
+                    foreach (Type type in Reflection.Create.AllEngineTypes(typeName))
+                    {
+                        method = Create.MethodBase(type, methodName, types); // type overload
+                        if (method != null)
+                            return method;
+                    }
                 }
                
                 if (method == null)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1695 

<!-- Add short description of what has been fixed -->

- Fixes issue of deserialising a method if multiple engine types with the same name and namespace is found
- Adding AllEngineTypes method in reflection engine that returns all types matching a type name

### Test files
<!-- Link to test files to validate the proposed changes -->

@kThorsager can you run through your testcases

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->