### PR TITLE
MEP_Engine: Single value for SolidVolume 

### DIFF
--- a/MEP_Engine/MEP_Engine.csproj
+++ b/MEP_Engine/MEP_Engine.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Query\Geometry.cs" />
     <Compile Include="Query\HydraulicDiameter.cs" />
     <Compile Include="Query\Length.cs" />
+    <Compile Include="Query\CompositeSolidVolumes.cs" />
     <Compile Include="Query\SolidVolume.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MEP_Engine/Query/CompositeSolidVolumes.cs
+++ b/MEP_Engine/Query/CompositeSolidVolumes.cs
@@ -1,0 +1,189 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
+using BH.oM.MEP.Elements;
+
+namespace BH.Engine.MEP
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Queries the solid volume of a Duct by multiplying the section profile's solid area by the element's length.")]
+        [Input("duct", "The Duct to query solid volume.")]
+        [MultiOutput(0, "elementSolidVolume", "SolidVolume of the Element itself within a compiled SectionProfile.")]
+        [MultiOutput(1, "insulationSolidVolume", "The solid volume of the Duct's exterior insulation.")]
+        [MultiOutput(2, "liningSolidVolume", "The solid volume of the Duct's interior lining.")]
+        public static Output<double, double, double> CompositeSolidVolumes(this Duct duct)
+        {
+            double length = duct.Length();
+            double elementSolidVolume = duct.SectionProperty.ElementSolidArea * length;
+            double insulationSolidVolume = duct.SectionProperty.InsulationSolidArea * length;
+            double liningSolidVolume = duct.SectionProperty.LiningSolidArea * length;
+
+            if (duct.SectionProperty == null)
+            {
+                Engine.Reflection.Compute.RecordError("No section property defined.");
+                return null;
+            }
+
+            //Negative LiningThickness Warning
+            if (duct.SectionProperty.LiningSolidArea < 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("LiningSolidArea is a negative value, and will result in incorrect SolidVolume results. Try adjusting LiningThickness to produce a positive value for SolidArea.");
+            }
+
+            //SolidArea = 0 user feedback.
+            if (duct.SectionProperty.ElementSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("ElementSolidArea is 0. Returning 0 for ElementSolidVolume.");
+            }
+
+            if (duct.SectionProperty.LiningSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for LiningSolidVolume.");
+            }
+
+            if (duct.SectionProperty.InsulationSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for InsulationSolidVolume.");
+            }
+
+            Output<double, double, double> output = new Output<double, double, double>
+            {
+                Item1 = elementSolidVolume,
+                Item2 = insulationSolidVolume,
+                Item3 = liningSolidVolume,
+            };
+            return output;
+        }
+
+        /***************************************************/
+
+        //This may get adjusted per finalised property names and section compositions.//
+        [Description("Queries the solid volume of a Pipe by multiplying the section profile's solid area by the element's length.")]
+        [Input("pipe", "The Pipe to query solid volume.")]
+        [MultiOutput(0, "elementSolidVolume", "SolidVolume of the Element itself within a compiled SectionProfile.")]
+        [MultiOutput(1, "insulationSolidVolume", "The solid volume of the Pipe's exterior insulation.")]
+        [MultiOutput(2, "liningSolidVolume", "The solid volume of the Pipe's interior lining.")]
+        public static Output<double, double, double> CompositeSolidVolumes(this Pipe pipe)
+        {
+            double length = pipe.Length();
+            double elementSolidVolume = pipe.SectionProperty.ElementSolidArea * length;
+            double insulationSolidVolume = pipe.SectionProperty.InsulationSolidArea * length;
+            double liningSolidVolume = pipe.SectionProperty.LiningSolidArea * length;
+
+            if (pipe.SectionProperty == null)
+            {
+                Engine.Reflection.Compute.RecordError("No section property defined.");
+                return null;
+            }
+
+            //Negative LiningThickness Warning
+            if (pipe.SectionProperty.LiningSolidArea < 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("LiningSolidArea is a negative value, and will result in incorrect SolidVolume results. Try adjusting LiningThickness to produce a positive value for SolidArea.");
+            }
+
+            //SolidArea = 0 user feedback.
+            if (pipe.SectionProperty.ElementSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("ElementSolidArea is 0. Returning 0 for ElementSolidVolume.");
+            }
+
+            if (pipe.SectionProperty.LiningSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for LiningSolidVolume.");
+            }
+
+            if (pipe.SectionProperty.InsulationSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for InsulationSolidVolume.");
+            }
+
+            Output<double, double, double> output = new Output<double, double, double>
+            {
+                Item1 = elementSolidVolume,
+                Item2 = insulationSolidVolume,
+                Item3 = liningSolidVolume,
+            };
+            return output;
+        }
+        /***************************************************/
+
+        //This method may get adjusted per finalised property names and section compositions.//
+        [Description("Queries the solid volume of a Wire by multiplying the section profile's solid area by the element's length.")]
+        [Input("wire", "The Wire to query solid volume.")]
+        [MultiOutput(0, "elementSolidVolume", "SolidVolume of the Element itself within a compiled SectionProfile.")]
+        [MultiOutput(1, "insulationSolidVolume", "The solid volume of the Wire's exterior insulation.")]
+        [MultiOutput(2, "liningSolidVolume", "The solid volume of the Wire's interior lining.")]
+        public static Output<double, double, double> CompositeSolidVolumes(this WireSegment wire)
+        {
+            double length = wire.Length();
+            double elementSolidVolume = wire.SectionProperty.ElementSolidArea * length;
+            double insulationSolidVolume = wire.SectionProperty.InsulationSolidArea * length;
+            double liningSolidVolume = wire.SectionProperty.LiningSolidArea * length;
+
+            if (wire.SectionProperty == null)
+            {
+                Engine.Reflection.Compute.RecordError("No section property defined.");
+                return null;
+            }
+
+            //Negative LiningThickness Warning
+            if (wire.SectionProperty.LiningSolidArea < 0)
+            {
+                Engine.Reflection.Compute.RecordWarning("LiningSolidArea is a negative value, and will result in incorrect SolidVolume results. Try adjusting LiningThickness to produce a positive value for SolidArea.");
+            }
+
+            //SolidArea = 0 user feedback.
+            if (wire.SectionProperty.ElementSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("ElementSolidArea is 0. Returning 0 for ElementSolidVolume.");
+            }
+
+            if (wire.SectionProperty.LiningSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for LiningSolidVolume.");
+            }
+
+            if (wire.SectionProperty.InsulationSolidArea <= 0)
+            {
+                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for InsulationSolidVolume.");
+            }
+
+            Output<double, double, double> output = new Output<double, double, double>
+            {
+                Item1 = elementSolidVolume,
+                Item2 = insulationSolidVolume,
+                Item3 = liningSolidVolume,
+            };
+            return output;
+        }
+        /***************************************************/
+    }
+}

