### PR TITLE
Geometry_Engine: Fix for centroid and normal

### DIFF
--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -62,6 +62,10 @@ namespace BH.Engine.Geometry
 
             Vector normal = Normal(curve, tolerance);
 
+            //Check if a normal could be found.
+            if (normal == null)
+                return null;
+
             for (int i = 1; i < curve.ControlPoints.Count - 2; i++)
             {
 
@@ -134,6 +138,10 @@ namespace BH.Engine.Geometry
             double xc0 = 0, yc0 = 0, zc0 = 0;
 
             Vector normal = Normal(curve, tolerance);
+
+            //Check if a normal could be found.
+            if (normal == null)
+                return null;
 
             Point pA = pts[0];
 

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -59,16 +59,8 @@ namespace BH.Engine.Geometry
             double xc0 = 0, yc0 = 0, zc0 = 0;
 
             Point pA = curve.ControlPoints[0];
-            Point pB0 = curve.ControlPoints[1];
-            Point pC0 = curve.ControlPoints[2];
-
-            Vector firstNormal;
-
-            firstNormal = CrossProduct(pB0 - pA, pC0 - pA);
 
             Vector normal = Normal(curve, tolerance);
-
-            Boolean dir = DotProduct(normal, firstNormal) > 0;
 
             for (int i = 1; i < curve.ControlPoints.Count - 2; i++)
             {
@@ -78,7 +70,7 @@ namespace BH.Engine.Geometry
 
                 double triangleArea = Area(pB - pA, pC - pA);
 
-                if (DotProduct(CrossProduct(pB - pA, pC - pA), firstNormal) > 0)
+                if (DotProduct(CrossProduct(pB - pA, pC - pA), normal) > 0)
                 {
                     xc0 += ((pA.X + pB.X + pC.X) / 3) * triangleArea;
                     yc0 += ((pA.Y + pB.Y + pC.Y) / 3) * triangleArea;
@@ -90,14 +82,6 @@ namespace BH.Engine.Geometry
                     yc0 -= ((pA.Y + pB.Y + pC.Y) / 3) * triangleArea;
                     zc0 -= ((pA.Z + pB.Z + pC.Z) / 3) * triangleArea;
                 }
-            }
-
-
-            if (!dir)
-            {
-                xc0 = -xc0;
-                yc0 = -yc0;
-                zc0 = -zc0;
             }
 
             double curveArea = curve.Area();
@@ -152,14 +136,6 @@ namespace BH.Engine.Geometry
             Vector normal = Normal(curve, tolerance);
 
             Point pA = pts[0];
-            Point pB0 = pts[1];
-            Point pC0 = pts[2];
-
-            Vector firstNormal;
-
-            firstNormal = CrossProduct(pB0 - pA, pC0 - pA);
-
-            Boolean dir = DotProduct(normal, firstNormal) > 0;
 
             for (int i = 1; i < pts.Count - 2; i++)
             {
@@ -169,7 +145,7 @@ namespace BH.Engine.Geometry
 
                 double triangleArea = Area(pB - pA, pC - pA);
 
-                if (DotProduct(CrossProduct(pB - pA, pC - pA), firstNormal) > 0)
+                if (DotProduct(CrossProduct(pB - pA, pC - pA), normal) > 0)
                 {
                     xc0 += ((pA.X + pB.X + pC.X) / 3) * triangleArea;
                     yc0 += ((pA.Y + pB.Y + pC.Y) / 3) * triangleArea;
@@ -196,7 +172,7 @@ namespace BH.Engine.Geometry
 
                     Point arcCentr = CircularSegmentCentroid(crv as Arc);
 
-                    if (DotProduct(CrossProduct(p2 - p1, p3 - p1), firstNormal) > 0)
+                    if (DotProduct(CrossProduct(p2 - p1, p3 - p1), normal) > 0)
                     {
                         xc0 += arcCentr.X * area;
                         yc0 += arcCentr.Y * area;
@@ -209,14 +185,6 @@ namespace BH.Engine.Geometry
                         zc0 -= arcCentr.Z * area;
                     }
                 }
-            }
-
-
-            if (!dir)
-            {
-                xc0 = -xc0;
-                yc0 = -yc0;
-                zc0 = -zc0;
             }
 
             double curveArea = curve.Area();

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -116,13 +116,14 @@ namespace BH.Engine.Geometry
             }
 
 
