### PR TITLE
Geometry_Engine: Add MarchingSquares & MarchingCubes

### DIFF
--- a/Geometry_Engine/Compute/MarchingCubes.cs
+++ b/Geometry_Engine/Compute/MarchingCubes.cs
@@ -66,11 +66,10 @@ namespace BH.Engine.Geometry
             foreach (List<Face> cell in mesh3d.Cells())
             {
                 // Create a mesh from the cell
-                List<double> tVertexVal = new List<double>(vertexValues);
-                Mesh mesh = SubMesh(meshVersion, cell, ref tVertexVal);
+                var meshAndValues = SubMesh(meshVersion, cell, vertexValues);
 
                 // Find the iso lines for the boundary of the cell
-                List<List<Polyline>> pLines = MarchingSquares(mesh, tVertexVal, isoValues).Select(x => x.Join()).ToList();
+                List<List<Polyline>> pLines = MarchingSquares(meshAndValues.Item1, meshAndValues.Item2, isoValues).Select(x => x.Join()).ToList();
 
                 // Create faces from the polyline
                 // Note that each vertex may be added twice here from neighboring cells

--- a/Geometry_Engine/Compute/MarchingCubes.cs
+++ b/Geometry_Engine/Compute/MarchingCubes.cs
@@ -47,6 +47,7 @@ namespace BH.Engine.Geometry
                 Reflection.Compute.RecordError("Number of vertexValues must match the number of vertices in the mesh.");
                 return new List<Mesh>();
             }
+
             if (isoValues == null)
                 return new List<Mesh>();
 

--- a/Geometry_Engine/Compute/MarchingCubes.cs
+++ b/Geometry_Engine/Compute/MarchingCubes.cs
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****   Public Methods                          ****/
+        /***************************************************/
+
+        [Description("Computes the contour meshes for the iso-values in the scalar field defined by the mesh and the values. \n" +
+                     "The values are assumed to change linearly between vertices.")]
+        [Input("mesh3d", "Mesh which defines the positions of the values in the scalar field.")]
+        [Input("vertexValues", "Value for of scalar field for each vertex in the mesh.")]
+        [Input("isoValues", "Values in the scalar field to produce the iso-meshes for.")]
+        [Output("isoMeshes", "Meshes on the iso-values of the scalar field defined by the mesh and values.")]
+        public static List<Mesh> MarchingCubes(this Mesh3D mesh3d, List<double> vertexValues, List<double> isoValues)
+        {
+            if (mesh3d?.Vertices == null || vertexValues == null || mesh3d.Vertices.Count != vertexValues.Count)
+            {
+                Reflection.Compute.RecordError("Number of vertexValues must match the number of vertices in the mesh.");
+                return new List<Mesh>();
+            }
+            if (isoValues == null)
+                return new List<Mesh>();
+
+            // add empty lists
+            List<List<Point>> vertices = new List<List<Point>>();
+            List<List<Face>> faces = new List<List<Face>>();
+            for (int i = 0; i < isoValues.Count; i++)
+            {
+                vertices.Add(new List<Point>());
+                faces.Add(new List<Face>());
+            }
+
+            // SubMesh works on regular meshes, and since we're looking at it one cell at a time, the extra information in the mesh3d is not needed
+            Mesh meshVersion = mesh3d.ToMesh();
+            // Look at every cell
+            foreach (List<Face> cell in mesh3d.Cells())
+            {
+                // Create a mesh from the cell
+                List<double> tVertexVal = new List<double>(vertexValues);
+                Mesh mesh = SubMesh(meshVersion, cell, ref tVertexVal);
+
+                // Find the iso lines for the boundary of the cell
+                List<List<Polyline>> pLines = MarchingSquares(mesh, tVertexVal, isoValues).Select(x => x.Join()).ToList();
+
+                // Create faces from the polyline
+                // Note that each vertex may be added twice here from neighboring cells
+                for (int j = 0; j < isoValues.Count; j++)
+                {
+                    foreach (Polyline polyline in pLines[j])
+                    {
+                        vertices[j].AddRange(polyline.ControlPoints.Skip(1));
+                        int nPts = vertices[j].Count;
+
+                        int first = polyline.ControlPoints.Count - 1;
+                        // A rough triangulation of the imagined face covering the polyline, (assumes convex polyline)
+                        for (int i = 1; i < first - 1; i++)
+                        {
+                            faces[j].Add(new Face()
+                            {
+                                A = nPts - first,
+                                B = nPts - (i + 1),
+                                C = nPts - i,
+                            });
+                        }
+
+                    }
+                }
+            }
+
+            return vertices.Zip(faces, (v, f) => new Mesh()
+            {
+                Vertices = v,
+                Faces = f,
+            }).ToList();
+        }
+
+        /***************************************************/
+
+    }
+}
+

