### PR TITLE
Serialiser_Engine: Fixing member mapping for Immutable inheriting from non-abstract class

### DIFF
--- a/Serialiser_Engine/Compute/RegisterClassMap.cs
+++ b/Serialiser_Engine/Compute/RegisterClassMap.cs
@@ -42,9 +42,6 @@ namespace BH.Engine.Serialiser
         {
             try
             {
-                if (type.Name.StartsWith("Tree"))
-                    Console.WriteLine("Here");
-
                 BsonClassMap cm = new BsonClassMap(type);
                 cm.AutoMap();
                 cm.SetDiscriminator(type.FullName);

--- a/Serialiser_Engine/Objects/MemberMapConventions/ImmutableBHoMClassMapConvention.cs
+++ b/Serialiser_Engine/Objects/MemberMapConventions/ImmutableBHoMClassMapConvention.cs
@@ -82,7 +82,7 @@ namespace BH.Engine.Serialiser.MemberMapConventions
                 {
                     if (property.DeclaringType == classType && !IsOverridden(property))
                         classMap.MapMember(property);
-                    else if(!property.CanWrite)
+                    else if(!property.CanWrite && classType.BaseType != null && classType.BaseType.IsAbstract)
                     {
                         //Forcing immutable properties from base class to be added via reflection.
                         //This is due to BsonClassMap refusing to add members from base class to the class map which is needed


### PR DESCRIPTION
## Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1851

See issue for more details.

This fixes a bug introduced in https://github.com/BHoM/BHoM_Engine/commit/db0c1bdc1c192ddc46c3fed4e00d98514034f0df


### Test files
![image](https://user-images.githubusercontent.com/16853390/84984515-8f2f1300-b16d-11ea-893e-7f582967c76c.png)

You can also make sure that this change doesn't brake any other serialisation by using https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Serializer_Engine/serialisationTest.gh?csf=1&web=1&e=d4cOIv

### Additional comments
This is a very specific change that cannot break anything else so I am happy to merge it this week. Let me know if you disagree.