### PR TITLE
Structure_Engine: Fix bug for default values for minimum cover for reinforcement layout

### DIFF
--- a/Structure_Engine/Query/ReinforcementLayout.cs
+++ b/Structure_Engine/Query/ReinforcementLayout.cs
@@ -290,8 +290,9 @@ namespace BH.Engine.Structure
             innerProfileEdges = new List<ICurve>();
             longReif = new List<LongitudinalReinforcement>();
             tranReif = new List<TransverseReinforcement>();
-            longCover = 0;
-            tranCover = 0;
+            //Starting default value to the minimum cover of the section.
+            longCover = section.MinimumCover;
+            tranCover = section.MinimumCover;
 
             if (section == null)
                 return false;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1893 

<!-- Add short description of what has been fixed -->

Make sure that minimum cover is used as default parameter for cover for setting reinforcement layouts

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EpXy3FR30txGs3Q3jTlTwOoBv9zjDu3k-0Z34O9CfSBIBQ?e=ASSrZ2

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->