### PR TITLE
Reflection_Engine: Making sure PropertyObjects also collects objets in list properties

### DIFF
--- a/Reflection_Engine/Query/PropertyObjects.cs
+++ b/Reflection_Engine/Query/PropertyObjects.cs
@@ -21,6 +21,7 @@
  */
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -43,7 +44,15 @@ namespace BH.Engine.Reflection
                 {
                     properties.Add(value);
                     if (goDeep)
-                        properties.AddRange(value.PropertyObjects(true));
+                    {
+                        if (value is IEnumerable)
+                        {
+                            foreach (object child in (IEnumerable)value)
+                                properties.AddRange(PropertyObjects(child, true));
+                        }
+                        else
+                            properties.AddRange(PropertyObjects(value, true));
+                    }
                 }
             }
             return properties;


### PR DESCRIPTION
 
### Issues addressed by this PR


The `PropertyObjects` method with `goDeep` set to true was not collecting the objects inside the list properties. This PR fixes that.

This is needed to [this PR in the DataViz toolkit](https://github.com/BuroHappoldEngineering/DataViz_Toolkit/pull/75)


### Test files
Use `PropertyObjects` component on any object that has a list property.

