### PR TITLE
Spatial_Engine: Restructure ISetElement and INewElement

### DIFF
--- a/Architecture_Engine/Query/NewElement1D.cs
+++ b/Architecture_Engine/Query/NewElement1D.cs
@@ -36,6 +36,7 @@ namespace BH.Engine.Architecture
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Returns an instance of an IElement1D from the given object")]
         [Input("room", "An Architecture Room object")]
         [Input("curve", "The curve to clone")]

--- a/Environment_Engine/Query/NewElement1D.cs
+++ b/Environment_Engine/Query/NewElement1D.cs
@@ -36,6 +36,7 @@ namespace BH.Engine.Environment
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Returns an instance of an IElement1D from the given object")]
         [Input("opening", "An Environmental Opening object")]
         [Input("curve", "The curve to clone")]
@@ -47,6 +48,7 @@ namespace BH.Engine.Environment
 
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Returns an instance of an IElement1D from the given object")]
         [Input("panel", "An Environmental Panel object")]
         [Input("curve", "The curve to clone")]
@@ -58,6 +60,7 @@ namespace BH.Engine.Environment
 
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Returns an instance of an IElement1D from the given object")]
         [Input("space", "An Environment Space object")]
         [Input("curve", "The curve to clone")]

--- a/Physical_Engine/Create/IElement/IElement1D/NewElement1D.cs
+++ b/Physical_Engine/Create/IElement/IElement1D/NewElement1D.cs
@@ -35,6 +35,7 @@ namespace BH.Engine.Physical
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Creates a valid IElement1D which can be assigned to the ISurface")]
         [Input("surface", "The 2-dimensional element which a corresponding valid IElement1D is to be gotten from")]
         [Input("curve", "The geometrical location of the new IElement1D as a ICurve")]
@@ -46,6 +47,7 @@ namespace BH.Engine.Physical
 
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Creates a valid IElement1D which can be assigned to the IOpening")]
         [Input("surface", "The 2-dimensional element which a corresponding valid IElement1D is to be gotten from")]
         [Input("curve", "The geometrical location of the new IElement1D as a ICurve")]

--- a/Spatial_Engine/Create/NewElement0D.cs
+++ b/Spatial_Engine/Create/NewElement0D.cs
@@ -33,13 +33,14 @@ namespace BH.Engine.Spatial
         /****            IElement1D            ****/
         /******************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a Point to the SetElement0D.")]
         [Description("Creates a IElement0D of a type which can be assigned to the IElement1D at the location of the point.")]
         [Input("element1D", "A IElement1D with a IElement0D type defined. The element is only used to identify the type of IElement0D to create, and will remain unchanged by this method.")]
         [Input("point", "The point location of which to assign to the new IElement0D.")]
         [Output("element0D", "A IElement0D which can be assigned to the IElement1D located at the point's location. Returns null if the IElement1D does not have a IElement0D type defined.")]
         public static IElement0D INewElement0D(this IElement1D element1D, Point point)
         {
-            return Reflection.Compute.RunExtensionMethod(element1D, "NewElement0D", new object[] { point }) as IElement0D;
+            return point;
         }
 
         /******************************************/

--- a/Spatial_Engine/Create/NewElement1D.cs
+++ b/Spatial_Engine/Create/NewElement1D.cs
@@ -33,13 +33,14 @@ namespace BH.Engine.Spatial
         /****            IElement2D            ****/
         /******************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Creates a IElement1D of a type which can be assigned to the IElement2D at the location of the curve.")]
         [Input("element2D", "A IElement2D of which to get the correct IElement1D type of. The element is only used to identify the type of IElement1D to create, and will remain unchanged by this method.")]
         [Input("curve", "The curve location of which to assign to the new IElement1D.")]
         [Output("element1D", "A IElement1D which can be assigned to the IElement2D located at the curve's location.")]
         public static IElement1D INewElement1D(this IElement2D element2D, ICurve curve)
         {
-            return Reflection.Compute.RunExtensionMethod(element2D, "NewElement1D", new object[] { curve }) as IElement1D;
+            return curve;
         }
 
         /******************************************/

