### PR TITLE
Reflection_Engine: Adding in pad locks for method and type extraction

### DIFF
--- a/Reflection_Engine/Query/AssemblyList.cs
+++ b/Reflection_Engine/Query/AssemblyList.cs
@@ -35,20 +35,26 @@ namespace BH.Engine.Reflection
 
         public static List<Assembly> BHoMAssemblyList()
         {
-            if (m_BHoMAssemblies == null || m_BHoMAssemblies.Count == 0)
-                ExtractAllAssemblies();
+            lock (m_GetAssembliesLock)
+            {
+                if (m_BHoMAssemblies == null || m_BHoMAssemblies.Count == 0)
+                    ExtractAllAssemblies();
 
-            return m_BHoMAssemblies.Values.ToList();
+                return m_BHoMAssemblies.Values.ToList();
+            }
         }
 
         /***************************************************/
 
         public static List<Assembly> AllAssemblyList()
         {
-            if (m_AllAssemblies == null || m_AllAssemblies.Count == 0)
-                ExtractAllAssemblies();
+            lock (m_GetAssembliesLock)
+            {
+                if (m_AllAssemblies == null || m_AllAssemblies.Count == 0)
+                    ExtractAllAssemblies();
 
-            return m_AllAssemblies.Values.ToList();
+                return m_AllAssemblies.Values.ToList();
+            }
         }
 
 
@@ -78,6 +84,7 @@ namespace BH.Engine.Reflection
 
         private static Dictionary<string, Assembly> m_BHoMAssemblies = null;
         private static Dictionary<string, Assembly> m_AllAssemblies = null;
+        private static readonly object m_GetAssembliesLock = new object();
 
         /***************************************************/
     }

--- a/Reflection_Engine/Query/MethodList.cs
+++ b/Reflection_Engine/Query/MethodList.cs
@@ -35,40 +35,49 @@ namespace BH.Engine.Reflection
 
         public static List<MethodInfo> BHoMMethodList()
         {
-            // If the dictionary exists already return it
-            if (m_BHoMMethodList != null && m_BHoMMethodList.Count > 0)
+            lock (m_GetMethodsLock)
+            {
+                // If the dictionary exists already return it
+                if (m_BHoMMethodList != null && m_BHoMMethodList.Count > 0)
+                    return m_BHoMMethodList;
+
+                // Otherwise, create it
+                ExtractAllMethods();
+
                 return m_BHoMMethodList;
-
-            // Otherwise, create it
-            ExtractAllMethods();
-
-            return m_BHoMMethodList;
+            }
         }
 
         /***************************************************/
 
         public static List<MethodBase> AllMethodList()
         {
-            // If the dictionary exists already return it
-            if (m_AllMethodList != null && m_AllMethodList.Count > 0)
+            lock (m_GetMethodsLock)
+            {
+                // If the dictionary exists already return it
+                if (m_AllMethodList != null && m_AllMethodList.Count > 0)
+                    return m_AllMethodList;
+
+                // Otherwise, create it
+                ExtractAllMethods();
+
                 return m_AllMethodList;
-
-            // Otherwise, create it
-            ExtractAllMethods();
-
-            return m_AllMethodList;
+            }
         }
 
         /***************************************************/
 
         public static List<MethodBase> ExternalMethodList()
         {
-            // Checking for an empty list may be dangerous, we should give different meaning to null and empty lists
-            // What if m_ExternalMethodList is empty after calling ExtractAllMethods() ?
-            if (m_ExternalMethodList == null || m_ExternalMethodList.Count <= 0)
-                ExtractAllMethods();
+            lock (m_GetMethodsLock)
+            {
+                // Checking for an empty list may be dangerous, we should give different meaning to null and empty lists
+                // What if m_ExternalMethodList is empty after calling ExtractAllMethods() ?
+                if (m_ExternalMethodList == null || m_ExternalMethodList.Count <= 0)
+                    ExtractAllMethods();
 
-            return m_ExternalMethodList;
+                return m_ExternalMethodList;
+            }
         }
 
 
