### PR TITLE
Spatial_Engine: ElementVertices fixed to return actual vertices

### DIFF
--- a/Spatial_Engine/Query/ElementVertices.cs
+++ b/Spatial_Engine/Query/ElementVertices.cs
@@ -56,7 +56,11 @@ namespace BH.Engine.Spatial
         public static List<Point> ElementVertices(this IElement1D element1D)
         {
             ICurve curve = element1D.IGeometry();
-            List<Point> vertices = curve.IDiscontinuityPoints();
+            List<Point> vertices;
+            if (curve is Polyline)
+                vertices = ((Polyline)curve).ControlPoints;
+            else
+                vertices = curve.IDiscontinuityPoints();
 
             if (curve.IIsClosed())
                 vertices.RemoveAt(vertices.Count - 1);

--- a/Spatial_Engine/Query/ElementVertices.cs
+++ b/Spatial_Engine/Query/ElementVertices.cs
@@ -56,11 +56,19 @@ namespace BH.Engine.Spatial
         public static List<Point> ElementVertices(this IElement1D element1D)
         {
             ICurve curve = element1D.IGeometry();
-            List<Point> vertices;
-            if (curve is Polyline)
-                vertices = ((Polyline)curve).ControlPoints;
-            else
-                vertices = curve.IDiscontinuityPoints();
+
+            List<Point> vertices = new List<Point>();
+            List<ICurve> subParts = curve.ISubParts().ToList();
+            if (subParts.Count == 0 || subParts.All(x => x is Circle))
+                return new List<Point>();
+
+            vertices.Add(curve.IStartPoint());
+            foreach (ICurve c in subParts)
+            {
+                List<Point> discPoints = c.IDiscontinuityPoints();
+                if (discPoints.Count != 0)
+                    vertices.AddRange(discPoints.Skip(1));
+            }
 
             if (curve.IIsClosed())
                 vertices.RemoveAt(vertices.Count - 1);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2017

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FSpatial%5FEngine%2FIssues%2FSpatial%5FEngine%5F%232017%5FElementVerticesBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - both issue specific test as well as updated general test


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Following #2017, my understanding of different types of points in relationship to their parent curve:
> * control points - control points of a curve in its nurbs form (currently simplified for `Arc` and `Circle` in the BHoM)
> * discontinuity points - points at geometrical discontinuities of a curve (discrete change in the tangent)
> * vertices - control points in case of a `Polyline` (see the example above) and discontinuity points for all other types - in general, all points that are either a discontinuity or are explicitly specified in the curve definition

The method subject to this PR should return the third option, as far as I see it.