### PR TITLE
BH.Engine.MEP.Create.PipeSectionProperty fixed not to crash on null insulation/lining

### DIFF
--- a/MEP_Engine/Create/Elements/PipeSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/PipeSectionProperty.cs
@@ -55,13 +55,13 @@ namespace BH.Engine.MEP
             double elementSolidArea = sectionProfile.ElementProfile.Area();
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
 
-            double liningSolidArea = sectionProfile.LiningProfile.Area();
-            double liningVoidArea = sectionProfile.LiningProfile.VoidArea();
+            double liningSolidArea = 0;
+            double liningVoidArea = double.NaN;
 
-            double insulationSolidArea = sectionProfile.InsulationProfile.Area();
-            double insulationVoidArea = sectionProfile.InsulationProfile.VoidArea();
+            double insulationSolidArea = 0;
+            double insulationVoidArea = double.NaN;
 
-            if(sectionProfile.LiningProfile != null)
+            if (sectionProfile.LiningProfile != null)
             {
                 liningSolidArea = sectionProfile.LiningProfile.Area();
                 liningVoidArea = sectionProfile.LiningProfile.VoidArea();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2012

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FRevit%5FToolkit%2FRevit%5FToolkit%2DIssue858%2DPullPipeBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.Engine.MEP.Create.PipeSectionProperty` fixed not to crash on null insulation/lining

