### PR TITLE
Reflection_Engine: Remove calls to Clone methods and Clean SetProperty methods

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -60,6 +60,12 @@ namespace BH.Engine.Reflection
 
             if (prop != null)
             {
+                if (!prop.CanWrite)
+                {
+                    Engine.Reflection.Compute.RecordError("This property doesn't have a public setter so it is not possible to modify it.");
+                    return obj;
+                }
+
                 if (value.GetType() != prop.PropertyType && value.GetType().GenericTypeArguments.Length > 0 && prop.PropertyType.GenericTypeArguments.Length > 0)
                 {
                     value = Modify.CastGeneric(value as dynamic, prop.PropertyType.GenericTypeArguments[0]);


### PR DESCRIPTION
### NOTE: Depends on 

One PR on the BHoM_UI depends on this: https://github.com/BHoM/BHoM_UI/pull/326
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2065 

As discussed in https://github.com/BHoM/admin/issues/9, I have removed the cloning inside the only reflection method that was doing it.

Note that the BHoM_UI is already doing the cloning for the `Modify` and `SetProperty`. 

I have also cleaned the methods here because a lot of it was outdated legacy code:
- I have removed the `Modify.PropertyValue` because it was 
   - non-compliant in term of name
   - only working on BHoM object (for no reason since it was calling `SetProperty(this object,...)` anyways
   - was redundant with `SetProperty` method
- I have changed the output of `SetProperty` method to be compliant with the current state of the code. Note that that methods was not used anywhere in any repo. Ironically, we will later have all `Modify` methods to return void but it needs to be compliant until then. 
- Delete the `SetProperty` method that was taking list as first input. There was quite a few things that was incorrect in that method and, since it wasn't used anywhere and was not compliant for the UI, I decided to remove it. If you want a trip down to memory lane, this methods was migrated from teh BHoM_Adapter repo which is not using it anymore (see https://github.com/BHoM/BHoM_Engine/commit/1364a20af3443d13fddd73de76a752b5e6fd770e).

Make sure to also switch to the PR in BHoM_UI since the method name has changed from `PropertyName` to `SetPropertyName`. Because the `SetProperty` component is not a dynamic component, the change of name doesn't cause incompatibility with old saved components.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
A bit more changes that I initially intended but feels good to have that old legacy code finally cleaned up and compliant 😄 