### PR TITLE
MEP_Engine: Added support to Cable Tray objects

### DIFF
--- a/MEP_Engine/Create/CableTrayConnectionProperty.cs
+++ b/MEP_Engine/Create/CableTrayConnectionProperty.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
  *
@@ -20,18 +20,15 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.ComponentModel;
 
-using BH.oM.MEP.MaterialFragments;
-using BH.oM.MEP.SectionProperties;
-using BH.Engine.Spatial;
-using BH.Engine.Geometry;
 using BH.oM.Reflection.Attributes;
+using BH.oM.MEP.ConnectionProperties;
 
 namespace BH.Engine.MEP
 {
@@ -40,24 +37,19 @@ namespace BH.Engine.MEP
         /***************************************************/
         /****               Public Methods              ****/
         /***************************************************/
-        [Description("Creates a composite Cable Tray sectionProfile.")]
-        [Input("sectionProfile", "A base ShapeProfile upon which to base the composite section.")]
-        [Input("cableTrayMaterial", "Material properties for the Cable Tray object.")]
-        [Output("cableTraySectionProperty", "Cable Tray Section property used to provide accurate Cable Tray assembly and capacities.")]
-        public static CableTraySectionProperty CableTraySectionProperty(SectionProfile sectionProfile, IMEPMaterial cableTrayMaterial = null, string name = "")
+
+        [Description("Returns a cable tray connection property")]
+        [Input("isStartConnected", "Whether the start point of the Cable Tray is connected to another segment or not.")]
+        [Input("isEndConnected", "Whether the end point of the Cable Tray is connected to another segment or not.")]
+        [Output("cableTrayConnectionProperty", "A cable tray connection property")]
+        public static CableTrayConnectionProperty CableTrayConnectionProperty(bool isStartConnected, bool isEndConnected)
         {
-            double elementSolidArea = sectionProfile.ElementProfile.Area();
-            double elementVoidArea = sectionProfile.ElementProfile.VoidArea();          
-
-            CableTraySectionProperty property = new CableTraySectionProperty(sectionProfile, elementSolidArea, elementVoidArea);
-            property.Name = name;
-
-            if (property == null)
+            return new CableTrayConnectionProperty
             {
-                BH.Engine.Reflection.Compute.RecordError("Insufficient information to create a CableTraySectionProperty. Please ensure you have all required inputs.");
-            }
-            return property;
+                IsStartConnected = isStartConnected,
+                IsEndConnected = isEndConnected,      
+            };
         }
-        /***************************************************/
     }
 }
+

--- a/MEP_Engine/Create/Elements/CableTray.cs
+++ b/MEP_Engine/Create/Elements/CableTray.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.MEP.Elements;
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using BH.oM.MEP.SectionProperties;
+
+namespace BH.Engine.MEP
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        [Description("Creates a Cable Tray object.")]
+        [Input("line", "A line that determines the Cable Tray's length and direction.")]        
+        [Input("sectionProperty", "Provide a cableTraySectionProperty to prepare a composite Cable Tray section for accurate capacity and spatial quality.")]
+        [Input("orientationAngle", "This is the Cable Tray's planometric orientation angle (the rotation around its central axis created about the profile centroid).")]        
+        [Output("cableTray", "A Cable Tray object is a passageway which conveys material (typically cables)")]
+        public static CableTray CableTray(Line line, CableTraySectionProperty sectionProperty = null, double orientationAngle = 0)
+        {
+            return new CableTray
+            {
+                StartNode = (Node)line.Start,
+                EndNode = (Node)line.End,
+                SectionProperty = sectionProperty,
+                OrientationAngle = orientationAngle,
+            };
+        }
+        /***************************************************/
+    }
+}

