### PR TITLE
Structure_Engine: Plastic modulus, SplitCurve removal of unneeded curve cast

### DIFF
--- a/Structure_Engine/Compute/PlasticModulus.cs
+++ b/Structure_Engine/Compute/PlasticModulus.cs
@@ -301,7 +301,7 @@ namespace BH.Engine.Structure
         private static IEnumerable<ICurve> SplitOnPoints(IEnumerable<ICurve> curves, double x, double tol = Tolerance.Distance)
         {
             List<PolyCurve> results = new List<PolyCurve>();
-            foreach (PolyCurve curve in curves)
+            foreach (ICurve curve in curves)
             {
                 List<ICurve> subCurves = curve.ISubParts().ToList();
                 List<ICurve> temp = new List<ICurve>();


### PR DESCRIPTION
   
### Issues addressed by this PR
Closes #1795 
While the solution seems simplistic, it does work as the only problem was that the foreach loop assumed `PolyCurve` without reason. But SubParts works for `ICurve`. Think is was left over from when it worked differently, but aw well.

Works now.


### Test files
<!-- Link to test files to validate the proposed changes -->
see issue #1795 
