### PR TITLE
Structure_Engine: Allow Query.Geometry to return invalid PlanarSurfaces for the case of invalid Structure.Panels

### DIFF
--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -83,7 +83,7 @@ namespace BH.Engine.Structure
         [Output("surface", "The geometry of the structural Panel at its centre.")]
         public static IGeometry Geometry(this Panel panel)
         {
-            return Engine.Geometry.Create.PlanarSurface(
+            return new PlanarSurface(
                 Engine.Geometry.Compute.IJoin(panel.ExternalEdges.Select(x => x.Curve).ToList()).FirstOrDefault(),
                 panel.Openings.SelectMany(x => Engine.Geometry.Compute.IJoin(x.Edges.Select(y => y.Curve).ToList())).Cast<ICurve>().ToList()
             );


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1853 

The above is a resolution of current bug to return to similar behaviour before implementation of immutable PlanarSurfaces.

### Test files
<!-- Link to test files to validate the proposed changes -->

Should resolve original issue here:
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FModelLaundry%5FToolkit%2FModelLaundry%2DIssue253%5FInvalidPerimeterSnapToGrids&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4

And should now give warnings instead of errors here:
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/Installers/Scripts/BuroHappold_BHoM_v3.2/0010_Model%20Laundry/Structures_ClassicPanelML.gh?csf=1&web=1&e=OIBDJ6



### Additional comments
<!-- As required -->