--- a/MEP_Engine/Create/Elements/CableTray.cs
+++ b/MEP_Engine/Create/Elements/CableTray.cs
@@ -31,26 +31,29 @@ using BH.oM.MEP.Elements;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using BH.oM.MEP.SectionProperties;
+using BH.oM.MEP.ConnectionProperties;
 
 namespace BH.Engine.MEP
 {
     public static partial class Create
     {
         /***************************************************/
-        /**** Public Methods                            ****/
+        /****              Public Methods               ****/
         /***************************************************/
         [Description("Creates a Cable Tray object.")]
         [Input("line", "A line that determines the Cable Tray's length and direction.")]        
         [Input("sectionProperty", "Provide a cableTraySectionProperty to prepare a composite Cable Tray section for accurate capacity and spatial quality.")]
+        [Input("connectionProperty", "Provide a cableTrayConnectionProperty to store information about its physical connectors.")]
         [Input("orientationAngle", "This is the Cable Tray's planometric orientation angle (the rotation around its central axis created about the profile centroid).")]        
         [Output("cableTray", "A Cable Tray object is a passageway which conveys material (typically cables)")]
-        public static CableTray CableTray(Line line, CableTraySectionProperty sectionProperty = null, double orientationAngle = 0)
+        public static CableTray CableTray(Line line, CableTraySectionProperty sectionProperty = null, CableTrayConnectionProperty connectionProperty = null, double orientationAngle = 0)
         {
             return new CableTray
             {
                 StartNode = (Node)line.Start,
                 EndNode = (Node)line.End,
                 SectionProperty = sectionProperty,
+                ConnectionProperty = connectionProperty,
                 OrientationAngle = orientationAngle,
             };
         }

--- a/MEP_Engine/Create/Elements/CableTraySectionProperty.cs
+++ b/MEP_Engine/Create/Elements/CableTraySectionProperty.cs
@@ -1,0 +1,63 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System.ComponentModel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.MEP.MaterialFragments;
+using BH.oM.MEP.SectionProperties;
+using BH.Engine.Spatial;
+using BH.Engine.Geometry;
+using BH.oM.Reflection.Attributes;
+
+namespace BH.Engine.MEP
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        [Description("Creates a composite Cable Tray sectionProfile.")]
+        [Input("sectionProfile", "A base ShapeProfile upon which to base the composite section.")]
+        [Input("cableTrayMaterial", "Material properties for the Cable Tray object.")]
+        [Output("cableTraySectionProperty", "Cable Tray Section property used to provide accurate Cable Tray assembly and capacities.")]
+        public static CableTraySectionProperty CableTraySectionProperty(SectionProfile sectionProfile, IMEPMaterial cableTrayMaterial = null, string name = "")
+        {
+            double elementSolidArea = sectionProfile.ElementProfile.Area();
+            double elementVoidArea = sectionProfile.ElementProfile.VoidArea();          
+
+            CableTraySectionProperty property = new CableTraySectionProperty(sectionProfile, elementSolidArea, elementVoidArea);
+            property.Name = name;
+
+            if (property == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Insufficient information to create a CableTraySectionProperty. Please ensure you have all required inputs.");
+            }
+            return property;
+        }
+        /***************************************************/
+    }
+}

--- a/MEP_Engine/MEP_Engine.csproj
+++ b/MEP_Engine/MEP_Engine.csproj
@@ -71,7 +71,9 @@
   <ItemGroup>
     <Compile Include="Create\CoolingCoil.cs" />
     <Compile Include="Create\ElectricalConnector.cs" />
+    <Compile Include="Create\Elements\CableTray.cs" />
     <Compile Include="Create\Elements\Duct.cs" />
+    <Compile Include="Create\Elements\CableTraySectionProperty.cs" />
     <Compile Include="Create\Elements\DuctSectionProperty.cs" />
     <Compile Include="Create\Elements\Pipe.cs" />
     <Compile Include="Create\Elements\PipeSectionProperty.cs" />

--- a/MEP_Engine/MEP_Engine.csproj
+++ b/MEP_Engine/MEP_Engine.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Create\CoolingCoil.cs" />
+    <Compile Include="Create\CableTrayConnectionProperty.cs" />
     <Compile Include="Create\ElectricalConnector.cs" />
     <Compile Include="Create\Elements\CableTray.cs" />
     <Compile Include="Create\Elements\Duct.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
[BHoM/BHoM#1000](https://github.com/BHoM/BHoM/pull/1000)

   
## Issues addressed by this PR
Closes #2006 

<!-- Add short description of what has been fixed -->
Added support for Cable Tray object.

### Test files
Test file [here](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/MEP_Engine/Issue%20%232006-Add%20support%20to%20Cable%20Tray%20objects?csf=1&web=1&e=9df38m). No instructions needed


### Changelog
Added `BH.Engine.MEP.CableTray` and `BH.Engine.MEP.CableTraySectionProperty`.

