### PR TITLE
Geometry_Engine: Clear not implemented create methods for NurbsCurve and NurbsSurface

### DIFF
--- a/Geometry_Engine/Create/NurbsCurve.cs
+++ b/Geometry_Engine/Create/NurbsCurve.cs
@@ -34,22 +34,6 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [NotImplemented]
-        public static NurbsCurve NurbsCurve(IEnumerable<Point> controlPoints, int degree = 3)
-        {
-            throw new NotImplementedException();
-        }
-
-        /***************************************************/
-
-        [NotImplemented]
-        public static NurbsCurve NurbsCurve(IEnumerable<Point> controlPoints, IEnumerable<double> weights, int degree = 3)
-        {
-            throw new NotImplementedException();
-        }
-
-        /***************************************************/
-                
         public static NurbsCurve NurbsCurve(IEnumerable<Point> controlPoints, IEnumerable<double> weights, IEnumerable<double> knots)
         {
             return new NurbsCurve { ControlPoints = controlPoints.ToList(), Knots = knots.ToList(), Weights = weights.ToList() };
@@ -61,31 +45,7 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [NotImplemented]
-        public static NurbsCurve RandomNurbsCurve(int seed = -1, BoundingBox box = null, int minNbCPs = 5, int maxNbCPs = 20)
-        {
-            throw new NotImplementedException();
-        }
-
-        /***************************************************/
-
-        [NotImplemented]
         public static NurbsCurve RandomNurbsCurve(Random rnd, BoundingBox box = null, int minNbCPs = 5, int maxNbCPs = 20)
-        {
-            throw new NotImplementedException();
-        }
-
-        /***************************************************/
-
-        [NotImplemented]
-        public static NurbsCurve RandomNurbsCurve(Point from, int seed = -1, BoundingBox box = null, int minNbCPs = 5, int maxNbCPs = 20)
-        {
-            throw new NotImplementedException();
-        }
-
-        /***************************************************/
-
-        [NotImplemented]
-        public static NurbsCurve RandomNurbsCurve(Point from, Random rnd, BoundingBox box = null, int minNbCPs = 5, int maxNbCPs = 20)
         {
             throw new NotImplementedException();
         }
@@ -93,4 +53,3 @@ namespace BH.Engine.Geometry
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Create/NurbsSurface.cs
+++ b/Geometry_Engine/Create/NurbsSurface.cs
@@ -31,42 +31,7 @@ namespace BH.Engine.Geometry
     public static partial class Create
     {
         /***************************************************/
-        /**** Public Methods                            ****/
-        /***************************************************/
-
-        [NotImplemented]
-        public static NurbsSurface NurbsSurface(IEnumerable<Point> controlPoints, int degree = 3)
-        {
-            throw new NotImplementedException();
-        }
-
-        /***************************************************/
-
-        [NotImplemented]
-        public static NurbsSurface NurbsSurface(IEnumerable<Point> controlPoints, IEnumerable<double> weights, int degree = 3)
-        {
-            throw new NotImplementedException();
-        }
-
-        /***************************************************/
-
-        [NotImplemented]
-        public static NurbsSurface NurbsSurface(IEnumerable<Point> controlPoints, IEnumerable<double> weights, IEnumerable<double> uKnots, IEnumerable<double> vKnots)
-        {
-            throw new NotImplementedException();
-        }
-
-
-        /***************************************************/
         /**** Random Geometry                           ****/
-        /***************************************************/
-
-        [NotImplemented]
-        public static NurbsSurface RandomNurbsSurface(int seed = -1, BoundingBox box = null, int minNbCPs = 4, int maxNbCPs = 20)
-        {
-            throw new NotImplementedException();
-        }
-
         /***************************************************/
 
         [NotImplemented]
@@ -78,4 +43,3 @@ namespace BH.Engine.Geometry
         /***************************************************/
     }
 }
-


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1955 

<!-- Add short description of what has been fixed -->
Removing all non-referenced create methods with `[NotImplemented]` attribute. `Random` methods are being left over to be implemented later (see #1968).

### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removing not implemented `Create.NurbsCurve` and `Create.NurbsSurface` methods from `Geometry_Engine`.

