### PR TITLE
Geometry_Engine: Add IsEqual(NurbsCurve)

### DIFF
--- a/Geometry_Engine/Query/IsEqual.cs
+++ b/Geometry_Engine/Query/IsEqual.cs
@@ -117,6 +117,18 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        public static bool IsEqual(this NurbsCurve curve, NurbsCurve other, double tolerance = Tolerance.Distance)
+        {
+            return curve.ControlPoints.Count == other.ControlPoints.Count
+                && curve.Knots.Count == other.Knots.Count
+                && curve.Weights.Count == other.Weights.Count
+                && curve.ControlPoints.Zip(other.ControlPoints, (a, b) => a.IsEqual(b, tolerance)).All(x => x)
+                && curve.Knots.Zip(other.Knots, (a, b) => Math.Abs(a - b) < tolerance).All(x => x)          //TODO: Using distance tolerance. Find out what kind of tolerance should be used.
+                && curve.Weights.Zip(other.Weights, (a, b) => Math.Abs(a - b) < tolerance).All(x => x);     //TODO: Using distance tolerance. Find out what kind of tolerance should be used.
+        }
+
+        /***************************************************/
+
         public static bool IsEqual(this PolyCurve curve, PolyCurve other, double tolerance = Tolerance.Distance)
         {
             return curve.Curves.Count == other.Curves.Count


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1958 

<!-- Add short description of what has been fixed -->
Adding a method to compare NurbsCurves. Comparison is comparing the objects properties not the curves geometry. Two geometrically identical curves but of different degrees will be marked as not equal.

### Test files
<!-- Link to test files to validate the proposed changes -->
[SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometry%5FEngine%2D%231958%2DAddIsEqual%28NurbsCurve%29)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Add `IsEqual` method in `Geometry_Engine` for `NurbsCurve` class.

### Additional comments
<!-- As required -->
- We don't have a specified numerical tolerance for values like control point's weight or knot. Used distance tolerance instead as a temporary solution.
- Didn't manage to create two geometrically identical nurbs of different degrees using our components. If anyone can share a know-how I can add such a case to the test file 😅 