### PR TITLE
Structure_Engine: Renamed master/slave to primary/secondary

### DIFF
--- a/Structure_Engine/Create/Constraints/LinkConstraint.cs
+++ b/Structure_Engine/Create/Constraints/LinkConstraint.cs
@@ -63,7 +63,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
         
-        [Description("Creates a LinkConstraint where all directions are linked, rotations at slave nodes are linked to rotations of masters.")]
+        [Description("Creates a LinkConstraint where all directions are linked, rotations at secondary nodes are linked to rotations of the primary.")]
         [Input("name", "Name of the created LinkConstraint. Defaults to 'Fixed'. This is required for various structural packages to create the object.")]
         [Output("linkConstraint", "The created LinkConstraint.")]
         public static LinkConstraint LinkConstraintFixed(string name = "Fixed")
@@ -88,7 +88,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Creates a LinkConstraint where all directions are linked, but the rotations of the slave nodes are not linked to the master.")]
+        [Description("Creates a LinkConstraint where all directions are linked, but the rotations of the secondary nodes are not linked to the primary.")]
         [Input("name", "Name of the created LinkConstraint. Defaults to 'Pinned'. This is required for various structural packages to create the object.")]
         [Output("linkConstraint", "The created LinkConstraint.")]
         public static LinkConstraint LinkConstraintPinned(string name = "Pinned")
@@ -158,7 +158,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Creates a LinkConstraint where the directions are linked to give rigidity in the xy-plane, but the rotations of the slave nodes are not linked to the master, and there is no constraint out of plane.")]
+        [Description("Creates a LinkConstraint where the directions are linked to give rigidity in the xy-plane, but the rotations of the secondary nodes are not linked to the primary, and there is no constraint out of plane.")]
         [Input("name", "Name of the created LinkConstraint. Defaults to 'xy-Plane Pin'. This is required for various structural packages to create the object.")]
         [Output("linkConstraint", "The created LinkConstraint.")]
         public static LinkConstraint LinkConstraintXYPlanePin(string name = "xy-Plane Pin")
@@ -174,7 +174,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Creates a LinkConstraint where the directions are linked to give rigidity in the yz-plane, but the rotations of the slave nodes are not linked to the master, and there is no constraint out of plane.")]
+        [Description("Creates a LinkConstraint where the directions are linked to give rigidity in the yz-plane, but the rotations of the secondary nodes are not linked to the primary, and there is no constraint out of plane.")]
         [Input("name", "Name of the created LinkConstraint. Defaults to 'yz-Plane Pin'. This is required for various structural packages to create the object.")]
         [Output("linkConstraint", "The created LinkConstraint.")]
         public static LinkConstraint LinkConstraintYZPlanePin(string name = "yz-Plane Pin")
@@ -190,7 +190,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Creates a LinkConstraint where the directions are linked to give rigidity in the zx-plane, but the rotations of the slave nodes are not linked to the master, and there is no constraint out of plane.")]
+        [Description("Creates a LinkConstraint where the directions are linked to give rigidity in the zx-plane, but the rotations of the secondary nodes are not linked to the primary, and there is no constraint out of plane.")]
         [Input("name", "Name of the created LinkConstraint. Defaults to 'zx-Plane Pin'. This is required for various structural packages to create the object.")]
         [Output("linkConstraint", "The created LinkConstraint.")]
         public static LinkConstraint LinkConstraintZXPlanePin(string name = "zx-Plane Pin")

--- a/Structure_Engine/Create/Elements/RigidLink.cs
+++ b/Structure_Engine/Create/Elements/RigidLink.cs
@@ -53,11 +53,6 @@ namespace BH.Engine.Structure
 
         }
 
-        [Deprecated("2.4", "Method replace with method to accept name input", null, "RigidLink")]
-        public static RigidLink RigidLink(Node masterNode, IEnumerable<Node> slaveNodes, LinkConstraint constraint = null)
-        {
-            return Engine.Structure.Create.RigidLink(masterNode, slaveNodes, constraint, "");
-        }
 
         /***************************************************/
     }

--- a/Structure_Engine/Create/Elements/RigidLink.cs
+++ b/Structure_Engine/Create/Elements/RigidLink.cs
@@ -46,8 +46,8 @@ namespace BH.Engine.Structure
             return new RigidLink
             {
                 Name = name,
-                MasterNode = masterNode,
-                SlaveNodes = slaveNodes.ToList(),
+                PrimaryNode = masterNode,
+                SecondaryNodes = slaveNodes.ToList(),
                 Constraint = constraint == null ? LinkConstraintFixed() : constraint
             };
 

--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -118,16 +118,16 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Gets the geometry of a RigidLink as a list of lines between the master node and the slave nodes. Method required for automatic display in UI packages.")]
+        [Description("Gets the geometry of a RigidLink as a list of lines between the primary node and the secondary nodes. Method required for automatic display in UI packages.")]
         [Input("link", "RigidLink to get the line geometry from.")]
-        [Output("lines", "The geometry of the RigidLink as a list of master-slave lines.")]
+        [Output("lines", "The geometry of the RigidLink as a list of primary-secondary lines.")]
         public static IGeometry Geometry(this RigidLink link)
         {
             List<IGeometry> lines = new List<IGeometry>();
 
-            foreach (Node sn in link.SlaveNodes)
+            foreach (Node sn in link.SecondaryNodes)
             {
-                lines.Add(new Line() { Start = link.MasterNode.Position, End = sn.Position });
+                lines.Add(new Line() { Start = link.PrimaryNode.Position, End = sn.Position });
             }
             return new CompositeGeometry() { Elements = lines };
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
/BHoM/BHoM/pull/961
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/Structure_oM/Issue921-RigidLink%20property%20rename/Test%20Rigid%20Links%20-%20multi%20adapter.gh?csf=1&web=1&e=iDXtGs

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->