-            //Get out normal, by cross product between the average of points and 
+            //Get out normal, by cross product between the average of points and first points of the curve
             Point avg = curve.ControlPoints.Average();
             Point pA = curve.ControlPoints[0];
 
             foreach (Point pt in curve.ControlPoints.Skip(1))
             {
                 Vector normal = CrossProduct(avg - pA, avg - pt);
+                //If normal is non-zero (if the first points are not on a line with the average point) use this as the normal
                 if (normal.SquareLength() > tolerance * tolerance)
                 {
                     normal = normal.Normalise();
@@ -197,6 +198,7 @@ namespace BH.Engine.Geometry
                 foreach (Point pt in points.Skip(1))
                 {
                     Vector normal = CrossProduct(avg - pA, avg - pt);
+                    //If normal is non-zero (if the first points are not on a line with the average point) use this as the normal
                     if (normal.SquareLength() > tolerance * tolerance)
                     {
                         normal = normal.Normalise();

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -117,24 +117,20 @@ namespace BH.Engine.Geometry
             }
 
 
-            //Get out normal, by cross product between the average of points and first points of the curve
             //Get out normal, from cross product of first points that are not colinear
-            Vector normal = Normal(curve.ControlPoints, tolerance);
+            Point avg = curve.ControlPoints.Average();
+            Vector normal = new Vector();
 
-            if (normal != null)
-            {
-                //Check if normal needs to be flipped from the right hand rule
-                if (!curve.IsClockwise(normal, tolerance))
-                    normal = -normal;
+            for (int i = 0; i < curve.ControlPoints.Count - 1; i++)
+                normal += (curve.ControlPoints[i] - avg).CrossProduct(curve.ControlPoints[i + 1] - avg);
 
-                return normal;
-            }
-            else
-            {
-                //No normal found
-                Engine.Reflection.Compute.RecordError("Could not find the Normal of the provided curve.");
-                return null;
-            }
+            normal = normal.Normalise();
+
+            //Check if normal needs to be flipped from the right hand rule
+            if (!curve.IsClockwise(normal, tolerance))
+                normal = -normal;
+
+            return normal;
 
         }
 
@@ -188,22 +184,19 @@ namespace BH.Engine.Geometry
                 }
 
                 //Get out normal, from cross product of first points that are not colinear
-                Vector normal = Normal(points, tolerance);
+                Point avg = points.Average();
+                Vector normal = new Vector();
 
-                if (normal != null)
-                {
-                    //Check if normal needs to be flipped from the right hand rule
-                    if (!curve.IsClockwise(normal, tolerance))
-                        normal = -normal;
+                for (int i = 0; i < points.Count - 1; i++)
+                    normal += (points[i] - avg).CrossProduct(points[i + 1] - avg);
 
-                    return normal;
-                }
-                else
-                {
-                    //No normal found
-                    Engine.Reflection.Compute.RecordError("Could not find the Normal of the provided curve.");
-                    return null;
-                }
+                normal = normal.Normalise();
+
+                //Check if normal needs to be flipped from the right hand rule
+                if (!curve.IsClockwise(normal, tolerance))
+                    normal = -normal;
+
+                return normal;
             }
         }
 
