### PR TITLE
Composite ShapeProfiles - supporting bidirectional offsets

### DIFF
--- a/Geometry_Engine/Create/ShapeProfile.cs
+++ b/Geometry_Engine/Create/ShapeProfile.cs
@@ -109,17 +109,17 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-            if (Math.Sqrt(2) * thickness <= Math.Sqrt(2) * outerRadius - outerRadius - Math.Sqrt(2) * innerRadius + innerRadius)
-            {
-                InvalidRatioError("thickness", "outerRadius and innerRadius");
-                return null;
-            }
+            //if (Math.Sqrt(2) * thickness <= Math.Sqrt(2) * outerRadius - outerRadius - Math.Sqrt(2) * innerRadius + innerRadius)
+            //{
+            //    InvalidRatioError("thickness", "outerRadius and innerRadius");
+            //    return null;
+            //}
 
-            if (height <= 0 || width <= 0 || thickness <= 0 || outerRadius < 0 || innerRadius < 0)
-            {
-                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
-                return null;
-            }
+            //if (height <= 0 || width <= 0 || thickness <= 0 || outerRadius < 0 || innerRadius < 0)
+            //{
+            //    Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+            //    return null;
+            //}
 
             List<ICurve> curves = BoxProfileCurves(width, height, thickness, thickness, innerRadius, outerRadius);
             return new BoxProfile(height, width, thickness, outerRadius, innerRadius, curves);
@@ -542,11 +542,11 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-            if (diameter <= 0 || thickness <= 0)
-            {
-                Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
-                return null;
-            }
+            //if (diameter <= 0 || thickness <= 0)
+            //{
+            //    Engine.Reflection.Compute.RecordError("Input length less or equal to 0");
+            //    return null;
+            //}
 
             List<ICurve> curves = TubeProfileCurves(diameter / 2, thickness);
             return new TubeProfile(diameter, thickness, curves);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1909 

<!-- Add short description of what has been fixed -->
Commented two error catches for BoxProfile and one for TubeProfile as these two are current test cases that will be immediately useful for MEP_oM. Removing these allows for multi-directional offsets, which I imaging could introduce conflicts to other toolkits + workflows. 

I'd like to simply start the discussion for how to best handles the concept of composite sections.

### Test files
<!-- Link to test files to validate the proposed changes -->
Requires the following branches from both BHoM and BHoM Engine: ```MEP_oM-#952-Object-Creation```

https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/MEP_oM/200728_MEP_oM%20Testing.gh?csf=1&web=1&e=1rmXkx

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

![CompositeSectionProfiles](https://user-images.githubusercontent.com/54593392/89188554-d4b46d80-d56c-11ea-918b-e8ecc7f45bab.gif)
