### PR TITLE
Data_Engine: Uncommenting code for getting all values from a Table

### DIFF
--- a/Data_Engine/Query/Values.cs
+++ b/Data_Engine/Query/Values.cs
@@ -42,7 +42,7 @@ namespace BH.Engine.Data
         [Output("Data", "All data in the table as CustomObjects.")]
         public static List<CustomObject> Values(this Table table)
         {
-            return null; // AsCustomObjects(table.Data.Select(), table.Data.Columns);
+            return AsCustomObjects(table.Data.Select(), table.Data.Columns);
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1920

<!-- Add short description of what has been fixed -->

Uncommenting out the code for getting out all values from a table.

This was commented out in https://github.com/BHoM/BHoM_Engine/pull/1833 which did not have anything to do with the tables.

@rolyhudson would you mind testing that the spatial trees are unaffected by this?

### Test files
<!-- Link to test files to validate the proposed changes -->

Testfiles from PR where this was commented out:

https://burohappold.sharepoint.com/:u:/s/BHoM/EaZM91qyXmVAo4ddZrneV6wB_1m8DlJ-Eq_PbDIsAlHoSQ?e=hxg7KS

And a more lightweight version:
https://burohappold.sharepoint.com/:u:/s/BHoM/Ec3OChqs5IpAvnWqCFjkTm4BJP_IaX6Z52Fg7R4BTgzHXw?e=yaG3zj


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->