### PR TITLE
Geometry_Engine: Add Centroid method for outline curves(s) with opening curve(s) in it.

### DIFF
--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -123,7 +123,6 @@ namespace BH.Engine.Geometry
 
             for (int i = 1; i < curve.ControlPoints.Count - 2; i++)
             {
-
                 Point pB = curve.ControlPoints[i];
                 Point pC = curve.ControlPoints[i + 1];
 
@@ -150,7 +149,6 @@ namespace BH.Engine.Geometry
             zc = zc0 / curveArea;
 
             return new Point { X = xc, Y = yc, Z = zc };
-
         }
 
         /***************************************************/
@@ -264,7 +262,6 @@ namespace BH.Engine.Geometry
             zc = zc0 / curveArea;
 
             return new Point { X = xc, Y = yc, Z = zc };
-
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.Geometry
 
         //TODO: Remove when PlanarSurface will implement IElement2D
         [Description("Queries the centre of area for a PlanarSurface.")]
-        [Input("planar surface", "The PlanarSurface to get the centre of area of.")]
+        [Input("surface", "The PlanarSurface to get the centre of area of.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given PlanarSurface.")]
         public static Point Centroid(this PlanarSurface surface, double tolerance = Tolerance.Distance)
@@ -53,11 +53,11 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves lists             ****/
         /***************************************************/
 