--- a/MEP_Engine/Query/SolidVolume.cs
+++ b/MEP_Engine/Query/SolidVolume.cs
@@ -21,14 +21,8 @@
  */
 
 using System.ComponentModel;
-using System.Collections.Generic;
-using System;
-
-using BH.oM.Reflection;
 using BH.oM.Reflection.Attributes;
 using BH.oM.MEP.Elements;
-using BH.Engine.Spatial;
-using System.Diagnostics.Eventing.Reader;
 
 namespace BH.Engine.MEP
 {

--- a/MEP_Engine/Query/SolidVolume.cs
+++ b/MEP_Engine/Query/SolidVolume.cs
@@ -28,6 +28,7 @@ using BH.oM.Reflection;
 using BH.oM.Reflection.Attributes;
 using BH.oM.MEP.Elements;
 using BH.Engine.Spatial;
+using System.Diagnostics.Eventing.Reader;
 
 namespace BH.Engine.MEP
 {
@@ -37,156 +38,160 @@ namespace BH.Engine.MEP
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Queries the solid volume of a Duct by multiplying the section profile's solid area by the element's length.")]
+        [Description("Queries the solid volume of a Duct by multiplying the section profile's solid area by the element's length. Note this element contains a composite section and this query method returns a single summed value. If you want precise values per section profile, please use CompositeSolidVolumes.")]
         [Input("duct", "The Duct to query solid volume.")]
-        [MultiOutput(0, "elementSolidVolume", "SolidVolume of the Element itself within a compiled SectionProfile.")]
-        [MultiOutput(1, "insulationSolidVolume", "The solid volume of the Duct's exterior insulation.")]
-        [MultiOutput(2, "liningSolidVolume", "The solid volume of the Duct's interior lining.")]
-        public static Output<double, double, double> SolidVolume(this Duct duct)
+        [Output("solidVolume", "Combined SolidVolume of the Element's SectionProfiles.")]
+
+        public static double SolidVolume(this Duct duct)
         {
             double length = duct.Length();
-            double elementSolidVolume = duct.SectionProperty.ElementSolidArea * length;
-            double insulationSolidVolume = duct.SectionProperty.InsulationSolidArea * length;
-            double liningSolidVolume = duct.SectionProperty.LiningSolidArea * length;
+            double elementSolidArea = duct.SectionProperty.ElementSolidArea;
+            double insulationSolidArea = duct.SectionProperty.InsulationSolidArea;
+            double liningSolidArea = duct.SectionProperty.LiningSolidArea;
 
-            if (duct.SectionProperty == null)
+            if(length <= 0)
             {
-                Engine.Reflection.Compute.RecordError("No section property defined.");
-                return null;
+                Engine.Reflection.Compute.RecordError("Cannot query SolidVolume from zero length members.");
+                return double.NaN;
             }
 
-            //Negative LiningThickness Warning
-            if (duct.SectionProperty.LiningSolidArea < 0)
+            if(duct.SectionProperty.SectionProfile.ElementProfile == null)
             {
-                Engine.Reflection.Compute.RecordWarning("LiningSolidArea is a negative value, and will result in incorrect SolidVolume results. Try adjusting LiningThickness to produce a positive value for SolidArea.");
+                Engine.Reflection.Compute.RecordWarning("No ElementProfile detected for object " + duct.BHoM_Guid);
             }
 
-            //SolidArea = 0 user feedback.
-            if (duct.SectionProperty.ElementSolidArea <= 0)
+            if (duct.SectionProperty.SectionProfile.InsulationProfile == null)
+            {
+                Engine.Reflection.Compute.RecordWarning("No InsulationProfile detected for object " + duct.BHoM_Guid);
+            }
+
+            if (duct.SectionProperty.SectionProfile.LiningProfile == null)
+            {
+                Engine.Reflection.Compute.RecordWarning("No LiningProfile detected for object " + duct.BHoM_Guid);
+            }
+
+            if (elementSolidArea <= 0)
             {
                 Engine.Reflection.Compute.RecordNote("ElementSolidArea is 0. Returning 0 for ElementSolidVolume.");
             }
 
-            if (duct.SectionProperty.LiningSolidArea <= 0)
+            if (insulationSolidArea <= 0)
             {
-                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for LiningSolidVolume.");
+                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for LiningSolidVolume.");
             }
 
-            if (duct.SectionProperty.InsulationSolidArea <= 0)
+            if (liningSolidArea <= 0)
             {
-                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for InsulationSolidVolume.");
+                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for InsulationSolidVolume.");
             }
 
-            Output<double, double, double> output = new Output<double, double, double>
-            {
-                Item1 = elementSolidVolume,
-                Item2 = insulationSolidVolume,
-                Item3 = liningSolidVolume,
-            };
-            return output;
+            return ((length * elementSolidArea) + (length * insulationSolidArea) + (length * liningSolidArea));
         }
+
         /***************************************************/
 
-        //This may get adjusted per finalised property names and section compositions.//
-        [Description("Queries the solid volume of a Pipe by multiplying the section profile's solid area by the element's length.")]
+        [Description("Queries the solid volume of a Pipe by multiplying the section profile's solid area by the element's length. Note this element contains a composite section and this query method returns a single summed value. If you want precise values per section profile, please use CompositeSolidVolumes.")]
         [Input("pipe", "The Pipe to query solid volume.")]
-        [MultiOutput(0, "elementSolidVolume", "SolidVolume of the Element itself within a compiled SectionProfile.")]
-        [MultiOutput(1, "insulationSolidVolume", "The solid volume of the Pipe's exterior insulation.")]
-        [MultiOutput(2, "liningSolidVolume", "The solid volume of the Pipe's interior lining.")]
-        public static Output<double, double, double> SolidVolume(this Pipe pipe)
+        [Output("solidVolume", "Combined SolidVolume of the Element's SectionProfiles.")]
+
+        public static double SolidVolume(this Pipe pipe)
         {
             double length = pipe.Length();
-            double elementSolidVolume = pipe.SectionProperty.ElementSolidArea * length;
-            double insulationSolidVolume = pipe.SectionProperty.InsulationSolidArea * length;
-            double liningSolidVolume = pipe.SectionProperty.LiningSolidArea * length;
+            double elementSolidArea = pipe.SectionProperty.ElementSolidArea;
+            double insulationSolidArea = pipe.SectionProperty.InsulationSolidArea;
+            double liningSolidArea = pipe.SectionProperty.LiningSolidArea;
 
-            if (pipe.SectionProperty == null)
+            if (length <= 0)
             {
-                Engine.Reflection.Compute.RecordError("No section property defined.");
-                return null;
+                Engine.Reflection.Compute.RecordError("Cannot query SolidVolume from zero length members.");
+                return double.NaN;
             }
 
-            //Negative LiningThickness Warning
-            if (pipe.SectionProperty.LiningSolidArea < 0)
+            if (pipe.SectionProperty.SectionProfile.ElementProfile == null)
             {
-                Engine.Reflection.Compute.RecordWarning("LiningSolidArea is a negative value, and will result in incorrect SolidVolume results. Try adjusting LiningThickness to produce a positive value for SolidArea.");
+                Engine.Reflection.Compute.RecordWarning("No ElementProfile detected for object " + pipe.BHoM_Guid);
             }
 
-            //SolidArea = 0 user feedback.
-            if (pipe.SectionProperty.ElementSolidArea <= 0)
+            if (pipe.SectionProperty.SectionProfile.InsulationProfile == null)
+            {
+                Engine.Reflection.Compute.RecordWarning("No InsulationProfile detected for object " + pipe.BHoM_Guid);
+            }
+
+            if (pipe.SectionProperty.SectionProfile.LiningProfile == null)
+            {
+                Engine.Reflection.Compute.RecordWarning("No LiningProfile detected for object " + pipe.BHoM_Guid);
+            }
+
+            if (elementSolidArea <= 0)
             {
                 Engine.Reflection.Compute.RecordNote("ElementSolidArea is 0. Returning 0 for ElementSolidVolume.");
             }
 
-            if (pipe.SectionProperty.LiningSolidArea <= 0)
+            if (insulationSolidArea <= 0)
             {
-                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for LiningSolidVolume.");
+                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for LiningSolidVolume.");
             }
 
-            if (pipe.SectionProperty.InsulationSolidArea <= 0)
+            if (liningSolidArea <= 0)
             {
-                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for InsulationSolidVolume.");
+                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for InsulationSolidVolume.");
             }
 
-            Output<double, double, double> output = new Output<double, double, double>
-            {
-                Item1 = elementSolidVolume,
-                Item2 = insulationSolidVolume,
-                Item3 = liningSolidVolume,
-            };
-            return output;
+            return ((length * elementSolidArea) + (length * insulationSolidArea) + (length * liningSolidArea));
         }
+
         /***************************************************/
 
-        //This method may get adjusted per finalised property names and section compositions.//
-        [Description("Queries the solid volume of a Wire by multiplying the section profile's solid area by the element's length.")]
-        [Input("wire", "The Wire to query solid volume.")]
-        [MultiOutput(0, "elementSolidVolume", "SolidVolume of the Element itself within a compiled SectionProfile.")]
-        [MultiOutput(1, "insulationSolidVolume", "The solid volume of the Wire's exterior insulation.")]
-        [MultiOutput(2, "liningSolidVolume", "The solid volume of the Wire's interior lining.")]
-        public static Output<double, double, double> SolidVolume(this WireSegment wire)
+        [Description("Queries the solid volume of a WireSegment by multiplying the section profile's solid area by the element's length. Note this element contains a composite section and this query method returns a single summed value. If you want precise values per section profile, please use CompositeSolidVolumes.")]
+        [Input("wireSegment", "The WireSegment to query solid volume.")]
+        [Output("solidVolume", "Combined SolidVolume of the Element's SectionProfiles.")]
+
+        public static double SolidVolume(this WireSegment wireSegment)
         {
-            double length = wire.Length();
-            double elementSolidVolume = wire.SectionProperty.ElementSolidArea * length;
-            double insulationSolidVolume = wire.SectionProperty.InsulationSolidArea * length;
-            double liningSolidVolume = wire.SectionProperty.LiningSolidArea * length;
+            double length = wireSegment.Length();
+            double elementSolidArea = wireSegment.SectionProperty.ElementSolidArea;
+            double insulationSolidArea = wireSegment.SectionProperty.InsulationSolidArea;
+            double liningSolidArea = wireSegment.SectionProperty.LiningSolidArea;
 
-            if (wire.SectionProperty == null)
+            if (length <= 0)
             {
-                Engine.Reflection.Compute.RecordError("No section property defined.");
-                return null;
+                Engine.Reflection.Compute.RecordError("Cannot query SolidVolume from zero length members.");
+                return double.NaN;
             }
 
-            //Negative LiningThickness Warning
-            if (wire.SectionProperty.LiningSolidArea < 0)
+            if (wireSegment.SectionProperty.SectionProfile.ElementProfile == null)
             {
-                Engine.Reflection.Compute.RecordWarning("LiningSolidArea is a negative value, and will result in incorrect SolidVolume results. Try adjusting LiningThickness to produce a positive value for SolidArea.");
+                Engine.Reflection.Compute.RecordWarning("No ElementProfile detected for object " + wireSegment.BHoM_Guid);
             }
 
-            //SolidArea = 0 user feedback.
-            if (wire.SectionProperty.ElementSolidArea <= 0)
+            if (wireSegment.SectionProperty.SectionProfile.InsulationProfile == null)
+            {
+                Engine.Reflection.Compute.RecordWarning("No InsulationProfile detected for object " + wireSegment.BHoM_Guid);
+            }
+
+            if (wireSegment.SectionProperty.SectionProfile.LiningProfile == null)
+            {
+                Engine.Reflection.Compute.RecordWarning("No LiningProfile detected for object " + wireSegment.BHoM_Guid);
+            }
+
+            if (elementSolidArea <= 0)
             {
                 Engine.Reflection.Compute.RecordNote("ElementSolidArea is 0. Returning 0 for ElementSolidVolume.");
             }
 
-            if (wire.SectionProperty.LiningSolidArea <= 0)
+            if (insulationSolidArea <= 0)
             {
-                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for LiningSolidVolume.");
+                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for LiningSolidVolume.");
             }
 
-            if (wire.SectionProperty.InsulationSolidArea <= 0)
+            if (liningSolidArea <= 0)
             {
-                Engine.Reflection.Compute.RecordNote("InsulationSolidArea is 0. Returning 0 for InsulationSolidVolume.");
+                Engine.Reflection.Compute.RecordNote("LiningSolidArea is 0. Returning 0 for InsulationSolidVolume.");
             }
 
-            Output<double, double, double> output = new Output<double, double, double>
-            {
-                Item1 = elementSolidVolume,
-                Item2 = insulationSolidVolume,
-                Item3 = liningSolidVolume,
-            };
-            return output;
+            return ((length * elementSolidArea) + (length * insulationSolidArea) + (length * liningSolidArea));
         }
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1997 

<!-- Add short description of what has been fixed -->
```SolidVolume()``` now outputs a single double for combined section profile values. 
```CompositeSolidVolumes()``` created to provide a profile-specific breakdown of solid volume values.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/MEP_Engine/Issue%20%231997-SolidVolume/200917_MEPEngine_SolidVolume.gh?csf=1&web=1&e=6ubHh2

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->