### PR TITLE
Versioning toolkit #84 upgrade bson package

### DIFF
--- a/Diffing_Engine/Convert/ToDiffingByteArray.cs
+++ b/Diffing_Engine/Convert/ToDiffingByteArray.cs
@@ -31,11 +31,8 @@ using System.Threading.Tasks;
 using System.Security.Cryptography;
 using System.Reflection;
 using BH.Engine.Serialiser;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
-using MongoDB.Bson;
 
 namespace BH.Engine.Diffing
 {
@@ -48,13 +45,10 @@ namespace BH.Engine.Diffing
         public static byte[] ToDiffingByteArray(this object obj, List<string> fieldsToIgnore)
         {
             if (fieldsToIgnore == null || fieldsToIgnore.Count == 0)
-                return BsonExtensionMethods.ToBson(obj);
+                return obj.ToBytes();  
 
             string objStr = ToDiffingJson(obj, fieldsToIgnore);
-
-            BsonDocument objDoc = BsonDocument.Parse(objStr);
-
-            return BsonExtensionMethods.ToBson(objDoc);
+            return objStr.ToBytes();
         }
 
 

--- a/Diffing_Engine/Convert/TryParseObjectToGuid.cs
+++ b/Diffing_Engine/Convert/TryParseObjectToGuid.cs
@@ -31,8 +31,6 @@ using System.Threading.Tasks;
 using System.Security.Cryptography;
 using System.Reflection;
 using BH.Engine.Serialiser;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 

--- a/Diffing_Engine/Diffing_Engine.csproj
+++ b/Diffing_Engine/Diffing_Engine.csproj
@@ -122,7 +122,6 @@
 xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y
 
 xcopy "$(TargetDir)KellermanSoftware.Compare-NET-Objects.dll"  "C:\ProgramData\BHoM\Assemblies" /Y
-
-xcopy "$(TargetDir)MongoDB.Bson.dll"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Diffing_Engine/Diffing_Engine.csproj
+++ b/Diffing_Engine/Diffing_Engine.csproj
@@ -48,10 +48,6 @@
       <HintPath>..\packages\CompareNETObjects.4.57.0\lib\net452\KellermanSoftware.Compare-NET-Objects.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=2.4.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.4.4\lib\net45\MongoDB.Bson.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>False</Private>

--- a/Diffing_Engine/packages.config
+++ b/Diffing_Engine/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CompareNETObjects" version="4.57.0" targetFramework="net452" />
-  <package id="MongoDB.Bson" version="2.4.4" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net452" />
   <package id="protobuf-net" version="2.4.0" targetFramework="net452" />
 </packages>

--- a/Environment_Engine/Environment_Engine.csproj
+++ b/Environment_Engine/Environment_Engine.csproj
@@ -319,9 +319,6 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Environment_Engine/packages.config
+++ b/Environment_Engine/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MongoDB.Bson" version="2.4.4" targetFramework="net452" />
-</packages>

--- a/Serialiser_Engine/Compute/ReadFromStream.cs
+++ b/Serialiser_Engine/Compute/ReadFromStream.cs
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Serialiser.Objects;
+using BH.Engine.Serialiser.Objects.MemberMapConventions;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Serialiser
+{
+    public static partial class Compute
+    {
+        /*******************************************/
+        /**** Public Methods                    ****/
+        /*******************************************/
+
+        public static List<T> ReadFromStream<T>(Stream stream)
+        {
+            try
+            {
+                var reader = new BsonBinaryReader(stream);
+                List<BsonDocument> bson = BsonSerializer.Deserialize(reader, typeof(object)) as List<BsonDocument>;
+                return bson.Select(x => (T)BsonSerializer.Deserialize(x, typeof(object))).ToList();
+            }
+            catch (Exception e)
+            {
+                BH.Engine.Reflection.Compute.RecordError(e.Message);
+                return new List<T>();
+            }
+
+            
+        }
+
+        /*******************************************/
+    }
+}

--- a/Serialiser_Engine/Compute/WriteToStream.cs
+++ b/Serialiser_Engine/Compute/WriteToStream.cs
@@ -1,0 +1,63 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Serialiser.Objects;
+using BH.Engine.Serialiser.Objects.MemberMapConventions;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Serialiser
+{
+    public static partial class Compute
+    {
+        /*******************************************/
+        /**** Public Methods                    ****/
+        /*******************************************/
+
+        public static bool WriteToStream<T>(this List<T> objects, Stream stream)
+        {
+            try
+            {
+                var writer = new BsonBinaryWriter(stream);
+                BsonSerializer.Serialize(writer, typeof(object), objects);
+                stream.Flush();
+            }
+            catch (Exception e)
+            {
+                BH.Engine.Reflection.Compute.RecordError(e.Message);
+                return false;
+            }
+
+            return true;
+        }
+
+        /*******************************************/
+    }
+}

--- a/Serialiser_Engine/Convert/Bytes.cs
+++ b/Serialiser_Engine/Convert/Bytes.cs
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using MongoDB.Bson.Serialization;
+
+namespace BH.Engine.Serialiser
+{
+    public static partial class Convert
+    {
+        /*******************************************/
+        /**** Public Methods                    ****/
+        /*******************************************/
+
+        [Description("Convert a BHoM object To a byte array")]
+        [Input("obj", "Object to be converted")]
+        [Output("bytes", "Byte array representing the object in Bson")]
+        public static byte[] ToBytes(this object obj)
+        {
+            BsonDocument doc = obj.ToBson();
+            return BsonExtensionMethods.ToBson(doc); 
+        }
+
+        /*******************************************/
+
+        [Description("Convert a byte array to a BHoMObject")]
+        [Input("bytes", "Byte array representing the object in Bson")]
+        [Output("obj", "Object recovered from the byte array")]
+        public static object FromBytes(byte[] bytes)
+        {
+            BsonDocument doc = BsonSerializer.Deserialize(bytes, typeof(BsonDocument)) as BsonDocument;
+            return FromBson(doc);
+        }
+
+        /*******************************************/
+    }
+}
+

--- a/Serialiser_Engine/Serialiser_Engine.csproj
+++ b/Serialiser_Engine/Serialiser_Engine.csproj
@@ -34,8 +34,8 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=2.10.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.10.4\lib\net452\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.9.3\lib\net452\MongoDB.Bson.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>

--- a/Serialiser_Engine/Serialiser_Engine.csproj
+++ b/Serialiser_Engine/Serialiser_Engine.csproj
@@ -34,9 +34,8 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=2.4.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.4.4\lib\net45\MongoDB.Bson.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="MongoDB.Bson, Version=2.10.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.10.4\lib\net452\MongoDB.Bson.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>

--- a/Serialiser_Engine/Serialiser_Engine.csproj
+++ b/Serialiser_Engine/Serialiser_Engine.csproj
@@ -54,10 +54,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\WriteToStream.cs" />
+    <Compile Include="Compute\ReadFromStream.cs" />
     <Compile Include="Compute\RegisterClassMap.cs" />
     <Compile Include="Compute\AllowUpgradeFromBson.cs" />
     <Compile Include="Convert\Bson.cs" />
     <Compile Include="Convert\Encrypted.cs" />
+    <Compile Include="Convert\Bytes.cs" />
     <Compile Include="Convert\Zip.cs" />
     <Compile Include="Convert\Json.cs" />
     <Compile Include="Modify\ApplyTaggedName.cs" />

--- a/Serialiser_Engine/packages.config
+++ b/Serialiser_Engine/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MongoDB.Bson" version="2.10.4" targetFramework="net452" />
+  <package id="MongoDB.Bson" version="2.9.3" targetFramework="net452" />
 </packages>

--- a/Serialiser_Engine/packages.config
+++ b/Serialiser_Engine/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MongoDB.Bson" version="2.4.4" targetFramework="net452" />
+  <package id="MongoDB.Bson" version="2.10.4" targetFramework="net452" />
 </packages>

--- a/Versioning_Engine/Compute/VersionKey.cs
+++ b/Versioning_Engine/Compute/VersionKey.cs
@@ -22,10 +22,6 @@
 
 using BH.Engine.Reflection;
 using BH.oM.Base;
-using MongoDB.Bson;
-using MongoDB.Bson.IO;
-using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Serializers;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Versioning_Engine/Query/VersionKey.cs
+++ b/Versioning_Engine/Query/VersionKey.cs
@@ -23,10 +23,6 @@
 using BH.Engine.Reflection;
 using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
-using MongoDB.Bson;
-using MongoDB.Bson.IO;
-using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Serializers;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Versioning_Engine/Versioning_Engine.csproj
+++ b/Versioning_Engine/Versioning_Engine.csproj
@@ -35,8 +35,8 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=2.10.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.10.4\lib\net452\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.9.3\lib\net452\MongoDB.Bson.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>

--- a/Versioning_Engine/Versioning_Engine.csproj
+++ b/Versioning_Engine/Versioning_Engine.csproj
@@ -35,8 +35,8 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MongoDB.Bson, Version=2.4.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MongoDB.Bson.2.4.4\lib\net45\MongoDB.Bson.dll</HintPath>
+    <Reference Include="MongoDB.Bson, Version=2.10.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MongoDB.Bson.2.10.4\lib\net452\MongoDB.Bson.dll</HintPath>
     </Reference>
     <Reference Include="Reflection_oM">
       <SpecificVersion>False</SpecificVersion>
@@ -63,14 +63,14 @@
     <Folder Include="Modify\" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Reflection_Engine\Reflection_Engine.csproj">
       <Project>{b0154405-9390-472d-9b5c-a2280823b18d}</Project>
       <Name>Reflection_Engine</Name>
       <Private>False</Private>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/Versioning_Engine/packages.config
+++ b/Versioning_Engine/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MongoDB.Bson" version="2.10.4" targetFramework="net452" />
+  <package id="MongoDB.Bson" version="2.9.3" targetFramework="net452" />
 </packages>

--- a/Versioning_Engine/packages.config
+++ b/Versioning_Engine/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MongoDB.Bson" version="2.4.4" targetFramework="net452" />
+  <package id="MongoDB.Bson" version="2.10.4" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1875 

As mentioned in the issue this upgrades the Bson package to fix the remaining issue we had with serialisation. 
This also centralise better the functionality related to conversions to and from Bson for consistency of behaviour and for simplicity purposes.


### Test files
There's a few things you can do to test this PR:
- Make sure everything still compile
- Test that the diffing engine is still working fine (@alelom)
- Serialise a few objects by using ToBytes-> FromBytes and makes sure they are still teh same. Personally, I have used the [serialisation test file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Serializer_Engine/serialisationTest.gh?csf=1&web=1&e=nyVLwI) that check that all files serialise properly


### Changelog
- Removing reference to Bson package in Environment engine
- Adding functionality for serialisation with Streams and byte arrays
- Removing reference to Mongo Bson in Diffing Engine
- Ugrading Bson package to 2.10.4


### Additional comments
I will now do the PRs on Versioning and Mong to upgrade their Bson package as well and on Sockets and File_Adapter to remove the reference to Bson by using the new functionality provided here. The only PR that will need to be merge at the same time is the Versioning_Toolkit one though (just in case 2.4 is not compatible with 2.10, which I doubt but better be safe).