--- a/Spatial_Engine/Modify/SetElements0D.cs
+++ b/Spatial_Engine/Modify/SetElements0D.cs
@@ -34,9 +34,9 @@ namespace BH.Engine.Spatial
         /****            IElement1D            ****/
         /******************************************/
 
-        [Description("Assigns the provided IElement0Ds to the IElement1D. The IElement0Ds location is used and may change the IElement1Ds geometry.")]
+        [Description("Assigns the provided IElement0Ds to the IElement1D. Points will always default the elements end. The IElement0Ds location is used and may change the IElement1Ds geometry.")]
         [Input("element1D", "The IElement1D to modify the IElement0D's properties of. This includes their location.")]
-        [Input("newElements0D", "The IElement0Ds to assign to the IElement1D. Must be of a type assignable to the IElement1D.")]
+        [Input("newElements0D", "The IElement0Ds to assign to the IElement1D. Must be of a type assignable to the IElement1D or a Point which will default the elements end properties.")]
         [Output("element1D", "The modified IElement1D which has unchanged properties and new IElement0Ds.")]
         public static IElement1D ISetElements0D(this IElement1D element1D, List<IElement0D> newElements0D)
         {

--- a/Spatial_Engine/Modify/SetOutlineElements1D.cs
+++ b/Spatial_Engine/Modify/SetOutlineElements1D.cs
@@ -34,9 +34,9 @@ namespace BH.Engine.Spatial
         /****          Public methods          ****/
         /******************************************/
 
-        [Description("Sets the outline IElement1Ds of the IElement2D. This will maintain the IElement2D properties but exchange the outlines IElement1Ds.")]
+        [Description("Sets the outline IElement1Ds of the IElement2D. ICurves will default the elements outline properties. This will maintain the IElement2D properties but exchange the outlines IElement1Ds.")]
         [Input("element2D", "The IElement2D to exchange the outline IElement1D's of. This includes their location.")]
-        [Input("newOutline", "The outline IElement1Ds to set to the IElement2D. Must be planar and of a type assignable to the IElement2D.")]
+        [Input("newOutline", "The outline IElement1Ds to set to the IElement2D. Must be planar and of a type assignable to the IElement2D or ICurve which will default the elements outline properties.")]
         [Output("element2D", "The modified IElement2D which has unchanged properties and exchanged outline IElement1Ds.")]
         public static IElement2D ISetOutlineElements1D(this IElement2D element2D, List<IElement1D> newOutline)
         {

--- a/Structure_Engine/Create/Elements/IElement0D/NewElement0D.cs
+++ b/Structure_Engine/Create/Elements/IElement0D/NewElement0D.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Structure
         [Output("node", "The created Node in the position provided as a IElement0D.")]
         public static IElement0D NewElement0D(this Bar bar, Point point)
         {
-            return Create.Node(point);
+            return point;
         }
 
         /***************************************************/

--- a/Structure_Engine/Create/Elements/IElement0D/NewElement0D.cs
+++ b/Structure_Engine/Create/Elements/IElement0D/NewElement0D.cs
@@ -37,6 +37,7 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a Point to the SetElements0D.")]
         [Description("Creates a new Element0D, appropriate to the input type. For this case the appropriate type for the Bar will be a new Node, in the position provided. \n" +
                      "Method required for any IElement1D element that contains IElement0D(s).")]
         [Input("bar", "Bar is used to determine the appropriate type of IElement0D to create.")]

--- a/Structure_Engine/Create/Elements/IElement1D/NewElement1D.cs
+++ b/Structure_Engine/Create/Elements/IElement1D/NewElement1D.cs
@@ -39,6 +39,7 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Creates a new Element1D, appropriate to the input type. For this case the appropriate type for the Opening will be a new Edge, in the position provided. \n" +
                      "Method required for any IElement2D.")]
         [Input("opening", "Opening just used to determine the appropriate type of IElement1D to create.")]
@@ -51,6 +52,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [ToBeRemoved("3.2", "Was used for incode purposes of defaulting elements, a task which is now achived by providing a ICurve to the SetOutlineElement1D.")]
         [Description("Creates a new Element1D, appropriate to the input type. For this case the appropriate type for the Panel will be a new Edge, in the position provided. \n" +
                      "Method required for any IElement2D.")]
         [Input("panel", "Panel just used to determine the appropriate type of IElement1D to create.")]