@@ -274,39 +267,6 @@ namespace BH.Engine.Geometry
         public static Vector INormal(this ICurve curve)
         {
             return Normal(curve as dynamic);
-        }
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
-
-        [Description("Private helper method used by Polyline and PolyCurve Normal methods. Extracting a normal based on the controlpoints of the curves. Assumes the incoming points to be planar.")]
-        private static Vector Normal(List<Point> points, double tolerance)
-        {
-            //Get out normal, from cross product of first points that are not colinear
-            Point avg = points.Average();
-            Point pA = points[0];
-
-            //If start and average points are equal, shift the list
-            if (pA.SquareDistance(avg) < tolerance * tolerance)
-            {
-                points = new List<Point>(points);
-                points.Add(points[0]);
-                points.RemoveAt(0);
-                pA = points[0];
-            }
-
-            foreach (Point pt in points.Skip(1))
-            {
-                Vector normal = CrossProduct(avg - pA, avg - pt);
-                //If normal is non-zero (if the first points are not on a line with the average point) use this as the normal
-                if (normal.SquareLength() > tolerance * tolerance)
-                {
-                    normal = normal.Normalise();
-                    return normal;
-                }
-            }
-            return null;
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -116,11 +116,10 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-
-            //Get out normal, from cross product of first points that are not colinear
             Point avg = curve.ControlPoints.Average();
             Vector normal = new Vector();
 
+            //Get out normal, from cross products between vectors from the average point to adjecent controlpoints on the curve
             for (int i = 0; i < curve.ControlPoints.Count - 1; i++)
                 normal += (curve.ControlPoints[i] - avg).CrossProduct(curve.ControlPoints[i + 1] - avg);
 
@@ -183,10 +182,11 @@ namespace BH.Engine.Geometry
                     }
                 }
 
-                //Get out normal, from cross product of first points that are not colinear
+                
                 Point avg = points.Average();
                 Vector normal = new Vector();
 
+                //Get out normal, from cross products between vectors from the average point to adjecent controlpoints on the curve
                 for (int i = 0; i < points.Count - 1; i++)
                     normal += (points[i] - avg).CrossProduct(points[i + 1] - avg);
 

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -117,10 +117,20 @@ namespace BH.Engine.Geometry
 
 
             //Get out normal, by cross product between the average of points and first points of the curve
-            Point avg = curve.ControlPoints.Average();
-            Point pA = curve.ControlPoints[0];
+            List<Point> points = curve.ControlPoints;
 
-            foreach (Point pt in curve.ControlPoints.Skip(1))
+            Point avg = points.Average();
+            Point pA = points[0];
+
+            if (pA.SquareDistance(avg) < tolerance * tolerance)
+            {
+                points = new List<Point>(points);
+                points.Add(points[0]);
+                points.RemoveAt(0);
+                pA = points[0];
+            }
+
+            foreach (Point pt in points.Skip(1))
             {
                 Vector normal = CrossProduct(avg - pA, avg - pt);
                 //If normal is non-zero (if the first points are not on a line with the average point) use this as the normal
@@ -194,6 +204,14 @@ namespace BH.Engine.Geometry
                 //Get out normal, from cross product of firt points that are not colinear
                 Point avg = points.Average();
                 Point pA = points[0];
+
+                if (pA.SquareDistance(avg) < tolerance * tolerance)
+                {
+                    points = new List<Point>(points);
+                    points.Add(points[0]);
+                    points.RemoveAt(0);
+                    pA = points[0];
+                }
 
                 foreach (Point pt in points.Skip(1))
                 {
@@ -286,6 +304,10 @@ namespace BH.Engine.Geometry
         {
             return Normal(curve as dynamic);
         }
+
+        /***************************************************/
+        /**** Public Methods - Interfaces               ****/
+        /***************************************************/
 
         /***************************************************/
     }

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -115,28 +115,30 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-            Vector normal = new Vector { X = 0, Y = 0, Z = 0 };
 
-            //Get out normal, from cross product of firt points that are not colinear
-            int i = 0;
-            do
+            //Get out normal, by cross product between the average of points and 
+            Point avg = curve.ControlPoints.Average();
+            Point pA = curve.ControlPoints[0];
+
+            foreach (Point pt in curve.ControlPoints.Skip(1))
             {
-                Point pA = curve.ControlPoints[i];
-                Point pB = curve.ControlPoints[(i + 1) % curve.ControlPoints.Count];
-                Point pC = curve.ControlPoints[(i + 2) % curve.ControlPoints.Count];
+                Vector normal = CrossProduct(avg - pA, avg - pt);
+                if (normal.SquareLength() > tolerance * tolerance)
+                {
+                    normal = normal.Normalise();
 
-                normal = CrossProduct(pB - pA, pC - pB);
-                i++;
+                    //Check if normal needs to be flipped from the right hand rule
+                    if (!curve.IsClockwise(normal, tolerance))
+                        normal = -normal;
 
-            } while (normal.SquareLength() < tolerance * tolerance && i < curve.ControlPoints.Count);
+                    return normal;
+                }
+            }
 
