### PR TITLE
Diffing_Engine: Added control over max number of differences for `DifferentProperties()`

### DIFF
--- a/Diffing_Engine/Query/DifferentProperties.cs
+++ b/Diffing_Engine/Query/DifferentProperties.cs
@@ -51,7 +51,7 @@ namespace BH.Engine.Diffing
 
             CompareLogic comparer = new CompareLogic();
 
-            comparer.Config.MaxDifferences = 1000;
+            comparer.Config.MaxDifferences = diffConfig.MaxPropertyDifferences;
             comparer.Config.MembersToIgnore = diffConfig.PropertiesToIgnore;
             comparer.Config.DoublePrecision = diffConfig.NumericTolerance;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/837
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1711 

<!-- Add short description of what has been fixed -->

Adds the option to regulate MaxDifferences in the `DifferentProperties()` method.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