-        [Description("Queries the combined centre of area of a set of ICurves with an optional set of openings.\nTo give a correct result all input curves must be planar, coplanar, closed and non-self-intersecting.\nOpening curves should also be inside of outline curves.")]
+        [Description("Queries the combined centre of area enclosed by a set of ICurves with an optional set of openings.\nTo give a correct result all input curves must be planar, coplanar, closed and non-self-intersecting.\nOpening curves should also be inside of outline curves.")]
         [Input("outlines", "Set of planar, coplanar, closed and non-self-intersecting ICurves to get the combined centre of area of.")]
         [Input("openings", "Set of planar, coplanar, closed and non-self-intersecting ICurves illustrating openings in initial set of outlines.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
-        [Output("centroid", "The Point at the centre of given PlanarSurface.")]
+        [Output("centroid", "The Point at the centre of given geometry.")]
         public static Point Centroid(this IEnumerable<ICurve> outlines, IEnumerable<ICurve> openings = null, double tolerance = Tolerance.Distance)
         {
             Point centroid = new Point();
@@ -88,10 +88,10 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
-        [Description("Queries the centre of area for a closed, planar, non-self-intersecting Polyline.")]
+        [Description("Queries the centre of area enclosed by a closed, planar, non-self-intersecting Polyline.")]
         [Input("curve", "The Polyline to get the centre of area of.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
-        [Output("centroid", "The Point at the centre of given Polyline.")]
+        [Output("centroid", "The Point at the centre of a region enclosed by given Polyline.")]
         public static Point Centroid(this Polyline curve, double tolerance = Tolerance.Distance)
         {
             if (!curve.IsPlanar(tolerance))
@@ -153,10 +153,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [Description("Queries the centre of area for a closed, planar, non-self-intersecting PolyCurve.")]
+        [Description("Queries the centre of area enclosed by a closed, planar, non-self-intersecting PolyCurve.")]
         [Input("curve", "The PolyCurve to get the centre of area of.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
-        [Output("centroid", "The Point at the centre of given Polyline.")]
+        [Output("centroid", "The Point at the centre of area enclosed by given Polyline.")]
         public static Point Centroid(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
             if (!curve.IsPlanar(tolerance))

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Geometry
         //TODO: Remove when PlanarSurface will implement IElement2D
         [Description("Queries the centre of area for a PlanarSurface.")]
         [Input("surface", "The PlanarSurface to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given PlanarSurface.")]
         public static Point Centroid(this PlanarSurface surface, double tolerance = Tolerance.Distance)
         {
@@ -56,10 +56,12 @@ namespace BH.Engine.Geometry
         [Description("Queries the combined centre of area enclosed by a set of ICurves with an optional set of openings.\nTo give a correct result all input curves must be planar, coplanar, closed and non-self-intersecting.\nOpening curves should also be inside of outline curves.")]
         [Input("outlines", "Set of planar, coplanar, closed and non-self-intersecting ICurves to get the combined centre of area of.")]
         [Input("openings", "Set of planar, coplanar, closed and non-self-intersecting ICurves illustrating openings in initial set of outlines.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given geometry.")]
         public static Point Centroid(this IEnumerable<ICurve> outlines, IEnumerable<ICurve> openings = null, double tolerance = Tolerance.Distance)
         {
+            openings = openings ?? new List<ICurve>();
+
             Point centroid = new Point();
             double area = 0;
 
@@ -90,7 +92,7 @@ namespace BH.Engine.Geometry
 
         [Description("Queries the centre of area enclosed by a closed, planar, non-self-intersecting Polyline.")]
         [Input("curve", "The Polyline to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of a region enclosed by given Polyline.")]
         public static Point Centroid(this Polyline curve, double tolerance = Tolerance.Distance)
         {
@@ -155,7 +157,7 @@ namespace BH.Engine.Geometry
 
         [Description("Queries the centre of area enclosed by a closed, planar, non-self-intersecting PolyCurve.")]
         [Input("curve", "The PolyCurve to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of area enclosed by given PolyCurve.")]
         public static Point Centroid(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
@@ -268,7 +270,7 @@ namespace BH.Engine.Geometry
 
         [Description("Queries the centre of area for an Ellipse.")]
         [Input("ellipse", "The Ellipse to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given Ellipse.")]
         public static Point Centroid(this Ellipse ellipse, double tolerance = Tolerance.Distance)
         {
@@ -279,7 +281,7 @@ namespace BH.Engine.Geometry
 
         [Description("Queries the centre of area for a Circle.")]
         [Input("circle", "The Circle to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given Circle.")]
         public static Point Centroid(this Circle circle, double tolerance = Tolerance.Distance)
         {
@@ -290,7 +292,7 @@ namespace BH.Engine.Geometry
 
         [Description("Queries the centre of area for a Line.")]
         [Input("line", "The Line to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given Line.")]
         public static Point Centroid(this Line line, double tolerance = Tolerance.Distance)
         {
@@ -304,7 +306,7 @@ namespace BH.Engine.Geometry
 
         [Description("Interface method that queries the centre of area for any ICurve.")]
         [Input("curve", "The ICurve to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given ICurve.")]
         public static Point ICentroid(this ICurve curve, double tolerance = Tolerance.Distance)
         {

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -53,27 +53,24 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves lists             ****/
         /***************************************************/
 
-        [Description("Qieries the combined centre of area of a set of ICurves with optional set of openings.\nTo give a correct result all input curves must be planar, coplanar, closed and non-self-intersecting.\nOpening curves should also be inside outline curves.")]
+        [Description("Queries the combined centre of area of a set of ICurves with an optional set of openings.\nTo give a correct result all input curves must be planar, coplanar, closed and non-self-intersecting.\nOpening curves should also be inside of outline curves.")]
         [Input("outlines", "Set of planar, coplanar, closed and non-self-intersecting ICurves to get the combined centre of area of.")]
-        [Input("openings", "Set of planar, coplanar, closed and non-self-intersecting ICurves ilustrating openings in initial set of outlines.")]
+        [Input("openings", "Set of planar, coplanar, closed and non-self-intersecting ICurves illustrating openings in initial set of outlines.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given PlanarSurface.")]
         public static Point Centroid(this IEnumerable<ICurve> outlines, IEnumerable<ICurve> openings = null, double tolerance = Tolerance.Distance)
         {
-            outlines = outlines.BooleanUnion(tolerance);
-            openings = openings.BooleanUnion(tolerance);
-
             Point centroid = new Point();
             double area = 0;
 
-            foreach (ICurve outline in outlines)
+            foreach (ICurve outline in outlines.BooleanUnion(tolerance))
             {
                 double outlineArea = outline.IArea();
                 centroid += (outline.ICentroid() * outlineArea);
                 area += outlineArea;
             }
 
-            foreach (ICurve opening in openings)
+            foreach (ICurve opening in openings.BooleanUnion(tolerance))
             {
                 Point openingCentroid = opening.ICentroid();
                 double openingArea = opening.IArea();

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -156,7 +156,7 @@ namespace BH.Engine.Geometry
         [Description("Queries the centre of area enclosed by a closed, planar, non-self-intersecting PolyCurve.")]
         [Input("curve", "The PolyCurve to get the centre of area of.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
-        [Output("centroid", "The Point at the centre of area enclosed by given Polyline.")]
+        [Output("centroid", "The Point at the centre of area enclosed by given PolyCurve.")]
         public static Point Centroid(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
             if (!curve.IsPlanar(tolerance))
@@ -303,7 +303,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Interface method that queries the centre of area for any ICurve.")]
-        [Input("iCurve", "The ICurve to get the centre of area of.")]
+        [Input("curve", "The ICurve to get the centre of area of.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given ICurve.")]
         public static Point ICentroid(this ICurve curve, double tolerance = Tolerance.Distance)

--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -89,7 +89,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Queries the centre of area for a closed, planar, non-self-intersecting Polyline.")]
-        [Input("polyline", "The Polyline to get the centre of area of.")]
+        [Input("curve", "The Polyline to get the centre of area of.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given Polyline.")]
         public static Point Centroid(this Polyline curve, double tolerance = Tolerance.Distance)
@@ -154,7 +154,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Queries the centre of area for a closed, planar, non-self-intersecting PolyCurve.")]
-        [Input("polyCurve", "The PolyCurve to get the centre of area of.")]
+        [Input("curve", "The PolyCurve to get the centre of area of.")]
         [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of given Polyline.")]
         public static Point Centroid(this PolyCurve curve, double tolerance = Tolerance.Distance)

--- a/Spatial_Engine/Query/Centroid.cs
+++ b/Spatial_Engine/Query/Centroid.cs
@@ -54,11 +54,11 @@ namespace BH.Engine.Spatial
         [PreviousVersion("3.3", "BH.Engine.Spatial.Query.Centroid(BH.oM.Dimensional.IElement2D)")]
         [Description("Queries the centre of area for a IElement2Ds surface representation. For an IElement2D with homogeneous material and thickness this will also be the centre of weight.")]
         [Input("element2D", "The IElement2D with the geometry to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of area for the homogeneous geometrical representation of the IElement2D.")]
         public static Point Centroid(this IElement2D element2D, double tolerance = Tolerance.Distance)
         {
-            return Geometry.Query.Centroid(new List<ICurve> { element2D.OutlineCurve() }, element2D.InternalOutlineCurves(), tolerance);
+            return Geometry.Query.Centroid(new List<ICurve> { element2D.OutlineCurve() });//, element2D.InternalOutlineCurves(), tolerance);
         }
 
         /******************************************/

--- a/Spatial_Engine/Query/Centroid.cs
+++ b/Spatial_Engine/Query/Centroid.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Spatial
         [Output("centroid", "The Point at the centre of area for the homogeneous geometrical representation of the IElement2D.")]
         public static Point Centroid(this IElement2D element2D, double tolerance = Tolerance.Distance)
         {
-            return Geometry.Query.Centroid(new List<ICurve> { element2D.OutlineCurve() });//, element2D.InternalOutlineCurves(), tolerance);
+            return Geometry.Query.Centroid(new List<ICurve> { element2D.OutlineCurve() }, element2D.InternalOutlineCurves(), tolerance);
         }
 
         /******************************************/

--- a/Spatial_Engine/Query/Centroid.cs
+++ b/Spatial_Engine/Query/Centroid.cs
@@ -61,21 +61,6 @@ namespace BH.Engine.Spatial
             return Geometry.Query.Centroid(new List<ICurve> { element2D.OutlineCurve() }, element2D.InternalOutlineCurves(), tolerance);
         }
 
-
-        /******************************************/
-        /****             IProfile             ****/
-        /******************************************/
-
-        //TODO: Before merging: create a method to query outer and inner curves or remove.
-        [Description("Queries the centre of area for a IProfile surface representation. For an IProfile with homogeneous material and thickness this will also be the centre of weight.")]
-        [Input("profile", "The IProfile with the geometry to get the centre of area of.")]
-        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
-        [Output("centroid", "The Point at the centre of area for the homogeneous geometrical representation of the IProfile.")]
-        public static Point Centroid(this IProfile profile, double tolerance = Tolerance.Distance)
-        {
-            return Geometry.Query.Centroid(profile.Edges, new List<ICurve>(), tolerance);
-        }
-
         /******************************************/
     }
 }

--- a/Spatial_Engine/Query/Centroid.cs
+++ b/Spatial_Engine/Query/Centroid.cs
@@ -20,9 +20,9 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Geometry;
 using BH.oM.Dimensional;
 using BH.oM.Geometry;
+using BH.oM.Geometry.ShapeProfiles;
 using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
@@ -51,32 +51,29 @@ namespace BH.Engine.Spatial
         /****            IElement2D            ****/
         /******************************************/
 
+        [PreviousVersion("3.3", "BH.Engine.Spatial.Query.Centroid(BH.oM.Dimensional.IElement2D)")]
         [Description("Queries the centre of area for a IElement2Ds surface representation. For an IElement2D with homogeneous material and thickness this will also be the centre of weight.")]
         [Input("element2D", "The IElement2D with the geometry to get the centre of area of.")]
+        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of area for the homogeneous geometrical representation of the IElement2D.")]
-        public static Point Centroid(this IElement2D element2D)
+        public static Point Centroid(this IElement2D element2D, double tolerance = Tolerance.Distance)
         {
-            Point tmp = Geometry.Query.Centroid(element2D.OutlineCurve());
-            double area = Geometry.Query.Area(element2D.OutlineCurve());
-
-            double x = tmp.X * area;
-            double y = tmp.Y * area;
-            double z = tmp.Z * area;
+            return Geometry.Query.Centroid(new List<ICurve> { element2D.OutlineCurve() }, element2D.InternalOutlineCurves(), tolerance);
+        }
 
 
-            List<PolyCurve> openings = Geometry.Compute.BooleanUnion(element2D.InternalOutlineCurves());
+        /******************************************/
+        /****             IProfile             ****/
+        /******************************************/
 
-            foreach (ICurve o in openings)
-            {
-                Point oTmp = Geometry.Query.ICentroid(o);
-                double oArea = o.IArea();
-                x -= oTmp.X * oArea;
-                y -= oTmp.Y * oArea;
-                z -= oTmp.Z * oArea;
-                area -= oArea;
-            }
-            
-            return new Point { X = x / area, Y = y / area, Z = z / area };
+        //TODO: Before merging: create a method to query outer and inner curves or remove.
+        [Description("Queries the centre of area for a IProfile surface representation. For an IProfile with homogeneous material and thickness this will also be the centre of weight.")]
+        [Input("profile", "The IProfile with the geometry to get the centre of area of.")]
+        [Input("tolerance", "Distance tolerance, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Output("centroid", "The Point at the centre of area for the homogeneous geometrical representation of the IProfile.")]
+        public static Point Centroid(this IProfile profile, double tolerance = Tolerance.Distance)
+        {
+            return Geometry.Query.Centroid(profile.Edges, new List<ICurve>(), tolerance);
         }
 
         /******************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1705 

<!-- Add short description of what has been fixed -->
<s>Work in progress. Draft version of dealing with redundant code while querying centroids of planar shapes with openings.
Details in the parent issue.</s>
Adding a `Geometry_Engine` method querying a combine centroid of any set of planar, coplanar, non-self-intersecting and closed curves with optional openings. Method itself is rather not meant to be widely used due to lack of checks. Needed to be public for being used in other methods for objects like `IElement2D` or `IProfile`

### Test files
<!-- Link to test files to validate the proposed changes -->
[Old test file](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2DIssue%231705%20Centroid%20from%20outline%20curves%28s%29%20with%20opening%20curve%28s%29%20in%20it)
[Geometry_Engine](https://burohappold.sharepoint.com/:f:/s/BHoM/Esd2eZj9Hc1Mkh5tar8m-NsBlIxJtyJ40zXatKwF4D3uOQ?e=2pvfb9) - general test for Centroid
[Spatial_Engine](https://burohappold.sharepoint.com/:f:/s/BHoM/EjAN0bkxublBirJzGJFTg8YBZXjfLC81kOPcpnTBXe_8vA?e=T7Xmj1) - general test for Centroid


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added new `Centroid(this IEnumerable<ICurve> outlines, IEnumerable<ICurve> openings)` method in the `Geometry_Engine`.
- Added new `Centroid(PlanarSurface)` method in the `Geometry_Engine`.
- Updated `Centroid(IElement2D)` method in the `Spatial_Engine` to use new method from the `Geometry_Engine` and take tolerance as an input.
- Added descriptions for `Centroid()` methods.

### Additional comments
<!-- As required -->
- `[PreviousVersion]` attribute has been used to update `Centroid(IElement2D)` inputs so rebuilding Versioning_Toolkit is needed for scripts using outdated methods to work.
- Centroid method for `IProfie` interface will be implemented separately as soon as #1986 will get resolved.