### PR TITLE
Reflection_Engine: List support for get set property

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -82,25 +82,10 @@ namespace BH.Engine.Reflection
                 prop.SetValue(obj, value);
                 return true;
             }
-            else if (obj is IBHoMObject)
+            else 
             {
-                IBHoMObject bhomObj = obj as IBHoMObject;
-                if (bhomObj == null) return false;
-
-                if (!bhomObj.CustomData.ContainsKey(propName))
-                    Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data");
-
-                bhomObj.CustomData[propName] = value;
-                return true;
+                return SetValue(obj as dynamic, propName, value);
             }
-            else if (obj is IDictionary)
-            {
-                IDictionary dic = obj as IDictionary;
-                dic[propName] = value;
-                return true;
-            }
-
-            return false;
         }
 
         /***************************************************/
@@ -142,6 +127,50 @@ namespace BH.Engine.Reflection
                 return true;
             }
 
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static bool SetValue(this IBHoMObject obj, string propName, object value)
+        {
+            if (obj == null) return false;
+
+            if (!obj.CustomData.ContainsKey(propName))
+                Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data");
+
+            obj.CustomData[propName] = value;
+            return true;
+        }
+
+        /***************************************************/
+
+        private static bool SetValue(this IDictionary dic, string propName, object value)
+        {
+            dic[propName] = value;
+            return true;
+        }
+
+        /***************************************************/
+
+        private static bool SetValue<T>(this IEnumerable<T> list, string propName, object value)
+        {
+            bool success = true;
+
+            foreach (T item in list)
+                success &= SetPropertyValue(item, propName, value);
+
+            return success;
+        }
+
+        /***************************************************/
+
+        private static bool SetValue(this object obj, string propName, object value)
+        {
+            Compute.RecordWarning("The objects does not contain any property with the name " + propName + ".");
+            return false;
         }
 
         /***************************************************/


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1905

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
![image](https://user-images.githubusercontent.com/16853390/88618187-05a72500-d0cb-11ea-9892-9337b526cdac.png)



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
I found out that there are a couple of annoying things happening when dealing with CustomObject exclusively:
- The output of GetProperty if the property is a `List<List<T>>` will not return a tree but a list of `List<T>` objects. 
- It is not possible to Set a list as property of a custom object. 

Those two are a UI issue: the UI considers that the property of a custom object is always an object (CustomData is after all a `Dictionary<string, object>`) so will return a list as a single object and will always expect a single object as input. 

I am currently refactoring completely the UI and the problem will be solved there. In the meantime, I have raised an issue here: https://github.com/BHoM/BHoM_UI/issues/296