### PR TITLE
Serialiser_Engine:  Fix remaining problems with serialisation

### DIFF
--- a/Diffing_Engine/Create/StreamPointer.cs
+++ b/Diffing_Engine/Create/StreamPointer.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Diffing
         [Description("Creates new Stream Pointer, generating a new StreamId.")]
         public static StreamPointer StreamPointer(string name = null, string description = null)
         {
-            return new StreamPointer(name, description);
+            return new StreamPointer(Guid.NewGuid(), name, description, DateTime.UtcNow.Ticks);
         }
     }
 }

--- a/Serialiser_Engine/Compute/RegisterClassMap.cs
+++ b/Serialiser_Engine/Compute/RegisterClassMap.cs
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Serialiser.Objects;
+using BH.Engine.Serialiser.Objects.MemberMapConventions;
+using MongoDB.Bson.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Serialiser
+{
+    public static partial class Compute
+    {
+        /*******************************************/
+        /**** Public Methods                    ****/
+        /*******************************************/
+
+        public static void RegisterClassMap(Type type)
+        {
+            try
+            {
+                if (type.Name.StartsWith("Tree"))
+                    Console.WriteLine("Here");
+
+                BsonClassMap cm = new BsonClassMap(type);
+                cm.AutoMap();
+                cm.SetDiscriminator(type.FullName);
+                cm.SetDiscriminatorIsRequired(true);
+                cm.SetIgnoreExtraElements(false);   // It would have been nice to use cm.MapExtraElementsProperty("CustomData") but it doesn't work for inherited properties
+                cm.SetIdMember(null);
+
+                BsonClassMap.RegisterClassMap(cm);
+
+                BsonSerializer.RegisterDiscriminatorConvention(type, new GenericDiscriminatorConvention());
+            }
+            catch (Exception e)
+            {
+                Debug.WriteLine(e.ToString());
+            }
+        }
+
+        /*******************************************/
+    }
+}

--- a/Serialiser_Engine/Convert/Bson.cs
+++ b/Serialiser_Engine/Convert/Bson.cs
@@ -38,6 +38,7 @@ using BH.Engine.Serialiser.Objects.MemberMapConventions;
 using System.Reflection;
 using BH.Engine.Serialiser.Objects;
 using System.Drawing;
+using System.Text.RegularExpressions;
 
 namespace BH.Engine.Serialiser
 {
@@ -170,6 +171,7 @@ namespace BH.Engine.Serialiser
                 BsonSerializer.RegisterSerializer(typeof(DataTable), new DataTableSerialiser());
                 BsonSerializer.RegisterSerializer(typeof(Bitmap), new BitmapSerializer());
                 BsonSerializer.RegisterSerializer(typeof(IntPtr), new IntPtrSerializer());
+                BsonSerializer.RegisterSerializer(typeof(Regex), new RegexSerializer());
 
                 var typeSerializer = new TypeSerializer();
                 BsonSerializer.RegisterSerializer(typeof(Type), typeSerializer);
@@ -201,40 +203,19 @@ namespace BH.Engine.Serialiser
                         generic.Invoke(null, null);
                     }
                     else if (!type.IsGenericType)
-                        RegisterClassMap(type);
-
+                        Compute.RegisterClassMap(type);
+                    else
+                        BsonSerializer.RegisterDiscriminatorConvention(type, new GenericDiscriminatorConvention());
                 }
 
             }
 
-            RegisterClassMap(typeof(System.Drawing.Color));
-            RegisterClassMap(typeof(MethodInfo));
-            RegisterClassMap(typeof(ConstructorInfo));
-            RegisterClassMap(typeof(Bitmap));
-            RegisterClassMap(typeof(IntPtr));
-        }
-
-        /*******************************************/
-
-        private static void RegisterClassMap(Type type)
-        {
-            try
-            {
-                BsonClassMap cm = new BsonClassMap(type);
-                cm.AutoMap();
-                cm.SetDiscriminator(type.FullName);
-                cm.SetDiscriminatorIsRequired(true);
-                cm.SetIgnoreExtraElements(false);   // It would have been nice to use cm.MapExtraElementsProperty("CustomData") but it doesn't work for inherited properties
-                cm.SetIdMember(null);
-
-                BsonClassMap.RegisterClassMap(cm);
-
-                BsonSerializer.RegisterDiscriminatorConvention(type, new GenericDiscriminatorConvention());
-            }
-            catch (Exception e)
-            {
-                Debug.WriteLine(e.ToString());
-            }
+            Compute.RegisterClassMap(typeof(System.Drawing.Color));
+            Compute.RegisterClassMap(typeof(MethodInfo));
+            Compute.RegisterClassMap(typeof(ConstructorInfo));
+            Compute.RegisterClassMap(typeof(Bitmap));
+            Compute.RegisterClassMap(typeof(IntPtr));
+            Compute.RegisterClassMap(typeof(Regex));
         }
 
         /*******************************************/

