### PR TITLE
Geometry_Engine: implementing DiscontinuityPoints(PolyCurve) and adding tolerances to inputs

### DIFF
--- a/Geometry_Engine/Query/DiscontinuityPoints.cs
+++ b/Geometry_Engine/Query/DiscontinuityPoints.cs
@@ -34,31 +34,57 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
-        public static List<Point> DiscontinuityPoints(this Arc curve)
+        [PreviousVersion("3.3", "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.Arc)")]
+        public static List<Point> DiscontinuityPoints(this Arc curve, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
             return new List<Point> { curve.StartPoint(), curve.EndPoint() };
         }
 
         /***************************************************/
 
-        public static List<Point> DiscontinuityPoints(this Circle curve)
+        [PreviousVersion("3.3", "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.Circle)")]
+        public static List<Point> DiscontinuityPoints(this Circle curve, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
             return new List<Point>();
         }
 
         /***************************************************/
 
-        public static List<Point> DiscontinuityPoints(this Line curve)
+        [PreviousVersion("3.3", "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.Line)")]
+        public static List<Point> DiscontinuityPoints(this Line curve, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
             return new List<Point> { curve.Start, curve.End };
         }
 
         /***************************************************/
 
-        [NotImplemented]
-        public static List<Point> DiscontinuityPoints(this PolyCurve curve)
+        [PreviousVersion("3.3", "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.PolyCurve)")]
+        public static List<Point> DiscontinuityPoints(this PolyCurve curve, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
-            return curve.Curves.SelectMany((x, i) => x.IDiscontinuityPoints().Skip((i > 0) ? 1 : 0)).ToList();
+            List<Point> result = new List<Point>();
+            List<ICurve> curves = curve.SubParts().Where(c => !(c is Circle || c is Ellipse)).ToList();
+            bool closed = curve.IsClosed(distanceTolerance);
+
+            if (curves.Count == 0)
+                return result;
+
+            int j;
+            for (int i = 0; i < curves.Count; i++)
+            {
+                j = (i - 1 + curves.Count) % curves.Count;
+                if (i > 0 || closed)
+                {
+                    if (!curves[j].IEndDir().IsEqual(curves[i].IStartDir(), distanceTolerance))
+                        result.Add(curves[i].IStartPoint());
+                }
+                else
+                    result.Add(curves[i].IStartPoint());
+            }
+
+            if (!closed)
+                result.Add(curve.EndPoint());
+
+            return result;
         }
 
         /***************************************************/
@@ -99,9 +125,10 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 
-        public static List<Point> IDiscontinuityPoints(this ICurve curve)
+        [PreviousVersion("3.3", "BH.Engine.Geometry.Query.IDiscontinuityPoints(BH.oM.Geometry.ICurve)")]
+        public static List<Point> IDiscontinuityPoints(this ICurve curve, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
-            return DiscontinuityPoints(curve as dynamic);
+            return DiscontinuityPoints(curve as dynamic, distanceTolerance, angleTolerance);
         }
 
 
@@ -109,7 +136,8 @@ namespace BH.Engine.Geometry
         /**** Private Fallback Methods                  ****/
         /***************************************************/
 
-        private static List<Point> DiscontinuityPoints(this ICurve curve)
+        [PreviousVersion("3.3", "BH.Engine.Geometry.Query.DiscontinuityPoints(BH.oM.Geometry.ICurve)")]
+        private static List<Point> DiscontinuityPoints(this ICurve curve, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
             Reflection.Compute.RecordError($"DiscontinuityPoints is not implemented for ICurves of type: {curve.GetType().Name}.");
             return null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1954 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2D%231954%2DimplementDiscontinuityPoints%28PolyCurve%29) - there are two "failing" cases in the test file. They are caused by errors from a grasshopper method. It is pointed in the file. **EDIT: Added another test file to prove versioning works fine.**

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- updated `DiscontinuityPoints()` method for the `PolyCurve` class to return real discontinuity points.
- added tolerances to the inputs of every `DiscontinuityPoints()` method.


### Additional comments
<!-- As required -->
`[PreviousVersion]` attribute has been used to update methods' inputs so rebuilding `Versioning_Toolkit` is needed for scripts using outdated methods to work. 