### PR TITLE
Geometry_Engine: Update PointClustersDBSCAN to use DomainTree

### DIFF
--- a/Data_Engine/Compute/DomainTreeClusters.cs
+++ b/Data_Engine/Compute/DomainTreeClusters.cs
@@ -40,42 +40,40 @@ namespace BH.Engine.Data
 
             List<T> items = new List<T>(data);
             List<bool> check = items.Select(x => false).ToList();
-            DomainTree<int> indexTree = Data.Create.DomainTree(items.Select((x, i) => Data.Create.DomainTreeLeaf(i, toDomainBox(x))));
+            List<DomainBox> domainBoxes = data.Select(x => toDomainBox(x)).ToList();
+            DomainTree<int> indexTree = Data.Create.DomainTree(domainBoxes.Select((x, i) => Data.Create.DomainTreeLeaf(i, x)));
 
             List<List<T>> result = new List<List<T>>();
-            List<T> toEvaluate = new List<T>();
+            List<int> toEvaluate = new List<int>();
 
             int count = -1;
             for (int i = 0; i < items.Count; i++)
             {
-                T pivot = items[i];
-
                 if (check[i])
                     continue;
 
                 result.Add(new List<T>());
                 count++;
-                toEvaluate.Add(pivot);
+                toEvaluate.Add(i);
                 check[i] = true;
 
                 while (toEvaluate.Count > 0)
                 {
                     // Find all the neighbours for each item in toEvaluate, and add them in toEvaluate
-                    foreach (int index in Data.Query.ItemsInRange<DomainTree<int>, int>(indexTree, x => TreeEvaluator(x.DomainBox, toDomainBox(toEvaluate[0]))))
+                    foreach (int index in Data.Query.ItemsInRange<DomainTree<int>, int>(indexTree, x => TreeEvaluator(x.DomainBox, domainBoxes[toEvaluate[0]])))
                     {
                         if (!check[index])
                         {
-                            T item = items[index];
-                            if (itemEvaluator(toEvaluate[0], item))
+                            if (itemEvaluator(items[toEvaluate[0]], items[index]))
                             {
-                                toEvaluate.Add(item);
+                                toEvaluate.Add(index);
                                 check[index] = true;
                             }
                         }
                     }
 
                     // move the checked items from toEvaluate to result
-                    result[count].Add(toEvaluate[0]);
+                    result[count].Add(items[toEvaluate[0]]);
                     toEvaluate.RemoveAt(0);
                 }
             }

--- a/Data_Engine/Compute/DomainTreeClusters.cs
+++ b/Data_Engine/Compute/DomainTreeClusters.cs
@@ -21,8 +21,10 @@
  */
 
 using BH.oM.Data.Collections;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace BH.Engine.Data
