### PR TITLE
Geometry_Engine: Adding more sample points to IsClockwise

### DIFF
--- a/Geometry_Engine/Query/IsClockwise.cs
+++ b/Geometry_Engine/Query/IsClockwise.cs
@@ -75,13 +75,16 @@ namespace BH.Engine.Geometry
                     cPts.Add(c.IEndPoint());
                 else if (c is Arc)
                 {
+                    cPts.Add((c as Arc).PointAtParameter(0.25));
                     cPts.Add((c as Arc).PointAtParameter(0.5));
+                    cPts.Add((c as Arc).PointAtParameter(0.75));
                     cPts.Add((c as Arc).EndPoint());
                 }
                 else if (c is Circle)
                 {
-                    cPts.Add((c as Circle).PointAtParameter(1.0 / 3));
-                    cPts.Add((c as Circle).PointAtParameter(2.0 / 3));
+                    cPts.Add((c as Circle).PointAtParameter(0.25));
+                    cPts.Add((c as Circle).PointAtParameter(0.5));
+                    cPts.Add((c as Circle).PointAtParameter(0.75));
                     cPts.Add((c as Circle).EndPoint());
                 }
                 else


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1983 

<!-- Add short description of what has been fixed -->

Adding mroe sample points for checking IsClockwise for arcs. Only taking start-middle-end caused issues for polycurves with large arcs with large both radius and angle span.

Tested third points as well, but was not enough.

Also changed the circle to stay consistent.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EhRMIIZQ0aZOgdHKcvcNDeQBDD-uYuRIcmV246ShArWHHw?e=pqYIEg

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->