@@ -163,6 +172,7 @@ namespace BH.Engine.Reflection
         private static List<MethodBase> m_AllMethodList = new List<MethodBase>();
         private static List<MethodBase> m_ExternalMethodList = new List<MethodBase>();
         private static List<Type> m_EngineTypeList = new List<Type>();
+        private static readonly object m_GetMethodsLock = new object();
 
         /***************************************************/
     }

--- a/Reflection_Engine/Query/TypeDictionary.cs
+++ b/Reflection_Engine/Query/TypeDictionary.cs
@@ -33,15 +33,18 @@ namespace BH.Engine.Reflection
 
         public static Dictionary<string, List<Type>> BHoMTypeDictionary()
         {
-            // If the dictionary exists already return it
-            if (m_BHoMTypeDictionary != null && m_BHoMTypeDictionary.Count > 0)
+            lock (m_GetTypesLock)
+            {
+                // If the dictionary exists already return it
+                if (m_BHoMTypeDictionary != null && m_BHoMTypeDictionary.Count > 0)
+                    return m_BHoMTypeDictionary;
+
+                // Otherwise, create it
+                m_BHoMTypeDictionary = new Dictionary<string, List<Type>>();
+                ExtractAllTypes();
+
                 return m_BHoMTypeDictionary;
-
-            // Otherwise, create it
-            m_BHoMTypeDictionary = new Dictionary<string, List<Type>>();
-            ExtractAllTypes();
-
-            return m_BHoMTypeDictionary;
+            }
         }
 
 

--- a/Reflection_Engine/Query/TypeList.cs
+++ b/Reflection_Engine/Query/TypeList.cs
@@ -34,70 +34,85 @@ namespace BH.Engine.Reflection
 
         public static List<Type> BHoMInterfaceList()
         {
-            // If the dictionary exists already return it
-            if (m_InterfaceList != null && m_InterfaceList.Count > 0)
+            lock (m_GetTypesLock)
+            {
+                // If the dictionary exists already return it
+                if (m_InterfaceList != null && m_InterfaceList.Count > 0)
+                    return m_InterfaceList;
+
+                // Otherwise, create it
+                ExtractAllTypes();
+
                 return m_InterfaceList;
-
-            // Otherwise, create it
-            ExtractAllTypes();
-
-            return m_InterfaceList;
+            }
         }
 
         /***************************************************/
 
         public static List<Type> BHoMTypeList()
         {
-            // If the dictionary exists already return it
-            if (m_BHoMTypeList != null && m_BHoMTypeList.Count > 0)
+            lock (m_GetTypesLock)
+            {
+                // If the dictionary exists already return it
+                if (m_BHoMTypeList != null && m_BHoMTypeList.Count > 0)
+                    return m_BHoMTypeList;
+
+                // Otherwise, create it
+                ExtractAllTypes();
+
                 return m_BHoMTypeList;
-
-            // Otherwise, create it
-            ExtractAllTypes();
-
-            return m_BHoMTypeList;
+            }
         }
 
         /***************************************************/
 
         public static List<Type> AdapterTypeList()
         {
-            // If the dictionary exists already return it
-            if (m_AdapterTypeList != null && m_AdapterTypeList.Count > 0)
+            lock (m_GetTypesLock)
+            {
+                // If the dictionary exists already return it
+                if (m_AdapterTypeList != null && m_AdapterTypeList.Count > 0)
+                    return m_AdapterTypeList;
+
+                // Otherwise, create it
+                ExtractAllTypes();
+
                 return m_AdapterTypeList;
-
-            // Otherwise, create it
-            ExtractAllTypes();
-
-            return m_AdapterTypeList;
+            }
         }
 
         /***************************************************/
 
         public static List<Type> AllTypeList()
         {
-            // If the dictionary exists already return it
-            if (m_AllTypeList != null && m_AllTypeList.Count > 0)
+            lock (m_GetTypesLock)
+            {
+                // If the dictionary exists already return it
+                if (m_AllTypeList != null && m_AllTypeList.Count > 0)
+                    return m_AllTypeList;
+
+                // Otherwise, create it
+                ExtractAllTypes();
+
                 return m_AllTypeList;
-
-            // Otherwise, create it
-            ExtractAllTypes();
-
-            return m_AllTypeList;
+            }
         }
 
         /***************************************************/
 
         public static List<Type> EngineTypeList()
         {
-            // If the dictionary exists already return it
-            if (m_EngineTypeList != null && m_EngineTypeList.Count > 0)
+            lock (m_GetMethodsLock)
+            {
+                // If the dictionary exists already return it
+                if (m_EngineTypeList != null && m_EngineTypeList.Count > 0)
+                    return m_EngineTypeList;
+
+                // Otherwise, create it
+                ExtractAllMethods();
+
                 return m_EngineTypeList;
-
-            // Otherwise, create it
-            ExtractAllMethods();
-
-            return m_EngineTypeList;
+            }
         }
 
 
