### PR TITLE
Library_Engine: Warning added when the library under given name is not found in the folder 

### DIFF
--- a/Library_Engine/Query/Datasets.cs
+++ b/Library_Engine/Query/Datasets.cs
@@ -46,7 +46,10 @@ namespace BH.Engine.Library
         {
             HashSet<string> keys;
             if (!LibraryPaths().TryGetValue(libraryName, out keys))
+            {
+                BH.Engine.Reflection.Compute.RecordWarning(String.Format("Library named {0} could not be found in the Libraries folder.", libraryName));
                 return new List<Dataset>();
+            }
 
             return keys.Select(x => ParseLibrary(x)).ToList();
 

--- a/Library_Engine/Query/Datasets.cs
+++ b/Library_Engine/Query/Datasets.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Library
             HashSet<string> keys;
             if (!LibraryPaths().TryGetValue(libraryName, out keys))
             {
-                BH.Engine.Reflection.Compute.RecordWarning(String.Format("Library named {0} could not be found in the Libraries folder.", libraryName));
+                BH.Engine.Reflection.Compute.RecordWarning(String.Format("No file or subfolder named {0} could be found in the Datasets folder.", libraryName));
                 return new List<Dataset>();
             }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1715

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FLibrary%20Engine%2FLibrary%5FEngine%231715%2DMissingNotFoundWarning).