--- a/Serialiser_Engine/Objects/BsonSerializers/BitmapSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/BitmapSerializer.cs
@@ -59,6 +59,12 @@ namespace BH.Engine.Serialiser.BsonSerializers
 
         public override Bitmap Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
         {
+            if (context.Reader.CurrentBsonType == BsonType.Null)
+            {
+                context.Reader.ReadNull();
+                return null;
+            }
+
             BsonBinaryData data = context.Reader.ReadBinaryData();
             var stream = new MemoryStream(data.Bytes);
             return new Bitmap(stream);

--- a/Serialiser_Engine/Objects/BsonSerializers/RegexSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/RegexSerializer.cs
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
+using System.Drawing;
+using System.Text.RegularExpressions;
+
+namespace BH.Engine.Serialiser.BsonSerializers
+{
+    public class RegexSerializer : SerializerBase<Regex>
+    {
+        /*******************************************/
+        /**** Public Methods                    ****/
+        /*******************************************/
+
+        public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, Regex value)
+        {
+            context.Writer.WriteString(value.ToString());
+        }
+
+        /*******************************************/
+
+        public override Regex Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
+        {
+            string text = context.Reader.ReadString();
+
+            return new Regex(text);
+        }
+
+        /*******************************************/
+    }
+}
+

--- a/Serialiser_Engine/Serialiser_Engine.csproj
+++ b/Serialiser_Engine/Serialiser_Engine.csproj
@@ -54,12 +54,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\RegisterClassMap.cs" />
     <Compile Include="Compute\AllowUpgradeFromBson.cs" />
     <Compile Include="Convert\Bson.cs" />
     <Compile Include="Convert\Encrypted.cs" />
     <Compile Include="Convert\Zip.cs" />
     <Compile Include="Convert\Json.cs" />
     <Compile Include="Modify\ApplyTaggedName.cs" />
+    <Compile Include="Objects\BsonSerializers\RegexSerializer.cs" />
     <Compile Include="Objects\BsonSerializers\IntPtrSerializer.cs" />
     <Compile Include="Objects\BsonSerializers\BitmapSerializer.cs" />
     <Compile Include="Objects\BsonSerializers\DataTableSerialiser.cs" />

--- a/Versioning_Engine/Convert/ToNewVersion.cs
+++ b/Versioning_Engine/Convert/ToNewVersion.cs
@@ -68,6 +68,9 @@ namespace BH.Engine.Versioning
             if (document == null)
                 return null;
 
+            if (document.Contains("_t") && document["_t"].ToString() == "DBNull")
+                return null;
+
             // Get the current version of the BHoM if not provided
             if (version.Length == 0)
                 version = GetCurrentAssemblyVersion();


### PR DESCRIPTION
### NOTE: Depends on 

https://github.com/BHoM/BHoM/pull/857
https://github.com/BHoM/Test_Toolkit/pull/247

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1620 
Closes #1755 
Closes #1737

Yatta !! Finally got all types working (at least those on my computer).

![image](https://user-images.githubusercontent.com/16853390/81470698-c4674d80-921e-11ea-99ee-b9b27fb73dcf.png)

This fixes the serialiser itself but will be accompanied by a few corrections on the non-compliant types themselves to get it all working (see PRs in the `depends on` section)

### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Serializer_Engine/serialisationTest.gh?csf=1&web=1&e=1okDsJ

If you have types failing on your machine, please make sure they compliant first. A common issue for example is an incorrect constructor for `IImmutable` classes.

### Changelog
- Move RegisterClassMap and add serialiser for regex
- Take care of the case where a bitmap is null
- Handle Enumerable as top objects and GenericTypeDefinition
- Don't send nulls to versioning



### Additional comments
FYI, A dummy object cannot be created for `MaterialComposition` because it has a restriction inside its constructor that throws an exception if that constraint is not met. 