### PR TITLE
Store previously run extension methods in a thread safe dictionary

### DIFF
--- a/Reflection_Engine/Compute/RunExtensionMethod.cs
+++ b/Reflection_Engine/Compute/RunExtensionMethod.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -99,9 +100,8 @@ namespace BH.Engine.Reflection
         /**** Private fields                            ****/
         /***************************************************/
 
-        private static Dictionary<Tuple<Type, string>, MethodInfo> m_PreviousInvokedMethods = new Dictionary<Tuple<Type, string>, MethodInfo>();
-
-
+        private static ConcurrentDictionary<Tuple<Type, string>, MethodInfo> m_PreviousInvokedMethods = new ConcurrentDictionary<Tuple<Type, string>, MethodInfo>();
+        
         /***************************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1856 

<!-- Add short description of what has been fixed -->

Fixes an issue with thread safety of the RunExtensionMethod.

When a multi-threaded part elsewhere calls methods that depend on RUnExtensionMethod, for the first run, you can end up in strange race conditions, where the dictionary can crash out with a null reference exception, when trying to add a method to it, even though neither the dictionary itself, the key or the value being null.

https://github.com/BHoM/BHoM_Engine/blob/1f3b86537c17c468aae717c28119a626dc45fa05/Reflection_Engine/Compute/RunExtensionMethod.cs#L89

This seem to have to do with the fact that dictionaries are not thread safe for writing, only for reading.

Switching to a `ConcurrentDictionary` seem to have solved the issue on my end. A minor slowdown for the test case could be seen, but still running close to as fast, and faster than some atempts I made using padlocks on the exisiting dictionary.

@adecler would like for you to have a look at this, please, and help determine if this is safe enough to get in this late. But the current system is not fully thread-safe, at least not on first call(s) to the same method, that happens before the methods has been extracted and stored in the dictionary. We have some use cases of AsParallel and similar throughout the code that do end up using this. Would probably have to get rid of that (and loose efficiency) if we can not get this resolved.

### Test files
<!-- Link to test files to validate the proposed changes -->

Script that gave me issues, where the derived component always crash on first run for me, but runs fine if you retrigger the run. After a rhino re-start, it fails again.

https://burohappold.sharepoint.com/:f:/s/BHoM/ElL1smrFkpBJnx6pdP7MeacBTNWotDQJH1ZM-1elQ8uehw?e=zHqy8z

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

fyi @al-fisher @rwemay @FraserGreenroyd 