### PR TITLE
Geometry_Engine: Transform and Subsequent methods for IGeometry objects

### DIFF
--- a/Geometry_Engine/Create/TransformMatrix.cs
+++ b/Geometry_Engine/Create/TransformMatrix.cs
@@ -111,6 +111,43 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static TransformMatrix ProjectionMatrix(Plane plane, Vector vector = null)
+        {
+            Point x = new Point() { X = 1 };
+            Point y = new Point() { Y = 1 };
+            Point z = new Point() { Z = 1 };
+
+            vector = vector ?? plane.Normal;
+
+            Vector refVector = (new Point()).ProjectAlong(plane, vector) - new Point();
+
+            // Set plane to origin for projection
+            plane = new Plane() { Normal = plane.Normal };
+
+            // Compute the projection for three controlPoints defining the transformation
+            x = x.ProjectAlong(plane, vector);
+            y = y.ProjectAlong(plane, vector);
+            z = z.ProjectAlong(plane, vector);
+
+            TransformMatrix project = new TransformMatrix
+            {
+                Matrix = new double[,]
+                {
+                    {  x.X, y.X, z.X, 0 },
+                    {  x.Y, y.Y, z.Y, 0 },
+                    {  x.Z, y.Z, z.Z, 0 },
+                    {  0,   0,   0,   1 }
+                }
+            };
+
+            // Move the projection out from the origin to the original plane
+            TransformMatrix move = TranslationMatrix(refVector);
+
+            return move * project;
+        }
+
+        /***************************************************/
+
         public static TransformMatrix RandomMatrix(int seed = -1, double minVal = -1, double maxVal = 1)
         {
             if (seed == -1)

--- a/Geometry_Engine/Create/TransformMatrix.cs
+++ b/Geometry_Engine/Create/TransformMatrix.cs
@@ -117,7 +117,7 @@ namespace BH.Engine.Geometry
             Point y = new Point() { Y = 1 };
             Point z = new Point() { Z = 1 };
 
-            vector = vector ?? plane.Normal;
+            vector = vector == null || vector.SquareLength() < Tolerance.Distance * Tolerance.Distance ? plane.Normal : vector;
 
             Vector refVector = (new Point()).ProjectAlong(plane, vector) - new Point();
 

--- a/Geometry_Engine/Modify/Mirror.cs
+++ b/Geometry_Engine/Modify/Mirror.cs
@@ -87,6 +87,20 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static Ellipse Mirror(this Ellipse ellipse, Plane p)
+        {
+            return new Ellipse
+            {
+                Axis1 = ellipse.Axis1.Mirror(p),
+                Axis2 = ellipse.Axis2.Mirror(p),
+                Centre = ellipse.Centre.Mirror(p),
+                Radius1 = ellipse.Radius1,
+                Radius2 = ellipse.Radius2,
+            };
+        }
+
+        /***************************************************/
+
         public static Line Mirror(this Line line, Plane p)
         {
             return new Line { Start = line.Start.Mirror(p), End = line.End.Mirror(p) };

--- a/Geometry_Engine/Modify/Mirror.cs
+++ b/Geometry_Engine/Modify/Mirror.cs
@@ -238,11 +238,10 @@ namespace BH.Engine.Geometry
 
         private static IGeometry Mirror(this IGeometry geometry, Plane p)
         {
-            Reflection.Compute.RecordError("Mirror not implemented for: " + geometry.GetType().Name);
+            Reflection.Compute.RecordError("Mirror method has not been implemented for type " + geometry.GetType().Name);
             return null;
         }
 
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Modify/Mirror.cs
+++ b/Geometry_Engine/Modify/Mirror.cs
@@ -222,7 +222,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods - Fallback                ****/
         /***************************************************/
 
-        public static IGeometry Mirror(this IGeometry geometry, Plane p)
+        private static IGeometry Mirror(this IGeometry geometry, Plane p)
         {
             Reflection.Compute.RecordError("Mirror not implemented for: " + geometry.GetType().Name);
             return null;

--- a/Geometry_Engine/Modify/Project.cs
+++ b/Geometry_Engine/Modify/Project.cs
@@ -257,11 +257,10 @@ namespace BH.Engine.Geometry
 
         private static IGeometry Project(this IGeometry geometry, Plane p)
         {
-            Reflection.Compute.RecordError("Project not implemented for: " + geometry.GetType().Name);
+            Reflection.Compute.RecordError("Project method has not been implemented for type " + geometry.GetType().Name);
             return null;
         }
 
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Modify/Project.cs
+++ b/Geometry_Engine/Modify/Project.cs
@@ -112,22 +112,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static Ellipse Project(this Ellipse ellipse, Plane p)
+        public static ICurve Project(this Ellipse ellipse, Plane p)
         {
-            Vector axis1 = ellipse.Axis1.Project(p);
-            Vector axis2 = ellipse.Axis2.Project(p);
-
-            double radius1 = Math.Sqrt(axis1.SquareLength() / ellipse.Axis1.SquareLength());
-            double radius2 = Math.Sqrt(axis2.SquareLength() / ellipse.Axis2.SquareLength());
-
-            return new Ellipse()
-            {
-                Axis1 = axis1,
-                Axis2 = axis2,
-                Centre = ellipse.Centre.Project(p),
-                Radius1 = ellipse.Radius1 * radius1,
-                Radius2 = ellipse.Radius2 * radius2
-            };
+            TransformMatrix project = Create.ProjectionMatrix(p, p.Normal);
+            return ellipse.Transform(project);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Project.cs
+++ b/Geometry_Engine/Modify/Project.cs
@@ -267,7 +267,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods - Fallback                ****/
         /***************************************************/
 
-        public static IGeometry Project(this IGeometry geometry, Plane p)
+        private static IGeometry Project(this IGeometry geometry, Plane p)
         {
             Reflection.Compute.RecordError("Project not implemented for: " + geometry.GetType().Name);
             return null;

--- a/Geometry_Engine/Modify/ProjectAlong.cs
+++ b/Geometry_Engine/Modify/ProjectAlong.cs
@@ -226,7 +226,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods - Fallback                ****/
         /***************************************************/
 
-        public static IGeometry ProjectAlong(this IGeometry geometry, Plane plane, Vector vector)
+        private static IGeometry ProjectAlong(this IGeometry geometry, Plane plane, Vector vector)
         {
             Reflection.Compute.RecordError("ProjectAlong not implemented for: " + geometry.GetType().Name);
             return null;

--- a/Geometry_Engine/Modify/ProjectAlong.cs
+++ b/Geometry_Engine/Modify/ProjectAlong.cs
@@ -80,12 +80,8 @@ namespace BH.Engine.Geometry
             if (circle.Normal.IsParallel(plane.Normal) != 0)
                 return new Circle { Centre = circle.Centre.ProjectAlong(plane, vector), Normal = circle.Normal.Clone(), Radius = circle.Radius };
 
-            Vector axis1 = plane.Normal.CrossProduct(circle.Normal);
-            Vector axis2 = axis1.CrossProduct(plane.Normal);
-            double denominator = circle.Normal.DotProduct(plane.Normal);
-            double radius2 = Math.Abs(denominator) < Tolerance.Distance ? double.PositiveInfinity : circle.Radius / denominator;
-            
-            return new Ellipse { Centre = circle.Centre.ProjectAlong(plane, vector), Axis1 = axis1, Axis2 = axis2, Radius1 = circle.Radius, Radius2 = radius2 };
+            TransformMatrix project = Create.ProjectionMatrix(plane, vector);
+            return circle.Transform(project);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/ProjectAlong.cs
+++ b/Geometry_Engine/Modify/ProjectAlong.cs
@@ -233,11 +233,10 @@ namespace BH.Engine.Geometry
 
         private static IGeometry ProjectAlong(this IGeometry geometry, Plane plane, Vector vector)
         {
-            Reflection.Compute.RecordError("ProjectAlong not implemented for: " + geometry.GetType().Name);
+            Reflection.Compute.RecordError("ProjectAlong method has not been implemented for type " + geometry.GetType().Name);
             return null;
         }
 
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Modify/ProjectAlong.cs
+++ b/Geometry_Engine/Modify/ProjectAlong.cs
@@ -82,7 +82,8 @@ namespace BH.Engine.Geometry
 
             Vector axis1 = plane.Normal.CrossProduct(circle.Normal);
             Vector axis2 = axis1.CrossProduct(plane.Normal);
-            double radius2 = circle.Radius * circle.Normal.DotProduct(plane.Normal);
+            double denominator = circle.Normal.DotProduct(plane.Normal);
+            double radius2 = Math.Abs(denominator) < Tolerance.Distance ? double.PositiveInfinity : circle.Radius / denominator;
             
             return new Ellipse { Centre = circle.Centre.ProjectAlong(plane, vector), Axis1 = axis1, Axis2 = axis2, Radius1 = circle.Radius, Radius2 = radius2 };
         }

--- a/Geometry_Engine/Modify/ProjectAlong.cs
+++ b/Geometry_Engine/Modify/ProjectAlong.cs
@@ -88,6 +88,14 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
+        
+        public static ICurve ProjectAlong(this Ellipse ellipse, Plane plane, Vector vector)
+        {
+            TransformMatrix project = Create.ProjectionMatrix(plane, vector);
+            return ellipse.Transform(project);
+        }
+
+        /***************************************************/
 
         public static Line ProjectAlong(this Line line, Plane plane, Vector vector)
         {

--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -244,11 +244,10 @@ namespace BH.Engine.Geometry
 
         private static IGeometry Rotate(this IGeometry geometry, double rad, Vector axis)
         {
-            Engine.Reflection.Compute.RecordError("Rotate not implemented for: " + geometry.GetType().Name);
+            Engine.Reflection.Compute.RecordError("Rotate method has not been implemented for type " + geometry.GetType().Name);
             return null;
         }
 
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -235,14 +235,14 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Some objects have no use for origin, this method will make them calleble from the interface method.")]
-        public static IGeometry Rotate(this IGeometry geometry, Point origin, Vector axis, double rad)
+        private static IGeometry Rotate(this IGeometry geometry, Point origin, Vector axis, double rad)
         {
             return Rotate(geometry as dynamic, rad, axis);
         }
 
         /***************************************************/
 
-        public static IGeometry Rotate(this IGeometry geometry, double rad, Vector axis)
+        private static IGeometry Rotate(this IGeometry geometry, double rad, Vector axis)
         {
             Engine.Reflection.Compute.RecordError("Rotate not implemented for: " + geometry.GetType().Name);
             return null;

--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -24,6 +24,7 @@ using BH.oM.Geometry;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Reflection.Attributes;
 using System;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Engine.Geometry
@@ -56,6 +57,13 @@ namespace BH.Engine.Geometry
         {
             TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);
             return Transform(plane, rotationMatrix);
+        }
+
+        /***************************************************/
+
+        public static Basis Rotate(this Basis basis, double rad, Vector axis)
+        {
+            return Create.Basis(basis.X.Rotate(rad, axis), basis.Y.Rotate(rad, axis));
         }
 
 
@@ -143,15 +151,23 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static NurbsSurface Rotate(this NurbsSurface surface, Point origin, Vector axis, double rad)
         {
-            throw new NotImplementedException();
+            TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);
+            return Transform(surface, rotationMatrix);
         }
 
         /***************************************************/
 
         public static Pipe Rotate(this Pipe surface, Point origin, Vector axis, double rad)
+        {
+            TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);
+            return Transform(surface, rotationMatrix);
+        }
+
+        /***************************************************/
+
+        public static PlanarSurface Rotate(this PlanarSurface surface, Point origin, Vector axis, double rad)
         {
             TransformMatrix rotationMatrix = Create.RotationMatrix(origin, axis, rad);
             return Transform(surface, rotationMatrix);
@@ -197,7 +213,7 @@ namespace BH.Engine.Geometry
 
         public static IGeometry IRotate(this IGeometry geometry, Point origin, Vector axis, double rad)
         {
-            return Rotate(geometry as dynamic, rad, axis);
+            return Rotate(geometry as dynamic, origin, axis, rad);
         }
 
         /***************************************************/
@@ -211,7 +227,25 @@ namespace BH.Engine.Geometry
 
         public static ISurface IRotate(this ISurface geometry, Point origin, Vector axis, double rad)
         {
+            return Rotate(geometry as dynamic, origin, axis, rad);
+        }
+
+        /***************************************************/
+        /**** Private Methods - Interfaces              ****/
+        /***************************************************/
+
+        [Description("Some objects have no use for origin, this method will make them calleble from the interface method.")]
+        public static IGeometry Rotate(this IGeometry geometry, Point origin, Vector axis, double rad)
+        {
             return Rotate(geometry as dynamic, rad, axis);
+        }
+
+        /***************************************************/
+
+        public static IGeometry Rotate(this IGeometry geometry, double rad, Vector axis)
+        {
+            Engine.Reflection.Compute.RecordError("Rotate not implemented for: " + geometry.GetType().Name);
+            return null;
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Scale.cs
+++ b/Geometry_Engine/Modify/Scale.cs
@@ -54,7 +54,7 @@ namespace BH.Engine.Geometry
             TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
             return Transform(plane, scaleMatrix);
         }
-
+        
 
         /***************************************************/
         /**** Public Methods - Curves                   ****/
@@ -136,10 +136,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static NurbsSurface Scale(this NurbsSurface surface, Point origin, Vector scaleVector)
         {
-            throw new NotImplementedException();
+            TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
+            return surface.Transform(scaleMatrix);
         }
 
         /***************************************************/
@@ -148,6 +148,14 @@ namespace BH.Engine.Geometry
         {
             TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
             return Transform(surface, scaleMatrix);
+        }
+
+        /***************************************************/
+
+        public static PlanarSurface Scale(this PlanarSurface surface, Point origin, Vector scaleVector)
+        {
+            TransformMatrix scaleMatrix = Create.ScaleMatrix(origin, scaleVector);
+            return surface.Transform(scaleMatrix);
         }
 
         /***************************************************/
@@ -206,6 +214,17 @@ namespace BH.Engine.Geometry
         public static ISurface IScale(this ISurface geometry, Point origin, Vector scaleVector)
         {
             return Scale(geometry as dynamic, origin, scaleVector);
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        public static IGeometry Scale(this IGeometry geometry, Point origin, Vector scaleVector)
+        {
+            Reflection.Compute.RecordError("Scale not implemented for: " + geometry.GetType().Name);
+            return null;
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Scale.cs
+++ b/Geometry_Engine/Modify/Scale.cs
@@ -223,11 +223,10 @@ namespace BH.Engine.Geometry
 
         private static IGeometry Scale(this IGeometry geometry, Point origin, Vector scaleVector)
         {
-            Reflection.Compute.RecordError("Scale not implemented for: " + geometry.GetType().Name);
+            Reflection.Compute.RecordError("Scale method has not been implemented for type " + geometry.GetType().Name);
             return null;
         }
 
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Modify/Scale.cs
+++ b/Geometry_Engine/Modify/Scale.cs
@@ -221,7 +221,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods                           ****/
         /***************************************************/
 
-        public static IGeometry Scale(this IGeometry geometry, Point origin, Vector scaleVector)
+        private static IGeometry Scale(this IGeometry geometry, Point origin, Vector scaleVector)
         {
             Reflection.Compute.RecordError("Scale not implemented for: " + geometry.GetType().Name);
             return null;

--- a/Geometry_Engine/Modify/Transform.cs
+++ b/Geometry_Engine/Modify/Transform.cs
@@ -304,7 +304,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods                           ****/
         /***************************************************/
 
-        public static IGeometry Transform(this IGeometry geometry, TransformMatrix transform)
+        private static IGeometry Transform(this IGeometry geometry, TransformMatrix transform)
         {
             Reflection.Compute.RecordError("Transform not implemented for: " + geometry.GetType().Name);
             return null;

--- a/Geometry_Engine/Modify/Transform.cs
+++ b/Geometry_Engine/Modify/Transform.cs
@@ -306,7 +306,7 @@ namespace BH.Engine.Geometry
 
         private static IGeometry Transform(this IGeometry geometry, TransformMatrix transform)
         {
-            Reflection.Compute.RecordError("Transform not implemented for: " + geometry.GetType().Name);
+            Reflection.Compute.RecordError("Transform method has not been implemented for type " + geometry.GetType().Name);
             return null;
         }
 
@@ -332,4 +332,3 @@ namespace BH.Engine.Geometry
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Modify/Transform.cs
+++ b/Geometry_Engine/Modify/Transform.cs
@@ -24,6 +24,7 @@ using BH.oM.Geometry;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Reflection.Attributes;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace BH.Engine.Geometry
@@ -65,6 +66,13 @@ namespace BH.Engine.Geometry
         public static Plane Transform(this Plane plane, TransformMatrix transform)
         {
             return new Plane { Origin = plane.Origin.Transform(transform), Normal = plane.Normal.Transform(transform).Normalise() };
+        }
+
+        /***************************************************/
+
+        public static Basis Transform(this Basis basis, TransformMatrix transform)
+        {
+            return Create.Basis(basis.X.Transform(transform), basis.Y.Transform(transform));
         }
 
         /***************************************************/
@@ -192,10 +200,21 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static NurbsSurface Transform(this NurbsSurface surface, TransformMatrix transform)
         {
-            throw new NotImplementedException();
+            List<SurfaceTrim> innerTrims = surface.InnerTrims.Select(x => new SurfaceTrim(ITransform(x.Curve3d, transform), x.Curve2d)).ToList();
+
+            List<SurfaceTrim> outerTrims = surface.OuterTrims.Select(x => new SurfaceTrim(ITransform(x.Curve3d, transform), x.Curve2d)).ToList();
+
+            return new NurbsSurface(
+                surface.ControlPoints.Select(x => Transform(x, transform)),
+                surface.Weights,
+                surface.UKnots,
+                surface.VKnots,
+                surface.UDegree,
+                surface.VDegree,
+                innerTrims,
+                outerTrims);
         }
 
         /***************************************************/
@@ -207,6 +226,13 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static PlanarSurface Transform(this PlanarSurface surface, TransformMatrix transform)
+        {
+            return new PlanarSurface(surface.ExternalBoundary.ITransform(transform), surface.InternalBoundaries.Select(x => x.ITransform(transform)).ToList());
+        }
+
+        /***************************************************/
+
         public static PolySurface Transform(this PolySurface surface, TransformMatrix transform)
         {
             return new PolySurface { Surfaces = surface.Surfaces.Select(x => x.ITransform(transform)).ToList() };
@@ -214,7 +240,7 @@ namespace BH.Engine.Geometry
 
 
         /***************************************************/
-        /**** Public Methods - Others                   ****/
+        /**** Public Methods - Mesh                     ****/
         /***************************************************/
 
         public static Mesh Transform(this Mesh mesh, TransformMatrix transform)
@@ -222,6 +248,19 @@ namespace BH.Engine.Geometry
             return new Mesh { Vertices = mesh.Vertices.Select(x => x.Transform(transform)).ToList(), Faces = mesh.Faces.Select(x => x.Clone() as Face).ToList() };
         }
 
+
+        /***************************************************/
+        /**** Public Methods - Solid                    ****/
+        /***************************************************/
+
+        public static BoundaryRepresentation Transform(this BoundaryRepresentation solid, TransformMatrix transform)
+        {
+            return new BoundaryRepresentation(solid.Surfaces.Select(x => x.ITransform(transform)));
+        }
+
+
+        /***************************************************/
+        /**** Public Methods - Misc                     ****/
         /***************************************************/
 
         public static CompositeGeometry Transform(this CompositeGeometry group, TransformMatrix transform)
@@ -253,9 +292,24 @@ namespace BH.Engine.Geometry
             return Transform(geometry as dynamic, transform);
         }
 
+        /***************************************************/
+
+        public static ISurface ITransform(this ISolid geometry, TransformMatrix transform)
+        {
+            return Transform(geometry as dynamic, transform);
+        }
+
 
         /***************************************************/
         /**** Private Methods                           ****/
+        /***************************************************/
+
+        public static IGeometry Transform(this IGeometry geometry, TransformMatrix transform)
+        {
+            Reflection.Compute.RecordError("Transform not implemented for: " + geometry.GetType().Name);
+            return null;
+        }
+
         /***************************************************/
 
         private static bool IsUniformScaling(this TransformMatrix transform)

--- a/Geometry_Engine/Modify/Translate.cs
+++ b/Geometry_Engine/Modify/Translate.cs
@@ -213,11 +213,10 @@ namespace BH.Engine.Geometry
 
         private static IGeometry Translate(this IGeometry geometry, Vector transform)
         {
-            Reflection.Compute.RecordError("Translate not implemented for: " + geometry.GetType().Name);
+            Reflection.Compute.RecordError("Translate method has not been implemented for type " + geometry.GetType().Name);
             return null;
         }
 
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Modify/Translate.cs
+++ b/Geometry_Engine/Modify/Translate.cs
@@ -211,7 +211,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods - Fallback                ****/
         /***************************************************/
 
-        public static IGeometry Translate(this IGeometry geometry, Vector transform)
+        private static IGeometry Translate(this IGeometry geometry, Vector transform)
         {
             Reflection.Compute.RecordError("Translate not implemented for: " + geometry.GetType().Name);
             return null;

--- a/Geometry_Engine/Modify/Translate.cs
+++ b/Geometry_Engine/Modify/Translate.cs
@@ -139,10 +139,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [NotImplemented]
         public static NurbsSurface Translate(this NurbsSurface surface, Vector transform)
         {
-            throw new NotImplementedException();
+            TransformMatrix translationMatrix = Create.TranslationMatrix(transform);
+            return Transform(surface, translationMatrix);
         }
 
         /***************************************************/
@@ -150,6 +150,13 @@ namespace BH.Engine.Geometry
         public static Pipe Translate(this Pipe surface, Vector transform)
         {
             return new Pipe { Centreline = surface.Centreline.ITranslate(transform), Radius = surface.Radius, Capped = surface.Capped };
+        }
+
+        /***************************************************/
+
+        public static PlanarSurface Translate(this PlanarSurface surface, Vector transform)
+        {
+            return new PlanarSurface(surface.ExternalBoundary.ITranslate(transform), surface.InternalBoundaries.Select(x => x.ITranslate(transform)).ToList());
         }
 
         /***************************************************/
@@ -198,6 +205,16 @@ namespace BH.Engine.Geometry
         public static ISurface ITranslate(this ISurface geometry, Vector transform)
         {
             return Translate(geometry as dynamic, transform);
+        }
+
+        /***************************************************/
+        /**** Private Methods - Fallback                ****/
+        /***************************************************/
+
+        public static IGeometry Translate(this IGeometry geometry, Vector transform)
+        {
+            Reflection.Compute.RecordError("Translate not implemented for: " + geometry.GetType().Name);
+            return null;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1818 
Adding the functionality for the Transform methods for most `IGeometry` objects

The main offenders are `NurbsCurve`, `NurbsSurface` & `PlanarSurface`

The Transform methods are:

- `Transform`
- `Translate`
- `Scale`
- `Rotate`
- `ProjectAlong`
- `Project`
- `Mirror`
<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/EZr4zXI_K0ZFk2nsaKQjiqIBBHS9g11IXVV77-w3uAsptQ?e=TPJDWB

### Changelog
- Also added a Create.ProjectionMatrix

### Additional comments
<!-- As required -->

Think the only controversial part is making the IRotate(IGeometry) work for anything else than vectors and adding private fall backs for the methods.


So more things were annoying, testing revealed that ProjectAlong for Circles did not work, which is what I based the Ellipse method on. So i threw in a ProjectionMatrix as ellipses can turn into not ellipses and circles were more convoluted than I cared to solve as I now had the ProjectionMatrix.

so this works with the caveat that some circles which may be able to be turned into Ellipses are being turned into Nurbs, but we barely support either so no great loss.