### PR TITLE
MEP_Engine: Allow for zero thickness lining and insulation in MEP element section profiles

### DIFF
--- a/MEP_Engine/Create/Elements/DuctSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/DuctSectionProperty.cs
@@ -53,15 +53,26 @@ namespace BH.Engine.MEP
             IMEPMaterial liningMaterial = null,
             string name = "")
         {
-            //Solid Areas
             double elementSolidArea = sectionProfile.ElementProfile.Area();
-            double liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
-            double insulationSolidArea = sectionProfile.InsulationProfile.Area();
-
-            //Void Areas
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
-            double liningVoidArea = sectionProfile.LiningProfile.VoidArea();
-            double insulationVoidArea = sectionProfile.InsulationProfile.VoidArea();
+
+            double liningSolidArea = 0;
+            double liningVoidArea = double.NaN;
+
+            double insulationSolidArea = 0;
+            double insulationVoidArea = double.NaN;
+
+            if (sectionProfile.LiningProfile != null)
+            {
+                liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
+                liningVoidArea = sectionProfile.LiningProfile.VoidArea();
+            }
+
+            if(sectionProfile.InsulationProfile != null)
+            {
+                insulationSolidArea = sectionProfile.InsulationProfile.Area();
+                insulationVoidArea = sectionProfile.InsulationProfile.VoidArea();
+            }
 
             //Duct specific properties
             double circularEquivalent = sectionProfile.ElementProfile.ICircularEquivalentDiameter();

--- a/MEP_Engine/Create/Elements/DuctSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/DuctSectionProperty.cs
@@ -64,7 +64,7 @@ namespace BH.Engine.MEP
 
             if (sectionProfile.LiningProfile != null)
             {
-                liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
+                liningSolidArea = sectionProfile.LiningProfile.Area();
                 liningVoidArea = sectionProfile.LiningProfile.VoidArea();
             }
 

--- a/MEP_Engine/Create/Elements/PipeSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/PipeSectionProperty.cs
@@ -52,15 +52,26 @@ namespace BH.Engine.MEP
             IMEPMaterial insulationMaterial = null,
             string name = "")
         {
-            //Solid Areas
             double elementSolidArea = sectionProfile.ElementProfile.Area();
-            double liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
-            double insulationSolidArea = sectionProfile.InsulationProfile.Area();
-
-            //Void Areas
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
+
+            double liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
             double liningVoidArea = sectionProfile.LiningProfile.VoidArea();
+
+            double insulationSolidArea = sectionProfile.InsulationProfile.Area();
             double insulationVoidArea = sectionProfile.InsulationProfile.VoidArea();
+
+            if(sectionProfile.LiningProfile != null)
+            {
+                liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
+                liningVoidArea = sectionProfile.LiningProfile.VoidArea();
+            }
+
+            if (sectionProfile.InsulationProfile != null)
+            {
+                insulationSolidArea = sectionProfile.InsulationProfile.Area();
+                insulationVoidArea = sectionProfile.InsulationProfile.VoidArea();
+            }
 
             PipeSectionProperty property = new PipeSectionProperty(sectionProfile, elementSolidArea, liningSolidArea, insulationSolidArea, elementVoidArea, liningVoidArea, insulationVoidArea);
             property.PipeMaterial = pipeMaterial;

--- a/MEP_Engine/Create/Elements/PipeSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/PipeSectionProperty.cs
@@ -55,7 +55,7 @@ namespace BH.Engine.MEP
             double elementSolidArea = sectionProfile.ElementProfile.Area();
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
 
-            double liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
+            double liningSolidArea = sectionProfile.LiningProfile.Area();
             double liningVoidArea = sectionProfile.LiningProfile.VoidArea();
 
             double insulationSolidArea = sectionProfile.InsulationProfile.Area();
@@ -63,7 +63,7 @@ namespace BH.Engine.MEP
 
             if(sectionProfile.LiningProfile != null)
             {
-                liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
+                liningSolidArea = sectionProfile.LiningProfile.Area();
                 liningVoidArea = sectionProfile.LiningProfile.VoidArea();
             }
 

--- a/MEP_Engine/Create/Elements/SectionProfile.cs
+++ b/MEP_Engine/Create/Elements/SectionProfile.cs
@@ -47,10 +47,28 @@ namespace BH.Engine.MEP
         public static SectionProfile SectionProfile(BoxProfile boxProfile, double liningThickness, double insulationThickness)
         {
             //Internal offset of original ShapeProfile
-            IProfile liningProfile = BH.Engine.Geometry.Create.BoxProfile((boxProfile.Height - (boxProfile.Thickness * 2)), (boxProfile.Width - (boxProfile.Thickness * 2)), liningThickness, boxProfile.OuterRadius, boxProfile.InnerRadius);
+            IProfile liningProfile = null;
+
+            if (liningThickness <= 0)
+            {
+                liningProfile = null;
+            }
+            else
+            {
+                liningProfile = BH.Engine.Geometry.Create.BoxProfile((boxProfile.Height - (boxProfile.Thickness * 2)), (boxProfile.Width - (boxProfile.Thickness * 2)), liningThickness, boxProfile.OuterRadius, boxProfile.InnerRadius);
+            }
 
             //External offset of original ShapeProfile
-            IProfile insulationProfile = BH.Engine.Geometry.Create.BoxProfile((boxProfile.Height + (insulationThickness * 2)), (boxProfile.Width + (insulationThickness * 2)), insulationThickness, boxProfile.InnerRadius, boxProfile.OuterRadius);
+            IProfile insulationProfile = null;
+
+            if (insulationThickness <= 0)
+            {
+                insulationProfile = null;
+            }
+            else
+            {
+                insulationProfile = BH.Engine.Geometry.Create.BoxProfile((boxProfile.Height + (insulationThickness * 2)), (boxProfile.Width + (insulationThickness * 2)), insulationThickness, boxProfile.InnerRadius, boxProfile.OuterRadius);
+            }
 
             return new SectionProfile(boxProfile, liningProfile, insulationProfile);
         }

--- a/MEP_Engine/Create/Elements/SectionProfile.cs
+++ b/MEP_Engine/Create/Elements/SectionProfile.cs
@@ -82,10 +82,28 @@ namespace BH.Engine.MEP
         public static SectionProfile SectionProfile(TubeProfile tubeProfile, double liningThickness, double insulationThickness)
         {
             //Internal offset of original ShapeProfile
-            IProfile liningProfile = BH.Engine.Geometry.Create.TubeProfile((((tubeProfile.Diameter/2) - tubeProfile.Thickness) * 2), liningThickness);
+            IProfile liningProfile = null;
+
+            if(liningThickness <= 0)
+            {
+                liningProfile = null;
+            }
+            else
+            {
+                liningProfile = BH.Engine.Geometry.Create.TubeProfile((((tubeProfile.Diameter / 2) - tubeProfile.Thickness) * 2), liningThickness);
+            }
 
             //External offset of original ShapeProfile
-            IProfile insulationProfile = BH.Engine.Geometry.Create.TubeProfile((tubeProfile.Diameter + (insulationThickness * 2)), insulationThickness);
+
+            IProfile insulationProfile = null;
+            if(insulationThickness <= 0)
+            {
+                insulationProfile = null;
+            }
+            else
+            {
+                insulationProfile = BH.Engine.Geometry.Create.TubeProfile((tubeProfile.Diameter + (insulationThickness * 2)), insulationThickness);
+            }
 
             return new SectionProfile(tubeProfile, liningProfile, insulationProfile);
         }

--- a/MEP_Engine/Create/Elements/WireSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/WireSectionProperty.cs
@@ -52,15 +52,26 @@ namespace BH.Engine.MEP
             IMEPMaterial insulationMaterial = null,
             string name = "")
         {
-            //Solid Areas
             double elementSolidArea = sectionProfile.ElementProfile.Area();
-            double liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
-            double insulationSolidArea = sectionProfile.InsulationProfile.Area();
-
-            //Void Areas
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
+
+            double liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
             double liningVoidArea = sectionProfile.LiningProfile.VoidArea();
+
+            double insulationSolidArea = sectionProfile.InsulationProfile.Area();
             double insulationVoidArea = sectionProfile.InsulationProfile.VoidArea();
+
+            if (sectionProfile.LiningProfile != null)
+            {
+                liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
+                liningVoidArea = sectionProfile.LiningProfile.VoidArea();
+            }
+
+            if (sectionProfile.InsulationProfile != null)
+            {
+                insulationSolidArea = sectionProfile.InsulationProfile.Area();
+                insulationVoidArea = sectionProfile.InsulationProfile.VoidArea();
+            }
 
             WireSectionProperty property = new WireSectionProperty(sectionProfile, elementSolidArea, liningSolidArea, insulationSolidArea, elementVoidArea, liningVoidArea, insulationVoidArea);
             property.ConductiveMaterial = conductiveMaterial;

--- a/MEP_Engine/Create/Elements/WireSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/WireSectionProperty.cs
@@ -55,7 +55,7 @@ namespace BH.Engine.MEP
             double elementSolidArea = sectionProfile.ElementProfile.Area();
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
 
-            double liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
+            double liningSolidArea = sectionProfile.LiningProfile.Area();
             double liningVoidArea = sectionProfile.LiningProfile.VoidArea();
 
             double insulationSolidArea = sectionProfile.InsulationProfile.Area();
@@ -63,7 +63,7 @@ namespace BH.Engine.MEP
 
             if (sectionProfile.LiningProfile != null)
             {
-                liningSolidArea = sectionProfile.LiningProfile.Area() - sectionProfile.ElementProfile.Area();
+                liningSolidArea = sectionProfile.LiningProfile.Area();
                 liningVoidArea = sectionProfile.LiningProfile.VoidArea();
             }
 

--- a/MEP_Engine/Query/CircularEquivalentDiameter.cs
+++ b/MEP_Engine/Query/CircularEquivalentDiameter.cs
@@ -55,5 +55,10 @@ namespace BH.Engine.MEP
             return (1.30 * Math.Pow(a * b, 0.625) / Math.Pow(a + b, 0.250)) / 1000;
         }
         /***************************************************/
+
+        public static double CircularEquivalentDiameter(this object profile)
+        {
+            return 0; //To catch things that are not box profile.
+        }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1989 
Closes #1953 

<!-- Add short description of what has been fixed -->
In our workshop on 200911 we applied a fix to allow for better handling of zero thickness elements found within composite section representations. The SectionProfile() will assume 0 thickness unless otherwise provided and provide a null where needed. 

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/MEP_Engine/200911_MEPoMTest.gh?csf=1&web=1&e=fUfGAB

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->