### PR TITLE
Geometry_Engine: Better handling of corner cases in IsContaining

### DIFF
--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -264,7 +264,7 @@ namespace BH.Engine.Geometry
             // - this is very problematic for edge cases (cutting line going through a sharp corner, to be superseded?
 
             BoundingBox box = curve.Bounds();
-            if (points.Any(x => !box.IsContaining(x, acceptOnEdge, tolerance)))
+            if (points.Any(x => !box.IsContaining(x, true, tolerance)))
                 return false;
 
             if (!curve.IsClosed(tolerance))

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -263,6 +263,10 @@ namespace BH.Engine.Geometry
             // - to be replaced with a general method for a nurbs curve?
             // - this is very problematic for edge cases (cutting line going through a sharp corner, to be superseded?
 
+            BoundingBox box = curve.Bounds();
+            if (points.Any(x => !box.IsContaining(x, acceptOnEdge, tolerance)))
+                return false;
+
             if (!curve.IsClosed(tolerance))
                 return false;
 

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -180,7 +180,7 @@ namespace BH.Engine.Geometry
                         {
                             Point end = p.Origin;
                             Vector direction = (end - pPt).Normalise();
-                            while (direction.SquareLength() <= sqTol || edgeDirections.Any(e => 1 - Math.Abs(e.DotProduct(direction)) <= Tolerance.Angle))
+                            while (direction.SquareLength() <= 0.5 || edgeDirections.Any(e => 1 - Math.Abs(e.DotProduct(direction)) <= Tolerance.Angle))
                             {
                                 end = end.Translate(Create.RandomVectorInPlane(p, true));
                                 direction = (end - pPt).Normalise();
@@ -286,7 +286,7 @@ namespace BH.Engine.Geometry
 
                 Point end = p.Origin;   // Avrage of control points
                 Vector direction = (end - pPt).Normalise();     // Gets a line cutting through the curves and the point
-                while (direction.SquareLength() <= sqTol || edgeDirections.Any(e => 1 - Math.Abs(e.DotProduct(direction)) <= Tolerance.Angle)) // not zeroa or parallel to edges
+                while (direction.SquareLength() <= 0.5 || edgeDirections.Any(e => 1 - Math.Abs(e.DotProduct(direction)) <= Tolerance.Angle)) // not zeroa or parallel to edges
                 {
                     end = end.Translate(Create.RandomVectorInPlane(p, true));
                     direction = (end - pPt).Normalise();


### PR DESCRIPTION

### Issues addressed by this PR
Closes #1214 

`IsContaining`s algorithm assumed that if a line, with end at point A,'s intersection point with an line L was within the distance tolerance, then any line which endpoint is at the point A will intersect the line L.

unfortunately not true,
This PR adds a relative factor based on their angles to query if the other intersection will happen.

This approach only works for linear cases, so added a sanity check for the `PolyCurve` case to avoid the most horrendous errors

### Test files
<!-- Link to test files to validate the proposed changes -->
Generic test:
https://burohappold.sharepoint.com/:u:/s/BHoM/EeLGxufNopJMnOX4g1fMMdoBt8NybP-hh7ytJFvGGoWFRw?e=hfBWhG

Specific test:
See issue

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->