-            normal = normal.Normalise();
+            //No normal found
+            Engine.Reflection.Compute.RecordError("Could not find the Normal of the provided curve.");
+            return null;
 
-            //Check if normal needs to be flipped from the right hand rule
-            if (!curve.IsClockwise(normal, tolerance))
-                normal = -normal;
-
-            return normal;
         }
 
         /***************************************************/
@@ -188,28 +190,29 @@ namespace BH.Engine.Geometry
                     }
                 }
 
-                Vector normal = new Vector { X = 0, Y = 0, Z = 0 };
-
                 //Get out normal, from cross product of firt points that are not colinear
-                int i = 0;
-                do
+                Point avg = points.Average();
+                Point pA = points[0];
+
+                foreach (Point pt in points.Skip(1))
                 {
-                    Point pA = points[i];
-                    Point pB = points[(i + 1) % points.Count];
-                    Point pC = points[(i + 2) % points.Count];
+                    Vector normal = CrossProduct(avg - pA, avg - pt);
+                    if (normal.SquareLength() > tolerance * tolerance)
+                    {
+                        normal = normal.Normalise();
 
-                    normal = CrossProduct(pB - pA, pC - pB);
-                    i++;
+                        //Check if normal needs to be flipped from the right hand rule
+                        if (!curve.IsClockwise(normal, tolerance))
+                            normal = -normal;
 
-                } while (normal.SquareLength() < tolerance * tolerance && i < points.Count);
+                        return normal;
+                    }
+                }
 
-                normal = normal.Normalise();
-
-                //Check if normal needs to be flipped from the right hand rule
-                if (!curve.IsClockwise(normal, tolerance))
-                    normal = -normal;
-
-                return normal;
+                //No normal found
+                Engine.Reflection.Compute.RecordError("Could not find the Normal of the provided curve.");
+                return null;
+                
             }
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1896 

<!-- Add short description of what has been fixed -->

Fixes the Normal method, using average of points instead of just looking at the first. As IsClockwise is being called, the direction of the normal will be fixed there.

Simplifying the Centroid methods for Polyline and PolyCurve. Given that the normal is now checked, and ensured to be in the right direction, should be able to rely on that, and not have to preform the "first normal" checks and direction checks, which was the cause of the problem in the issue.

As this is changing some quite core methods, would like to see quite rigorous testing on methods making use of this. I have tried testing through multiple generic cases, and have so far not had any issues, but would be thankful if more edgecases could be thought of that could have the potential to go wrong.

### Test files
<!-- Link to test files to validate the proposed changes -->

Issue test:
https://burohappold.sharepoint.com/:f:/s/BHoM/EoVbTyb6WHpEoomPOjc9JVUBwCGfK-_zrBfzlIQkNTyJKg?e=VRsqVQ

Boolean methods test:
https://burohappold.sharepoint.com/:f:/s/BHoM/EqCVTBONrQ9Bs-kJ1b22-2EB2Q_opuba0IkcEnYBE81G1Q?e=PAogpj

Any offset tests

Also, @FraserGreenroyd , can you check that this does not affect your projects scripts in any negative way.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->