@@ -33,7 +35,14 @@ namespace BH.Engine.Data
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static List<List<T>> DomainTreeClusters<T>(this List<T> data, Func<T, DomainBox> toDomainBox, Func<DomainBox, DomainBox, bool> TreeEvaluator, Func<T, T, bool> itemEvaluator, int minPointCount = 1)
+        [Description("Clusters data in different collections using a DomainTree.")]
+        [Input("data", "Data to cluster.")]
+        [Input("toDomainBox", "Method which takes a item in the data and produces a DomainBox for the tree.")]
+        [Input("treeEvaluator", "Method which evaluates if the items within the second DomainBox could be in the same cluster as the first DomainBox.")]
+        [Input("itemEvaluator", "Method which evaluates if the two items should be in the same cluster.")]
+        [Input("minItemCount", "Lowest number of item in a cluster to return.")]
+        [Output("clusters", "Clusters where itemEvaluator is never true between items from different clusters.")]
+        public static List<List<T>> DomainTreeClusters<T>(this List<T> data, Func<T, DomainBox> toDomainBox, Func<DomainBox, DomainBox, bool> treeEvaluator, Func<T, T, bool> itemEvaluator, int minItemCount = 1)
         {
             if (data.Count == 0)
                 return new List<List<T>>();
@@ -60,7 +69,7 @@ namespace BH.Engine.Data
                 while (toEvaluate.Count > 0)
                 {
                     // Find all the neighbours for each item in toEvaluate, and add them in toEvaluate
-                    foreach (int index in Data.Query.ItemsInRange<DomainTree<int>, int>(indexTree, x => TreeEvaluator(x.DomainBox, domainBoxes[toEvaluate[0]])))
+                    foreach (int index in Data.Query.ItemsInRange<DomainTree<int>, int>(indexTree, x => treeEvaluator(x.DomainBox, domainBoxes[toEvaluate[0]])))
                     {
                         if (!check[index])
                         {
@@ -78,7 +87,7 @@ namespace BH.Engine.Data
                 }
             }
 
-            return result.Where(list => list.Count >= minPointCount).ToList();
+            return result.Where(list => list.Count >= minItemCount).ToList();
         }
 
         /***************************************************/

--- a/Data_Engine/Compute/DomainTreeClusters.cs
+++ b/Data_Engine/Compute/DomainTreeClusters.cs
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Data.Collections;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Data
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static List<List<T>> DomainTreeClusters<T>(this List<T> data, Func<T, DomainBox> toDomainBox, Func<T, T, double> distFunc, double maxDist, int minPointCount = 1)
+        {
+            if (data.Count == 0)
+                return new List<List<T>>();
+
+            List<T> items = new List<T>(data);
+            List<bool> check = items.Select(x => false).ToList();
+            DomainTree<int> indexTree = Data.Create.DomainTree(items.Select((x, i) => Data.Create.DomainTreeLeaf(i, toDomainBox(x))));
+
+            double sqDist = maxDist * maxDist;
+
+            Func<DomainTree<int>, DomainBox, bool> evaluator = (a, b) => a.DomainBox.SquareDistance(b) < sqDist;
+
+            List<List<T>> result = new List<List<T>>();
+            List<T> toEvaluate = new List<T>();
+
+            int count = -1;
+            for (int i = 0; i < items.Count; i++)
+            {
+                T pivot = items[i];
+
+                if (check[i])
+                    continue;
+
+                result.Add(new List<T>());
+                count++;
+                toEvaluate.Add(pivot);
+                check[i] = true;
+
+                while (toEvaluate.Count > 0)
+                {
+                    // Find all the neighbours for each item in toEvaluate, and add them in toEvaluate
+                    foreach (int index in Data.Query.ItemsInRange<DomainTree<int>, int>(indexTree, x => evaluator(x, toDomainBox(toEvaluate[0]))))
+                    {
+                        if (!check[index])
+                        {
+                            T item = items[index];
+                            if (distFunc(toEvaluate[0], item) < maxDist)
+                            {
+                                toEvaluate.Add(item);
+                                check[index] = true;
+                            }
+                        }
+                    }
+
+                    // move the checked items from toEvaluate to result
+                    result[count].Add(toEvaluate[0]);
+                    toEvaluate.RemoveAt(0);
+                }
+            }
+
+            return result.Where(list => list.Count >= minPointCount).ToList();
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Data_Engine/Create/DomainTree.cs
+++ b/Data_Engine/Create/DomainTree.cs
@@ -80,8 +80,8 @@ namespace BH.Engine.Data
             {
                 DomainTree<T> tree = new DomainTree<T>()
                 {
-                    Children = children.ToList(),
-                    DomainBox = children.Select(x => x.DomainBox).Aggregate((x, y) => x + y)
+                    Children = children?.ToList() ?? new List<DomainTree<T>>(),
+                    DomainBox = children?.Select(x => x?.DomainBox).Aggregate((x, y) => x + y)
                 };
 
                 return tree;

--- a/Data_Engine/Create/Node.cs
+++ b/Data_Engine/Create/Node.cs
@@ -110,7 +110,7 @@ namespace BH.Engine.Data
 
             leafSize = Math.Max(leafSize, 2);
 
-            if (dataItems.Count() > leafSize)
+            if (dataItems != null && dataItems.Skip(leafSize).Any())
             {
                 // Partition the data where each collection will form a child Node
                 IEnumerable<IEnumerable<TNode>> subLists = partitionMethod(dataItems);

--- a/Data_Engine/Data_Engine.csproj
+++ b/Data_Engine/Data_Engine.csproj
@@ -67,6 +67,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\DomainTreeClusters.cs" />
     <Compile Include="Compute\ClusterDBSCAN.cs" />
     <Compile Include="Compute\Series.cs" />
     <Compile Include="Compute\FilterData.cs" />

--- a/Data_Engine/Query/Children.cs
+++ b/Data_Engine/Query/Children.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Data
         [Output("nodes", "Child nodes of the input node.")]
         public static IEnumerable<TNode> IChildren<TNode, T>(this TNode node) where TNode : INode<T>
         {
-            return Children(node as dynamic);
+            return Children(node as dynamic) ?? new List<TNode>();
         }
 
         /***************************************************/
@@ -51,7 +51,7 @@ namespace BH.Engine.Data
         [Output("nodes", "Child nodes of the input node.")]
         public static List<DomainTree<T>> Children<T>(this DomainTree<T> node)
         {
-            return node.Children;
+            return node?.Children ?? new List<DomainTree<T>>();
         }
 
 
@@ -59,7 +59,7 @@ namespace BH.Engine.Data
         /**** Private Methods                           ****/
         /***************************************************/
 
-        public static IEnumerable<INode<T>> Children<T>(this INode<T> node)
+        private static IEnumerable<INode<T>> Children<T>(this INode<T> node)
         {
             Reflection.Compute.RecordError("The method Values is not implemented for " + node.GetType().Name);
             return null;

--- a/Data_Engine/Query/ClosestData.cs
+++ b/Data_Engine/Query/ClosestData.cs
@@ -63,13 +63,16 @@ namespace BH.Engine.Data
                                         double maxDistance = double.PositiveInfinity,
                                         double tolerance = Tolerance.Distance)
         {
-            Func<DomainTree<T>, double> evaluationMethod = (x) => x.DomainBox.SquareDistance(searchBox);
+            if (searchBox == null)
+                return new List<T>();
+
+            Func<DomainTree<T>, double> evaluationMethod = (x) => x.DomainBox?.SquareDistance(searchBox) ?? double.PositiveInfinity;
 
             Func<DomainTree<T>, double> worstCaseMethod;
             if (tightBox)
-                worstCaseMethod = (x) => x.DomainBox.FurthestTightSquareDistance(searchBox);
+                worstCaseMethod = (x) => x.DomainBox?.FurthestTightSquareDistance(searchBox) ?? double.PositiveInfinity;
             else
-                worstCaseMethod = (x) => x.DomainBox.FurthestSquareDistance(searchBox);
+                worstCaseMethod = (x) => x.DomainBox?.FurthestSquareDistance(searchBox) ?? double.PositiveInfinity;
 
             return ClosestData<DomainTree<T>, T>(tree, evaluationMethod, worstCaseMethod, maxDistance * maxDistance, tolerance * tolerance);
         }
@@ -92,6 +95,9 @@ namespace BH.Engine.Data
                                             double maxEvaluation = double.PositiveInfinity,
                                             double tolerance = Tolerance.Distance) where TNode : INode<T>
         {
+            if (tree == null)
+                return new List<T>();
+
             List<Tuple<double, TNode>> list = new List<Tuple<double, TNode>>()
             {
                 new Tuple<double, TNode>(evaluationMethod(tree), tree)

--- a/Data_Engine/Query/ItemsInRange.cs
+++ b/Data_Engine/Query/ItemsInRange.cs
@@ -45,7 +45,10 @@ namespace BH.Engine.Data
         [Output("data", "All data in the tree which DomainBox is in range of the box.")]
         public static IEnumerable<T> ItemsInRange<T>(this DomainTree<T> tree, DomainBox box, double tolerance = Tolerance.Distance)
         {
-            Func<DomainTree<T>, bool> isWithinSearch = x => x.DomainBox.IsInRange(box, tolerance);
+            if (box == null)
+                return new List<T>();
+
+            Func<DomainTree<T>, bool> isWithinSearch = x => x.DomainBox?.IsInRange(box, tolerance) ?? false;
 
             return ItemsInRange<DomainTree<T>, T>(tree, isWithinSearch);
         }
@@ -60,7 +63,7 @@ namespace BH.Engine.Data
         [Output("data", "All data in the tree which nodes returned true for the isWithinSearch method.")]
         public static IEnumerable<T> ItemsInRange<TNode, T>(this TNode tree, Func<TNode, bool> isWithinSearch) where TNode : INode<T>
         {
-            if (isWithinSearch(tree))
+            if (tree != null && isWithinSearch(tree))
             {
                 return tree.IChildren<TNode, T>().SelectMany(x => ItemsInRange<TNode, T>(x, isWithinSearch)).Concat(tree.IValues());
             }

--- a/Data_Engine/Query/Values.cs
+++ b/Data_Engine/Query/Values.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.Data
         [Output("data", "Data values contained in this node.")]
         public static IEnumerable<T> IValues<T>(this INode<T> node)
         {
-            return Values(node as dynamic);
+            return Values(node as dynamic) ?? new List<T>();
         }
 
         /***************************************************/
@@ -62,7 +62,7 @@ namespace BH.Engine.Data
         [Output("data", "Data values contained in this node.")]
         public static List<T> Values<T>(this DomainTree<T> node)
         {
-            return node.Values ?? new List<T>();
+            return node?.Values ?? new List<T>();
         }
 
 
@@ -70,7 +70,7 @@ namespace BH.Engine.Data
         /**** Private Methods                           ****/
         /***************************************************/
 
-        public static IEnumerable<T> Values<T>(this INode<T> node)
+        private static IEnumerable<T> Values<T>(this INode<T> node)
         {
             Reflection.Compute.RecordError("The method Values is not implemented for " + node.GetType().Name);
             return null;

--- a/Geometry_Engine/Compute/PointClustersDBSCAN.cs
+++ b/Geometry_Engine/Compute/PointClustersDBSCAN.cs
@@ -37,9 +37,11 @@ namespace BH.Engine.Geometry
         
         public static List<List<Point>> PointClustersDBSCAN(this List<Point> points, double maxDist, int minPointCount = 1)
         {
+            double sqDist = maxDist * maxDist;
             Func<Point, DomainBox> toDomainBox = a => a.IBounds().DomainBox();
-            Func<Point, Point, double> distanceFunction = (a, b) => 0;  // The distance between the boxes is enough to determine if a Point is in range
-            return Data.Compute.DomainTreeClusters<Point>(points, toDomainBox, distanceFunction, maxDist, minPointCount);
+            Func<DomainBox, DomainBox, bool> treeFunction = (a, b) => a.SquareDistance(b) < sqDist;
+            Func<Point, Point, bool> itemFunction = (a, b) => true;  // The distance between the boxes is enough to determine if a Point is in range
+            return Data.Compute.DomainTreeClusters<Point>(points, toDomainBox, treeFunction, itemFunction, minPointCount);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Compute/PointClustersDBSCAN.cs
+++ b/Geometry_Engine/Compute/PointClustersDBSCAN.cs
@@ -38,7 +38,14 @@ namespace BH.Engine.Geometry
         public static List<List<Point>> PointClustersDBSCAN(this List<Point> points, double maxDist, int minPointCount = 1)
         {
             double sqDist = maxDist * maxDist;
-            Func<Point, DomainBox> toDomainBox = a => a.IBounds().DomainBox();
+            Func<Point, DomainBox> toDomainBox = a => new DomainBox()
+            {
+                Domains = new Domain[] {
+                    new Domain(a.X, a.X),
+                    new Domain(a.Y, a.Y),
+                    new Domain(a.Z, a.Z),
+                }
+            };
             Func<DomainBox, DomainBox, bool> treeFunction = (a, b) => a.SquareDistance(b) < sqDist;
             Func<Point, Point, bool> itemFunction = (a, b) => true;  // The distance between the boxes is enough to determine if a Point is in range
             return Data.Compute.DomainTreeClusters<Point>(points, toDomainBox, treeFunction, itemFunction, minPointCount);

--- a/Geometry_Engine/Compute/PointClustersDBSCAN.cs
+++ b/Geometry_Engine/Compute/PointClustersDBSCAN.cs
@@ -22,6 +22,7 @@
 
 using BH.Engine.Data;
 using BH.oM.Geometry;
+using BH.oM.Data.Collections;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -33,12 +34,53 @@ namespace BH.Engine.Geometry
         /***************************************************/
         /**** public Methods - Vectors                  ****/
         /***************************************************/
-
+        
         public static List<List<Point>> PointClustersDBSCAN(this List<Point> points, double maxDist, int minPointCount = 1)
         {
-            double maxSqrDist = maxDist * maxDist;
-            Func<Point, Point, bool> metricFunction = (x, y) => x.SquareDistance(y) <= maxSqrDist;
-            return points.ClusterDBSCAN(metricFunction, minPointCount);
+            List<Point> items = new List<Point>(points);
+            DomainTree<int> indexTree = Data.Create.DomainTree(items.Select((x,i) => Data.Create.DomainTreeLeaf(i, x.IBounds().DomainBox())));
+
+            double sqDist = maxDist * maxDist;
+
+            // Distance between boxes is the distance between Points for Points
+            Func<DomainTree<int>, DomainBox, bool> evaluator = (a, b) => a.DomainBox.SquareDistance(b) < sqDist;
+
+            List<List<Point>> result = new List<List<Point>>();
+            List<Point> toEvaluate = new List<Point>();
+
+            int count = -1;
+            for (int i = 0; i < items.Count; i++)
+            {
+                Point pivot = items[i];
+
+                if (pivot == null)
+                    continue;
+
+                result.Add(new List<Point>());
+                count++;
+                toEvaluate.Add(pivot);
+                items[i] = null;    // Set to null as it is not there anymore, but this also retains the indecies for the tree.
+
+                while (toEvaluate.Count > 0)
+                {
+                    // Find all the neighbours for each point in toEvaluate, and add them in toEvaluate
+                    foreach (int index in Data.Query.ItemsInRange<DomainTree<int>, int>(indexTree, x => evaluator(x, toEvaluate[0].IBounds().DomainBox())))
+                    {
+                        Point pt = items[index];
+                        if (pt != null)
+                        {
+                            toEvaluate.Add(pt);
+                            items[index] = null;
+                        }
+                    }
+
+                    // move the checked points from toEvaluate to result
+                    result[count].Add(toEvaluate[0]);
+                    toEvaluate.RemoveAt(0);
+                }
+            }
+
+            return result.Where(list => list.Count >= minPointCount).ToList();
         }
 
         /***************************************************/


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1881 
Had some hopes about making this general for DBSCAN and making them use `INode`, but there were annoyances as it i not a `IEnumerable`, there are difficulties in changing the objects in the tree without messing with the data and the DBSCAN method would need to be refactored to look at things per Collection rather than per Item.

And just adding clusters for IGeometries or ICurves was also annoying since no general distance method existed and would add a extra layer to this method. And there doesn't seem to be any huge need either so.

But the speed up is considerable, especially for large sets of points. 😁
(40000 points, 1.3m to 3.4s in the test file)

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/s/BHoM/Ec8Vk7lcL1dCgXq-QdewJokBfJ4s8jwT5hIATIwiA-3WWg?e=RqtVBu

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->