--- a/Geometry_Engine/Compute/MarchingSquares.cs
+++ b/Geometry_Engine/Compute/MarchingSquares.cs
@@ -1,0 +1,155 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Data;
+using BH.oM.Data.Collections;
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****   Public Methods                          ****/
+        /***************************************************/
+
+        [Description("Computes contour lines of the iso-values in the scalar field defined by the mesh and the values. \n" +
+                     "The values are assumed to change linearly between vertices.")]
+        [Input("mesh3d", "Mesh which defines the positions of the values in the scalar field.")]
+        [Input("vertexValues", "The value for of scalar field for each vertex in the mesh.")]
+        [Input("isoValues", "Values in the scalar field to produce the iso-lines for.")]
+        [Output("isoLines", "Lines covering the iso-values in the scalar field defined by the mesh and values.")]
+        public static List<List<Line>> MarchingSquares(this Mesh mesh, List<double> vertexValues, List<double> isoValues)
+        {
+            if (mesh?.Vertices == null || vertexValues == null || mesh.Vertices.Count != vertexValues.Count)
+            {
+                Reflection.Compute.RecordError("Number of vertexValues must match the number of vertices in the mesh.");
+                return new List<List<Line>>();
+            }
+            if (isoValues == null)
+                return new List<List<Line>>();
+
+            List<List<Line>> results = new List<List<Line>>();
+            for (int i = 0; i < isoValues.Count; i++)
+                results.Add(new List<Line>());
+
+            // Look at every face
+            foreach (Face face in mesh.Faces)
+            {
+                // go around its edges and create lines between the intermediate points
+                Point[] prePoint = new Point[isoValues.Count];
+                int[] indexArray = face.ToArray();
+                for (int i = 0; i < indexArray.Length; i++)
+                {
+                    int indJ = indexArray[(i + 1) % indexArray.Length];
+                    int indI = indexArray[i];
+
+                    // get points on face edge at the iso value
+                    List<Point> pts = IntermidiatePoints(
+                        mesh.Vertices[indI], vertexValues[indI],
+                        mesh.Vertices[indJ], vertexValues[indJ],
+                        isoValues);
+
+                    // Check if there were a result for each iso value
+                    for (int k = 0; k < pts.Count; k++)
+                    {
+                        Point pt = pts[k];
+
+                        if (pt == null)
+                            continue;
+
+                        // As a Faces edges are a closed loop, there will always be an even number of results.
+                        if (prePoint[k] == null)
+                            prePoint[k] = pt;
+                        else
+                        {
+                            results[k].Add(new Line()
+                            {
+                                Start = prePoint[k].Clone(),
+                                End = pt,
+                            });
+                            prePoint[k] = null;
+                        }
+                    }
+                }
+            }
+
+            return results;
+        }
+
+
+        /***************************************************/
+        /****   Private Methods                         ****/
+        /***************************************************/
+
+        private static List<Point> IntermidiatePoints(Point firstPt, double fisrtValue, Point secondPt, double secondValue, List<double> evaluationValues)
+        {
+            Domain domain = Data.Create.Domain(fisrtValue, secondValue);
+            double distance = domain.Max - domain.Min;
+            List<Point> results = new List<Point>();
+
+            foreach (double eVal in evaluationValues)
+            {
+                if (!domain.IsInRange(eVal))
+                {
+                    results.Add(null);
+                    continue;
+                }
+
+                double d = Math.Abs(eVal - fisrtValue);
+                double factor = d / distance;
+
+                results.Add(firstPt + (secondPt - firstPt) * factor);
+            }
+
+            return results;
+        }
+
+        /***************************************************/
+
+        private static int[] ToArray(this Face face)
+        {
+            if (face.IsQuad())
+            {
+                return new int[]
+                {
+                    face.A, face.B, face.C, face.D
+                };
+            }
+            else
+            {
+                return new int[]
+                {
+                    face.A, face.B, face.C
+                };
+            }
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Geometry_Engine/Compute/MarchingSquares.cs
+++ b/Geometry_Engine/Compute/MarchingSquares.cs
@@ -63,7 +63,7 @@ namespace BH.Engine.Geometry
             {
                 // go around its edges and create lines between the intermediate points
                 Point[] prePoint = new Point[isoValues.Count];
-                int[] indexArray = face.ToArray();
+                int[] indexArray = face.Vertices();
                 for (int i = 0; i < indexArray.Length; i++)
                 {
                     int indJ = indexArray[(i + 1) % indexArray.Length];
@@ -90,7 +90,7 @@ namespace BH.Engine.Geometry
                         {
                             results[k].Add(new Line()
                             {
-                                Start = prePoint[k].Clone(),
+                                Start = prePoint[k],
                                 End = pt,
                             });
                             prePoint[k] = null;
@@ -132,25 +132,6 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        private static int[] ToArray(this Face face)
-        {
-            if (face.IsQuad())
-            {
-                return new int[]
-                {
-                    face.A, face.B, face.C, face.D
-                };
-            }
-            else
-            {
-                return new int[]
-                {
-                    face.A, face.B, face.C
-                };
-            }
-        }
-
-        /***************************************************/
     }
 }
 

--- a/Geometry_Engine/Compute/MarchingSquares.cs
+++ b/Geometry_Engine/Compute/MarchingSquares.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Geometry
 
         [Description("Computes contour lines of the iso-values in the scalar field defined by the mesh and the values. \n" +
                      "The values are assumed to change linearly between vertices.")]
-        [Input("mesh3d", "Mesh which defines the positions of the values in the scalar field.")]
+        [Input("mesh", "Mesh defining the positions of the values in the scalar field.")]
         [Input("vertexValues", "The value for of scalar field for each vertex in the mesh.")]
         [Input("isoValues", "Values in the scalar field to produce the iso-lines for.")]
         [Output("isoLines", "Lines covering the iso-values in the scalar field defined by the mesh and values.")]
@@ -50,6 +50,7 @@ namespace BH.Engine.Geometry
                 Reflection.Compute.RecordError("Number of vertexValues must match the number of vertices in the mesh.");
                 return new List<List<Line>>();
             }
+
             if (isoValues == null)
                 return new List<List<Line>>();
 
@@ -69,7 +70,7 @@ namespace BH.Engine.Geometry
                     int indI = indexArray[i];
 
                     // get points on face edge at the iso value
-                    List<Point> pts = IntermidiatePoints(
+                    List<Point> pts = IntermediatePoints(
                         mesh.Vertices[indI], vertexValues[indI],
                         mesh.Vertices[indJ], vertexValues[indJ],
                         isoValues);
@@ -106,7 +107,7 @@ namespace BH.Engine.Geometry
         /****   Private Methods                         ****/
         /***************************************************/
 
-        private static List<Point> IntermidiatePoints(Point firstPt, double fisrtValue, Point secondPt, double secondValue, List<double> evaluationValues)
+        private static List<Point> IntermediatePoints(Point firstPt, double fisrtValue, Point secondPt, double secondValue, List<double> evaluationValues)
         {
             Domain domain = Data.Create.Domain(fisrtValue, secondValue);
             double distance = domain.Max - domain.Min;

--- a/Geometry_Engine/Compute/SubMesh.cs
+++ b/Geometry_Engine/Compute/SubMesh.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Geometry
             List<Point> vertices = new List<Point>();
             List<Face> resultFaces = new List<Face>();
 
-            List<int> indecies = faces.SelectMany(x => x.ToArray()).Distinct().ToList();
+            IEnumerable<int> indecies = faces.SelectMany(x => x.Vertices()).Distinct();
             Dictionary<int, int> map = indecies.Select((x, i) => new Tuple<int, int>(x, i))
                                                .ToDictionary(x => x.Item1, x => x.Item2);
 

--- a/Geometry_Engine/Compute/SubMesh.cs
+++ b/Geometry_Engine/Compute/SubMesh.cs
@@ -71,12 +71,7 @@ namespace BH.Engine.Geometry
             if (vertexRelatedData != null && 
                 vertexRelatedData.Count == mesh.Vertices.Count)
             {
-                List<T> newList = new List<T>();
-                foreach (int i in indecies)
-                {
-                    newList.Add(vertexRelatedData[i]);
-                }
-                vertexRelatedData = newList;
+                vertexRelatedData = indecies.Select(i => vertexRelatedData[i]).ToList();
             }
 
             foreach (Face face in faces)

--- a/Geometry_Engine/Compute/SubMesh.cs
+++ b/Geometry_Engine/Compute/SubMesh.cs
@@ -1,0 +1,108 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****   Public Methods                          ****/
+        /***************************************************/
+
+        [Description("Create a mesh from selected faces of an existing mesh.")]
+        [Input("mesh", "Mesh to get a sub-section from.")]
+        [Input("faces", "The faces of the old mesh to carry over to the new mesh.")]
+        [Output("mesh", "Mesh composed of the faces and the vertices in those faces.")]
+        public static Mesh SubMesh(this Mesh mesh, List<Face> faces)
+        {
+            List<int> dummyList = new List<int>();
+            return SubMesh<int>(mesh, faces, ref dummyList);
+        }
+
+        /***************************************************/
+
+        [Description("Create a mesh from selected faces of an existing mesh.")]
+        [Input("mesh", "Mesh to get a sub-section from.")]
+        [Input("faces", "The faces of the old mesh to carry over to the new mesh.")]
+        [Input("vertexRelatedData", "A list where each item is related to the vertex at the same index in the mesh. \n" +
+                                    "Will be changed to relate to the new mesh's vertex list.")]
+        [Output("mesh", "Mesh composed of the faces and the vertices in those faces.")]
+        public static Mesh SubMesh<T>(this Mesh mesh, List<Face> faces, ref List<T> vertexRelatedData)
+        {
+            List<Point> vertices = new List<Point>();
+            List<Face> resultFaces = new List<Face>();
+
+            List<int> indecies = faces.SelectMany(x => x.ToArray()).Distinct().ToList();
+            List<Tuple<int, int>> mapping = indecies.Select((x, i) => new Tuple<int, int>(x, i)).ToList();
+
+            Dictionary<int, int> map = mapping.ToDictionary(x => x.Item1, x => x.Item2);
+
+            foreach (int i in indecies)
+            {
+                vertices.Add(mesh.Vertices[i]);
+            }
+
+            if (vertexRelatedData != null && 
+                vertexRelatedData.Count == mesh.Vertices.Count)
+            {
+                List<T> newList = new List<T>();
+                foreach (int i in indecies)
+                {
+                    newList.Add(vertexRelatedData[i]);
+                }
+                vertexRelatedData = newList;
+            }
+
+            foreach (Face face in faces)
+            {
+                Face newFace = new Face() 
+                {
+                    A = map[face.A],
+                    B = map[face.B],
+                    C = map[face.C]
+                };
+
+                if (face.IsQuad())
+                    newFace.D = map[face.D];
+
+                resultFaces.Add(newFace);
+            }
+
+            return new Mesh()
+            {
+                Vertices = vertices,
+                Faces = resultFaces,
+            };
+        }
+
+        /***************************************************/
+
+    }
+}
+

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -212,6 +212,7 @@
     <Compile Include="Query\TangentAtLength.cs" />
     <Compile Include="Query\TangentAtParameter.cs" />
     <Compile Include="Query\TangentAtPoint.cs" />
+    <Compile Include="Query\Vertices.cs" />
     <Compile Include="Query\UVCount.cs" />
     <Compile Include="Query\SamplePoints.cs" />
     <Compile Include="Query\SubParts.cs" />

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -77,6 +77,9 @@
     <Compile Include="Compute\CullDuplicates.cs" />
     <Compile Include="Compute\CollapseToScaledPolyline.cs" />
     <Compile Include="Compute\DistributeOutlines.cs" />
+    <Compile Include="Compute\MarchingCubes.cs" />
+    <Compile Include="Compute\SubMesh.cs" />
+    <Compile Include="Compute\MarchingSquares.cs" />
     <Compile Include="Compute\WetBlanketInterpretation.cs" />
     <Compile Include="Compute\IntegrateRegion.cs" />
     <Compile Include="Compute\Eigenvalues.cs" />

--- a/Geometry_Engine/Query/Vertices.cs
+++ b/Geometry_Engine/Query/Vertices.cs
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Queries the indices of this face's vertices.")]
+        [Input("face", "The face to query.")]
+        [Output("array", "Array containing the indices of the face's vertecies.")]
+        public static int[] Vertices(this Face face)
+        {
+            if (face.IsQuad())
+            {
+                return new int[]
+                {
+                    face.A, face.B, face.C, face.D
+                };
+            }
+            else
+            {
+                return new int[]
+                {
+                    face.A, face.B, face.C
+                };
+            }
+        }
+
+        /***************************************************/
+    }
+}
+


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->
Implements the MarchingSquares and MarchingCubes for meshes and mesh3d's respectively.

In essence it allows one to extract a constant value range from a linearly approximated scalar field.
This implementation is general in the sense that it does not require neither squares nor cubes but is general to the degree that the BHoM mesh allows. (only 3 to 4 vertices per face)
And it is also not bound to the world axis but placed in the local space provided by the meshes.

Example: the scalar field = distance from a point.
![a1f3270b-019f-4cad-8af5-ea2918d85b7b](https://user-images.githubusercontent.com/69650289/90528497-fae42b00-e172-11ea-9fbc-c01649a93f21.gif)

Anyway could probably also be useful for result display.

### Test files
<!-- Link to test files to validate the proposed changes -->
[MarchingSquares.zip](https://github.com/BHoM/BHoM_Engine/files/5091004/MarchingSquares.zip)

[MarchingCubes.zip](https://github.com/BHoM/BHoM_Engine/files/5091000/MarchingCubes.zip)


 ### Additional comments
<!-- As required -->
