### PR TITLE
Serialiser_Engine: Auto-versioning of methods and types during serialisation

### DIFF
--- a/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Reflection;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using MongoDB.Bson.Serialization;
@@ -101,7 +102,7 @@ namespace BH.Engine.Serialiser.BsonSerializers
             {
                 MethodBase method = GetMethod(methodName, typeName, paramTypesJson);
 
-                if (method == null)
+                if (method == null || method.IsDeprecated())
                 {
                     // Try to upgrade through versioning
                     BsonDocument doc = new BsonDocument();

--- a/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
@@ -267,15 +267,22 @@ namespace BH.Engine.Serialiser.BsonSerializers
             }
             catch (Exception e)
             {
-                if (e.Message.Contains("DBNull"))
-                    actualType = null;
+                BsonDocument doc = null;
+
+                try
+                {
+                    context.Reader.ReturnToBookmark(bookmark);
+                    IBsonSerializer bSerializer = BsonSerializer.LookupSerializer(typeof(BsonDocument));
+                    doc = bSerializer.Deserialize(context, args) as BsonDocument;
+                }
+                catch { }
+                
+                if (doc != null && doc.Contains("_t") && doc["_t"].AsString == "DBNull")
+                    return null;
                 else
                     actualType = typeof(IDeprecated);
             }
-            finally
-            {
-                context.Reader.ReturnToBookmark(bookmark);
-            }
+            context.Reader.ReturnToBookmark(bookmark);
 
             if (actualType == null)
                 return null;

--- a/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
@@ -265,9 +265,12 @@ namespace BH.Engine.Serialiser.BsonSerializers
             {
                 actualType = _discriminatorConvention.GetActualType(reader, typeof(object));
             }
-            catch
+            catch (Exception e)
             {
-                actualType = typeof(IDeprecated);
+                if (e.Message.Contains("DBNull"))
+                    actualType = null;
+                else
+                    actualType = typeof(IDeprecated);
             }
             finally
             {


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1738
Closes #1766 

Methods and types are now upgraded directly during deserialisation, not need to call ToNewVersion separately.


### Test files
Here's what I have tested on. But I recommend to use the usual serialisation test files on SharePoint:
- Serialisation from #1756 is still giving me a 100% success as before
- I have tested various levels of inclusion of a type that needs upgrading and all seems fine.
![image](https://user-images.githubusercontent.com/16853390/81789984-53ce7280-9537-11ea-8ced-bbc2cec7e94c.png)
Here's the json used in there (in order of complexity, raw type, Custom object containing the type as property, List of that type to cover generic types, method that needs that type to be updated for it to work ):
```
{ "_t" : "System.Type", "Name" : "BH.oM.Geometry.IElement2D" }
```
```
{"Type": { "_t" : "System.Type", "Name" : "BH.oM.Geometry.IElement2D" }, "A": 1}
```
```
{ "_t" : "System.Type", "Name" : "System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089", "GenericArguments" : [{ "_t" : "System.Type", "Name" : "BH.oM.Geometry.IElement2D" }] }
```

```
{ "_t" : "System.Reflection.MethodBase", "TypeName" : "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.ModelLaundry.Modify, ModelLaundry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }", "MethodName" : "ExtendToEachOther", "Parameters" : ["{ \"_t\" : \"System.Type\", \"Name\" : \"System.Collections.Generic.List`1, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\", \"GenericArguments\" : [{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.IElement2D\" }] }", "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }", "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }", "{ \"_t\" : \"System.Type\", \"Name\" : \"System.Double, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089\" }"] }
```

- A method that needs to be upgraded through versioning. You probably want to do more testing on that one by using your own json or scripts that need upgrading:
```
{ "_t" : "System.Reflection.MethodBase", "TypeName" : "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.Engine.Geometry.Compute, Geometry_Engine, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null\" }", "MethodName" : "ClipPolylines", "Parameters" : ["{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Polyline\" }", "{ \"_t\" : \"System.Type\", \"Name\" : \"BH.oM.Geometry.Polyline\" }"] }
```

I strongly recommend reviewing and merging this alongside https://github.com/BHoM/BHoM_UI/pull/263 as that fixes the missing wires on upgrades.