--- a/Structure_Engine/Create/Elements/IElement1D/NewElement1D.cs
+++ b/Structure_Engine/Create/Elements/IElement1D/NewElement1D.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Structure
         [Output("edge", "The created Edge in the position provided as a IElement1D.")]
         public static IElement1D NewElement1D(this Opening opening, ICurve curve)
         {
-            return new Edge { Curve = curve.IClone() };
+            return curve.IClone();
         }
 
         /***************************************************/
@@ -60,7 +60,7 @@ namespace BH.Engine.Structure
         [Output("edge", "The created Edge in the position provided as a IElement1D.")]
         public static IElement1D NewElement1D(this Panel panel, ICurve curve)
         {
-            return new Edge { Curve = curve.IClone() };
+            return curve.IClone();
         }
 
         /***************************************************/

--- a/Structure_Engine/Modify/SetElements0D.cs
+++ b/Structure_Engine/Modify/SetElements0D.cs
@@ -56,7 +56,8 @@ namespace BH.Engine.Structure
             if (newElements0D[0] is Point)
             {
                 clone.StartNode = Create.Node(newElements0D[0] as Point);
-                clone.Release.StartRelease = Create.FixConstraint6DOF();
+                if (clone.Release != null)
+                    clone.Release.StartRelease = Create.FixConstraint6DOF();
             } else
                 clone.StartNode = newElements0D[0] as Node;
 
@@ -64,7 +65,8 @@ namespace BH.Engine.Structure
             if (newElements0D[1] is Point)
             {
                 clone.EndNode = Create.Node(newElements0D[1] as Point);
-                clone.Release.EndRelease = Create.FixConstraint6DOF();
+                if (clone.Release != null)
+                    clone.Release.EndRelease = Create.FixConstraint6DOF();
             }
             else
                 clone.EndNode = newElements0D[1] as Node;

--- a/Structure_Engine/Modify/SetElements0D.cs
+++ b/Structure_Engine/Modify/SetElements0D.cs
@@ -37,9 +37,10 @@ namespace BH.Engine.Structure
         /****            IElement1D            ****/
         /******************************************/
 
-        [Description("Sets the IElement0Ds of the Bar, i.e. its two end Nodes. Method required for IElement1Ds.")]
+        [Description("Sets the IElement0Ds of the Bar, i.e. its two end Nodes or Points. Method required for IElement1Ds.")]
         [Input("bar", "The Bar to set the IElement0Ds to.")]
-        [Input("newElements0D", "The new IElement0Ds of the Bar. Should be a list of length two, containing exactly two structural Nodes.")]
+        [Input("newElements0D", "The new IElement0Ds of the Bar. Should be a list of length two, containing exactly two structural Nodes or Geometrical Points. \n" +
+                                "Points will assigin default end properties to the Bar, i.e. Fixed releases, no support.")]
         [Output("bar","The bar with updated Nodes.")]
         public static Bar SetElements0D(this Bar bar, List<IElement0D> newElements0D)
         {

--- a/Structure_Engine/Modify/SetElements0D.cs
+++ b/Structure_Engine/Modify/SetElements0D.cs
@@ -58,7 +58,8 @@ namespace BH.Engine.Structure
                 clone.StartNode = Create.Node(newElements0D[0] as Point);
                 if (clone.Release != null)
                     clone.Release.StartRelease = Create.FixConstraint6DOF();
-            } else
+            }
+            else
                 clone.StartNode = newElements0D[0] as Node;
 
             // Default the Bars end if the input is an Point

--- a/Structure_Engine/Modify/SetElements0D.cs
+++ b/Structure_Engine/Modify/SetElements0D.cs
@@ -27,7 +27,7 @@ using System.Collections.Generic;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Quantities.Attributes;
 using System.ComponentModel;
