### PR TITLE
Geometry_Engine: Using explicit casting in Offset to avoid losing cPts while passing arguments to Polyline method

### DIFF
--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -269,8 +269,7 @@ namespace BH.Engine.Geometry
             //if there are only Line segmensts switching to polyline method which is more reliable 
             if (curve.Curves.All(x => x is Line))
             {
-                Polyline polyline = (Polyline)curve;
-                polyline = polyline.Offset(offset, normal, tangentExtensions, tolerance);
+                Polyline polyline = ((Polyline)curve).Offset(offset, normal, tangentExtensions, tolerance);
                 if (polyline == null)
                     return null;
 

--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -269,7 +269,7 @@ namespace BH.Engine.Geometry
             //if there are only Line segmensts switching to polyline method which is more reliable 
             if (curve.Curves.All(x => x is Line))
             {
-                Polyline polyline = new Polyline { ControlPoints = curve.DiscontinuityPoints() };
+                Polyline polyline = (Polyline)curve;
                 polyline = polyline.Offset(offset, normal, tangentExtensions, tolerance);
                 if (polyline == null)
                     return null;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2021 

<!-- Add short description of what has been fixed -->
Replaced former solution with explicit casting to avoid missing control points (especially for closed curves).

### Test files
<!-- Link to test files to validate the proposed changes -->
[Issue specific](https://burohappold.sharepoint.com/:f:/s/BHoM/EoUweCi8HYVBsS42hfgiDq4BwcSR1vzY7mbYByRTZM7mkA?e=MhFHHx)
[General offset test](https://burohappold.sharepoint.com/:f:/s/BHoM/EtBlmGmRgQNFrZn2dLnm0EUBD5LFSAt13Lz7uL01kJxpFg?e=du27WM)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Modified `Offset(Polyline)` method in the `Geometry_Engine`

### Additional comments
<!-- As required -->