### PR TITLE
Spatial_Engine: Missing methods added

### DIFF
--- a/Spatial_Engine/Query/Area.cs
+++ b/Spatial_Engine/Query/Area.cs
@@ -39,9 +39,9 @@ namespace BH.Engine.Spatial
         /****            IElement0D            ****/
         /******************************************/
 
-        [Description("Queries the area of an IElement0D. Always returns zero due to zero-dimensionality of an IElement0D.")]
+        [Description("Queries the area of the geometrical representation of an IElement0D. Always returns zero due to zero-dimensionality of an IElement0D.")]
         [Input("element0D", "The IElement0D to query the area of.")]
-        [Output("area", "The area of an IElement0D.", typeof(Area))]
+        [Output("area", "The area of the geometrical representation of an IElement0D.", typeof(Area))]
         public static double Area(this IElement0D element0D)
         {
             return 0;
@@ -52,9 +52,9 @@ namespace BH.Engine.Spatial
         /****            IElement1D            ****/
         /******************************************/
 
-        [Description("Queries the area of an IElement1D. Always returns zero because an IElement1D has only 1 dimension, i.e. should not be represented as a region even if closed.")]
+        [Description("Queries the area of the geometrical representation of an IElement1D. Always returns zero because an IElement1D has only 1 dimension, i.e. should not be represented as a region even if closed.")]
         [Input("element1D", "The IElement1D to query the area of.")]
-        [Output("area", "The area of an IElement1D.", typeof(Area))]
+        [Output("area", "The area of the geometrical representation of an IElement1D.", typeof(Area))]
         public static double Area(this IElement1D element1D)
         {
             BH.Engine.Reflection.Compute.RecordWarning("Area of an IElement1D cannot be queried because IElement1D has only 1 dimension, i.e. should not be represented as a region even if closed.");
@@ -127,9 +127,9 @@ namespace BH.Engine.Spatial
         /****   Public Methods - Interfaces    ****/
         /******************************************/
 
-        [Description("Queries the area of an IElement.")]
+        [Description("Queries the area of the geometrical representation of an IElement.")]
         [Input("element", "The IElement to query the area of.")]
-        [Output("area", "The area of an IElement.", typeof(Area))]
+        [Output("area", "The area of the geometrical representation of an IElement.", typeof(Area))]
         public static double IArea(this IElement element)
         {
             return Area(element as dynamic);

--- a/Spatial_Engine/Query/Area.cs
+++ b/Spatial_Engine/Query/Area.cs
@@ -130,7 +130,7 @@ namespace BH.Engine.Spatial
         [Description("Queries the area of an IElement.")]
         [Input("element", "The IElement to query the area of.")]
         [Output("area", "The area of an IElement.", typeof(Area))]
-        public static bool IArea(this IElement element)
+        public static double IArea(this IElement element)
         {
             return Area(element as dynamic);
         }

--- a/Spatial_Engine/Query/Area.cs
+++ b/Spatial_Engine/Query/Area.cs
@@ -36,6 +36,33 @@ namespace BH.Engine.Spatial
     public static partial class Query
     {
         /******************************************/
+        /****            IElement0D            ****/
+        /******************************************/
+
+        [Description("Queries the area of an IElement0D. Always returns zero due to zero-dimensionality of an IElement0D.")]
+        [Input("element0D", "The IElement0D to query the area of.")]
+        [Output("area", "The area of an IElement0D.", typeof(Area))]
+        public static double Area(this IElement0D element0D)
+        {
+            return 0;
+        }
+
+
+        /******************************************/
+        /****            IElement1D            ****/
+        /******************************************/
+
+        [Description("Queries the area of an IElement1D. Always returns zero because an IElement1D has only 1 dimension, i.e. should not be represented as a region even if closed.")]
+        [Input("element1D", "The IElement1D to query the area of.")]
+        [Output("area", "The area of an IElement1D.", typeof(Area))]
+        public static double Area(this IElement1D element1D)
+        {
+            BH.Engine.Reflection.Compute.RecordWarning("Area of an IElement1D cannot be queried because IElement1D has only 1 dimension, i.e. should not be represented as a region even if closed.");
+            return 0;
+        }
+
+
+        /******************************************/
         /****            IElement2D            ****/
         /******************************************/
 
@@ -93,6 +120,19 @@ namespace BH.Engine.Spatial
             // Using region integration as the Curves are defined on the XY-Plane.
             depth = depth.Select(x => x % 2 == 0 ? 1 : -1).ToArray();   // positive area as 1 and negative area as -1
             return curvesZ.Select((x, i) => Math.Abs(x.IIntegrateRegion(0)) * depth[i]).Sum();
+        }
+
+
+        /******************************************/
+        /****   Public Methods - Interfaces    ****/
+        /******************************************/
+
+        [Description("Queries the area of an IElement.")]
+        [Input("element", "The IElement to query the area of.")]
+        [Output("area", "The area of an IElement.", typeof(Area))]
+        public static bool IArea(this IElement element)
+        {
+            return Area(element as dynamic);
         }
 
         /******************************************/

--- a/Spatial_Engine/Query/Centroid.cs
+++ b/Spatial_Engine/Query/Centroid.cs
@@ -36,10 +36,10 @@ namespace BH.Engine.Spatial
         /****            IElement0D            ****/
         /******************************************/
         
-        [Description("Queries the centre of weight of an IElement0D. Always returns the point location due to zero-dimensionality of an IElement0D.")]
+        [Description("Queries the centre of weight for the homogeneous geometrical representation of an IElement0D. Always returns the point location due to zero-dimensionality of an IElement0D.")]
         [Input("element0D", "The IElement0D with the geometry to get the centre of weight of.")]
         [Output("centroid", "The Point at the centre of weight for the homogeneous geometrical representation of the IElement0D.")]
-        public static Point Centroid(this IElement0D element0D)
+        public static Point Centroid(this IElement0D element0D, double tolerance = Tolerance.Distance)
         {
             return element0D.IGeometry();
         }
@@ -79,10 +79,10 @@ namespace BH.Engine.Spatial
         /****   Public Methods - Interfaces    ****/
         /******************************************/
         
-        [Description("Queries the centre of weight for a representation of the IElement.")]
+        [Description("Queries the centre of weight for the homogeneous geometrical representation of an IElement.")]
         [Input("element", "The IElement with the geometry to get the centre of mass of.")]
         [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
-        [Output("centroid", "The Point at the centre of weight for the homogeneous geometrical representation of the IElement.")]
+        [Output("centroid", "The Point at the centre of weight for the homogeneous geometrical representation of an IElement.")]
         public static Point ICentroid(this IElement element, double tolerance = Tolerance.Distance)
         {
             return Centroid(element as dynamic, tolerance);

--- a/Spatial_Engine/Query/Centroid.cs
+++ b/Spatial_Engine/Query/Centroid.cs
@@ -83,7 +83,7 @@ namespace BH.Engine.Spatial
         [Input("element", "The IElement with the geometry to get the centre of mass of.")]
         [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
         [Output("centroid", "The Point at the centre of weight for the homogeneous geometrical representation of the IElement.")]
-        public static bool ICentroid(this IElement element, double tolerance = Tolerance.Distance)
+        public static Point ICentroid(this IElement element, double tolerance = Tolerance.Distance)
         {
             return Centroid(element as dynamic, tolerance);
         }

--- a/Spatial_Engine/Query/Centroid.cs
+++ b/Spatial_Engine/Query/Centroid.cs
@@ -33,6 +33,19 @@ namespace BH.Engine.Spatial
     public static partial class Query
     {
         /******************************************/
+        /****            IElement0D            ****/
+        /******************************************/
+        
+        [Description("Queries the centre of weight of an IElement0D. Always returns the point location due to zero-dimensionality of an IElement0D.")]
+        [Input("element0D", "The IElement0D with the geometry to get the centre of weight of.")]
+        [Output("centroid", "The Point at the centre of weight for the homogeneous geometrical representation of the IElement0D.")]
+        public static Point Centroid(this IElement0D element0D)
+        {
+            return element0D.IGeometry();
+        }
+
+
+        /******************************************/
         /****            IElement1D            ****/
         /******************************************/
 
@@ -59,6 +72,20 @@ namespace BH.Engine.Spatial
         public static Point Centroid(this IElement2D element2D, double tolerance = Tolerance.Distance)
         {
             return Geometry.Query.Centroid(new List<ICurve> { element2D.OutlineCurve() }, element2D.InternalOutlineCurves(), tolerance);
+        }
+
+
+        /******************************************/
+        /****   Public Methods - Interfaces    ****/
+        /******************************************/
+        
+        [Description("Queries the centre of weight for a representation of the IElement.")]
+        [Input("element", "The IElement with the geometry to get the centre of mass of.")]
+        [Input("tolerance", "Distance tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Distance")]
+        [Output("centroid", "The Point at the centre of weight for the homogeneous geometrical representation of the IElement.")]
+        public static bool ICentroid(this IElement element, double tolerance = Tolerance.Distance)
+        {
+            return Centroid(element as dynamic, tolerance);
         }
 
         /******************************************/

--- a/Spatial_Engine/Query/ControlPoints.cs
+++ b/Spatial_Engine/Query/ControlPoints.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Spatial
         /****            IElement0D            ****/
         /******************************************/
 
-        [Description("Queries the control points of the geometrical representation of the IElement0D. Always returns the point location due to zero-dimensionality of an IElement0D.")]
+        [Description("Queries the control points of the geometrical representation of an IElement0D. Always returns the point location due to zero-dimensionality of an IElement0D.")]
         [Input("element0D", "The IElement0D with the geometry to get the control points from.")]
         [Output("cPoints", "The control points of the geometrical representation of an IElement0D.")]
         public static List<Point> ControlPoints(this IElement0D element0D)
@@ -82,7 +82,7 @@ namespace BH.Engine.Spatial
         /****             IElement             ****/
         /******************************************/
 
-        [Description("Queries the control points of the geometrical representation of the IElement.")]
+        [Description("Queries the control points of the geometrical representation of an IElement.")]
         [Input("element", "The IElement with the geometry to get the control points from.")]
         [Output("cPoints", "The control points of the geometrical representation of an IElement.")]
         public static List<Point> IControlPoints(this IElement element)

--- a/Spatial_Engine/Query/ControlPoints.cs
+++ b/Spatial_Engine/Query/ControlPoints.cs
@@ -31,6 +31,19 @@ namespace BH.Engine.Spatial
     public static partial class Query
     {
         /******************************************/
+        /****            IElement0D            ****/
+        /******************************************/
+
+        [Description("Queries the control points of the geometrical representation of the IElement0D. Always returns the point location due to zero-dimensionality of an IElement0D.")]
+        [Input("element0D", "The IElement0D with the geometry to get the control points from.")]
+        [Output("cPoints", "The control points of the geometrical representation of an IElement0D.")]
+        public static List<Point> ControlPoints(this IElement0D element0D)
+        {
+            return new List<Point> { element0D.IGeometry() };
+        }
+
+
+        /******************************************/
         /****            IElement1D            ****/
         /******************************************/
 
@@ -62,6 +75,19 @@ namespace BH.Engine.Spatial
                 }
             }
             return pts;
+        }
+
+
+        /******************************************/
+        /****             IElement             ****/
+        /******************************************/
+
+        [Description("Queries the control points of the geometrical representation of the IElement.")]
+        [Input("element", "The IElement with the geometry to get the control points from.")]
+        [Output("cPoints", "The control points of the geometrical representation of an IElement.")]
+        public static List<Point> IControlPoints(this IElement element)
+        {
+            return ControlPoints(element as dynamic);
         }
 
         /******************************************/

--- a/Spatial_Engine/Query/ElementCurves.cs
+++ b/Spatial_Engine/Query/ElementCurves.cs
@@ -34,10 +34,24 @@ namespace BH.Engine.Spatial
     public static partial class Query
     {
         /******************************************/
+        /****            IElement0D            ****/
+        /******************************************/
+
+        [Description("Queries the defining curves of the IElement0D. Always returns empty collection due to zero-dimensionality of an IElement0D.")]
+        [Input("element0D", "The IElement0D to extract the defining curves from.")]
+        [Input("recursive", "Has no effect for IElement0D. Input here to unify inputs between all IElements.")]
+        [Output("elementCurves", "The curves defining the base geometry of the IElement0D.")]
+        public static List<ICurve> ElementCurves(this IElement0D element0D, bool recursive = true)
+        {
+            return new List<ICurve>();
+        }
+
+
+        /******************************************/
         /****            IElement1D            ****/
         /******************************************/
 
-        [Description("Queries the geometricly defining curve of the IElement1D.")]
+        [Description("Queries the defining curves of the IElement1D.")]
         [Input("element1D", "The IElement1D of which to get the curve definintion.")]
         [Input("recursive", "Has no effect for IElement1D. Input here to unify inputs between all IElements.")]
         [Output("elementCurves", "The curve defining the base geometry of the IElement1D.")]

--- a/Spatial_Engine/Query/ElementCurves.cs
+++ b/Spatial_Engine/Query/ElementCurves.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Spatial
         /****            IElement0D            ****/
         /******************************************/
 
-        [Description("Queries the defining curves of the IElement0D. Always returns empty collection due to zero-dimensionality of an IElement0D.")]
+        [Description("Queries the defining curves of an IElement0D. Always returns empty collection due to zero-dimensionality of an IElement0D.")]
         [Input("element0D", "The IElement0D to extract the defining curves from.")]
         [Input("recursive", "Has no effect for IElement0D. Input here to unify inputs between all IElements.")]
         [Output("elementCurves", "The curves defining the base geometry of the IElement0D.")]
@@ -51,7 +51,7 @@ namespace BH.Engine.Spatial
         /****            IElement1D            ****/
         /******************************************/
 
-        [Description("Queries the defining curves of the IElement1D.")]
+        [Description("Queries the defining curves of an IElement1D.")]
         [Input("element1D", "The IElement1D of which to get the curve definintion.")]
         [Input("recursive", "Has no effect for IElement1D. Input here to unify inputs between all IElements.")]
         [Output("elementCurves", "The curve defining the base geometry of the IElement1D.")]

--- a/Spatial_Engine/Query/IsSelfIntersecting.cs
+++ b/Spatial_Engine/Query/IsSelfIntersecting.cs
@@ -20,19 +20,30 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Geometry;
 using BH.oM.Dimensional;
 using BH.oM.Geometry;
 using BH.oM.Quantities.Attributes;
 using BH.oM.Reflection.Attributes;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace BH.Engine.Spatial
 {
     public static partial class Query
     {
+        /******************************************/
+        /****            IElement0D            ****/
+        /******************************************/
+
+        [Description("Returns if the one dimensional representation of the IElement0D is closer to itself than the tolerance at any two points. Always false due to zero-dimensionality of an IElement0D.")]
+        [Input("element0D", "The IElement0D to evaluate self intersections from.")]
+        [Input("tolerance", "Minimum distance to be considered intersecting.", typeof(Length))]
+        [Output("A boolean which is true if the IElement0D is self intersecting.")]
+        public static bool IsSelfIntersecting(this IElement0D element0D, double tolerance = Tolerance.Distance)
+        {
+            return false;
+        }
+
+
         /******************************************/
         /****            IElement1D            ****/
         /******************************************/
@@ -67,6 +78,20 @@ namespace BH.Engine.Spatial
             }
 
             return false;
+        }
+
+
+        /******************************************/
+        /****   Public Methods - Interfaces    ****/
+        /******************************************/
+
+        [Description("Returns if the one dimensional representation of the IElement is closer to itself than the tolerance at any two points.")]
+        [Input("element", "The IElement to evaluate self intersections from.")]
+        [Input("tolerance", "Minimum distance to be considered intersecting.", typeof(Length))]
+        [Output("A boolean which is true if the IElement is self intersecting.")]
+        public static bool IIsSelfIntersecting(this IElement element, double tolerance = Tolerance.Distance)
+        {
+            return IsSelfIntersecting(element as dynamic, tolerance);
         }
 
         /******************************************/

--- a/Spatial_Engine/Query/IsSelfIntersecting.cs
+++ b/Spatial_Engine/Query/IsSelfIntersecting.cs
@@ -34,10 +34,10 @@ namespace BH.Engine.Spatial
         /****            IElement0D            ****/
         /******************************************/
 
-        [Description("Returns if the one dimensional representation of the IElement0D is closer to itself than the tolerance at any two points. Always false due to zero-dimensionality of an IElement0D.")]
+        [Description("Checks if the one dimensional representation of the IElement0D is closer to itself than the tolerance at any two points. Always false because a zero-dimensional IElement0D does not consist of curves.")]
         [Input("element0D", "The IElement0D to evaluate self intersections from.")]
         [Input("tolerance", "Minimum distance to be considered intersecting.", typeof(Length))]
-        [Output("A boolean which is true if the IElement0D is self intersecting.")]
+        [Output("A boolean which is true if the geometrical representation of an IElement0D is self intersecting.")]
         public static bool IsSelfIntersecting(this IElement0D element0D, double tolerance = Tolerance.Distance)
         {
             return false;
@@ -48,7 +48,7 @@ namespace BH.Engine.Spatial
         /****            IElement1D            ****/
         /******************************************/
 
-        [Description("Returns if the one dimensional representation of the IElement1D is closer to itself than the tolerance at any two points.")]
+        [Description("Checks if the one dimensional representation of the IElement1D is closer to itself than the tolerance at any two points.")]
         [Input("element1D", "The IElement1D to evaluate self intersections from.")]
         [Input("tolerance", "Minimum distance to be considered intersecting.", typeof(Length))]
         [Output("A boolean which is true if the IElement1Ds curve is self intersecting.")]
@@ -62,7 +62,7 @@ namespace BH.Engine.Spatial
         /****            IElement2D            ****/
         /******************************************/
 
-        [Description("Returns if any of the element curves of the IElement2D is closer to itself than the tolerance at any two points. Does not check for intersections between external and internal curves, or between different internal curves.")]
+        [Description("Checks if any of the element curves of the IElement2D is closer to itself than the tolerance at any two points. Does not check for intersections between external and internal curves, or between different internal curves.")]
         [Input("element2D", "The IElement2D which curves are to be evaluated for self intersection.")]
         [Input("tolerance", "Minimum distance to be considered intersecting.", typeof(Length))]
         [Output("A boolean which is true if any of the IElement2Ds element curves are self intersecting.")]
@@ -85,10 +85,10 @@ namespace BH.Engine.Spatial
         /****   Public Methods - Interfaces    ****/
         /******************************************/
 
-        [Description("Returns if the one dimensional representation of the IElement is closer to itself than the tolerance at any two points.")]
+        [Description("Checks if any of the curves defining an IElement is closer to itself than the tolerance at any two points (is self intersecting). In case of IElement2D, does not check for intersections between external and internal curves, or between different internal curves.")]
         [Input("element", "The IElement to evaluate self intersections from.")]
         [Input("tolerance", "Minimum distance to be considered intersecting.", typeof(Length))]
-        [Output("A boolean which is true if the IElement is self intersecting.")]
+        [Output("A boolean which is true if any of the IElement's curves is self intersecting.")]
         public static bool IIsSelfIntersecting(this IElement element, double tolerance = Tolerance.Distance)
         {
             return IsSelfIntersecting(element as dynamic, tolerance);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2019

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed - obvious cases added. But I encourage to read the code carefully and randomly test the changes!


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Missing Spatial_Engine methods added:
- IsSelfIntersecting (`IElement0D`, interface)
- ElementCurves(`IElement0D`)
- ControlPoints(`IElement0D`, interface)
- Centroid(`IElement0D`, interface)
- Area(`IElement0D`, `IElement1D`, interface)

### Additional comments
<!-- As required -->