@@ -173,7 +188,7 @@ namespace BH.Engine.Reflection
         private static List<Type> m_AdapterTypeList = new List<Type>();
         private static List<Type> m_AllTypeList = new List<Type>();
         private static List<Type> m_InterfaceList = new List<Type>();
-
+        private static readonly object m_GetTypesLock = new object();
 
         /***************************************************/
     }

--- a/Reflection_Engine/Query/UsedAssemblies.cs
+++ b/Reflection_Engine/Query/UsedAssemblies.cs
@@ -39,14 +39,17 @@ namespace BH.Engine.Reflection
         {
             try
             {
-                if (m_AllAssemblies == null || m_AllAssemblies.Count == 0)
-                    ExtractAllAssemblies();
+                lock (m_GetAssembliesLock)
+                {
+                    if (m_AllAssemblies == null || m_AllAssemblies.Count == 0)
+                        ExtractAllAssemblies();
 
-                IEnumerable<AssemblyName> assemblyNames = assembly.GetReferencedAssemblies();
-                foreach (AssemblyName name in assemblyNames)
-                    Compute.RecordWarning("Could not find the assembly with the name " + name);
+                    IEnumerable<AssemblyName> assemblyNames = assembly.GetReferencedAssemblies();
+                    foreach (AssemblyName name in assemblyNames)
+                        Compute.RecordWarning("Could not find the assembly with the name " + name);
 
-                return assemblyNames.Where(x => m_BHoMAssemblies.ContainsKey(x.FullName)).Select(x => m_BHoMAssemblies[x.FullName]).ToList();
+                    return assemblyNames.Where(x => m_BHoMAssemblies.ContainsKey(x.FullName)).Select(x => m_BHoMAssemblies[x.FullName]).ToList();
+                }
             }
             catch (Exception e)
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2003

<!-- Add short description of what has been fixed -->

Adding padlocks around methods calling ExtractAllMethods and ExtractAllTypes to make methods threadsafe.

This is an attempt of solving the https://github.com/BHoM/BHoM_UI/issues/305 issue.

Note that the `m_GetMethodsLock` in the Engine types is intentional, as engine types currently is extracted when extracting methods. Something we might want to change in the future, but outside the scope of this PR.

**EDIT:** Had a look through and added locks to other potentially unsafe places for the BHoMAnalytics as well as making sure the whole Reflection_Engine got covered. This includes LoadAllAssemblies, AssemblyList and RegisterTypes in BSON converts. Not sure if the one is BSON is needed, as Mongo might be threadsafe and able to cope with it, but rather safe than sorry.

### Test files
<!-- Link to test files to validate the proposed changes -->

No real testfile needed. Everything should work as before, but hopefully stops the crashes of GH at startup.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->