-
+using BH.Engine.Base;
 
 namespace BH.Engine.Structure
 {
@@ -49,9 +49,25 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Bar clone = bar.GetShallowClone() as Bar;
-            clone.StartNode = newElements0D[0] as Node;
-            clone.EndNode = newElements0D[1] as Node;
+            Bar clone = bar.DeepClone() as Bar;
+
+            // Default the Bars end if the input is an Point
+            if (newElements0D[0] is Point)
+            {
+                clone.StartNode = Create.Node(newElements0D[0] as Point);
+                clone.Release.StartRelease = Create.FixConstraint6DOF();
+            } else
+                clone.StartNode = newElements0D[0] as Node;
+
+            // Default the Bars end if the input is an Point
+            if (newElements0D[1] is Point)
+            {
+                clone.EndNode = Create.Node(newElements0D[1] as Point);
+                clone.Release.EndRelease = Create.FixConstraint6DOF();
+            }
+            else
+                clone.EndNode = newElements0D[1] as Node;
+
             return clone;
         }
 

--- a/Structure_Engine/Modify/SetOutlineElements1D.cs
+++ b/Structure_Engine/Modify/SetOutlineElements1D.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Structure
         public static Opening SetOutlineElements1D(this Opening opening, List<IElement1D> edges)
         {
             Opening o = opening.GetShallowClone(true) as Opening;
-            o.Edges = new List<Edge>(edges.Cast<Edge>());
+            o.Edges = edges.Select(x => x is ICurve ? new Edge() { Curve = (x as ICurve) } : x as Edge).ToList();
             return o;
         }
 
@@ -58,7 +58,7 @@ namespace BH.Engine.Structure
         public static Panel SetOutlineElements1D(this Panel panel, List<IElement1D> edges)
         {
             Panel pp = panel.GetShallowClone(true) as Panel;
-            pp.ExternalEdges = new List<Edge>(edges.Cast<Edge>());
+            pp.ExternalEdges = edges.Select(x => x is ICurve ? new Edge() { Curve = (x as ICurve) } : x as Edge).ToList();
             return pp;
         }
 

--- a/Structure_Engine/Modify/SetOutlineElements1D.cs
+++ b/Structure_Engine/Modify/SetOutlineElements1D.cs
@@ -40,7 +40,8 @@ namespace BH.Engine.Structure
 
         [Description("Sets the Outline Element1Ds of an opening, i.e. the Edges of an Opening. Method required for all IElement2Ds.")]
         [Input("opening", "The Opening to update the Edges of.")]
-        [Input("edges", "A list of IElement1Ds which all should be of type structural Edge.")]
+        [Input("edges", "A list of IElement1Ds which all should be of type structural Edge or Geometrical ICurve. \n" + 
+                        "ICurve will default the outlines properties.")]
         [Output("opening", "The opening with updated Edges.")]
         public static Opening SetOutlineElements1D(this Opening opening, List<IElement1D> edges)
         {
@@ -53,7 +54,8 @@ namespace BH.Engine.Structure
 
         [Description("Sets the outline Element1Ds of a Panel, i.e. the ExternalEdges of a Panel. Method required for all IElement2Ds.")]
         [Input("panel", "The Panel to update the ExternalEdges of.")]
-        [Input("edges", "A list of IElement1Ds which all should be of type structural Edge.")]
+        [Input("edges", "A list of IElement1Ds which all should be of type structural Edge or Geometrical ICurve. \n" +
+                        "ICurve will default the outlines properties.")]
         [Output("panel", "The Panel with updated ExternalEdges.")]
         public static Panel SetOutlineElements1D(this Panel panel, List<IElement1D> edges)
         {


### PR DESCRIPTION
### Issues addressed by this PR
Closes #1785
As specified in change-log

### Test files
<!-- Link to test files to validate the proposed changes -->
Tests that the defaulting for the only element (`Bar`) which needs it is working.
https://burohappold.sharepoint.com/:u:/s/BHoM/EXdhou5wJ9xFmUZReD9Inx0B8LoeNgGw6H28RWnIghZkrg?e=yJAyoE

### Changelog
- `ISetElement` `0D` & `1D` methods now defaults if provided a `IGeometry`
- `INewElement` `0D` & `1D` methods are no longer needed and now return the inputted point/curve awaiting removal

### Additional comments
<!-- As required -->
No urgent reason to delete the new methods in each project, but will tag them as `ToBeRemoved and raise separate issues to be resolved at toolkit(project?) leads discretion.
raised in #1788 

Not versioning since it not really anything to version to (maybe the components second input to a `IGeometry` holder component? (don't think that's possible))