### PR TITLE
Geometry_Engine: Replace calls to Clone, IClone, and GetShallowClone methods with calls to DeepClone and ShallowClone

### DIFF
--- a/Geometry_Engine/Compute/BooleanDifference.cs
+++ b/Geometry_Engine/Compute/BooleanDifference.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -37,7 +38,7 @@ namespace BH.Engine.Geometry
         public static List<Line> BooleanDifference(this Line line, Line refLine, double tolerance = Tolerance.Distance)
         {
             if (refLine.Length() <= tolerance)
-                return new List<Line> { line.Clone() };
+                return new List<Line> { line.DeepClone() };
 
             if (line.IsCollinear(refLine, tolerance))
             {
@@ -61,14 +62,14 @@ namespace BH.Engine.Geometry
                     Point aRPt = refLine.ControlPoints().Average();
 
                     if (aRPt.SquareDistance(splitLine[0]) > sqTol && aPt.SquareDistance(refLine) > sqTol)
-                        splitLine = new List<Line> { line.Clone() };
+                        splitLine = new List<Line> { line.DeepClone() };
                     else
                         splitLine = new List<Line>();
                 }
 
                 return splitLine;
             }
-            return new List<Line> { line.Clone() };
+            return new List<Line> { line.DeepClone() };
         }
 
         /***************************************************/
@@ -79,7 +80,7 @@ namespace BH.Engine.Geometry
 
             foreach (Line line in lines)
             {
-                List<Line> splitLine = new List<Line> { line.Clone() };
+                List<Line> splitLine = new List<Line> { line.DeepClone() };
                 int k = 0;
                 bool split = false;
                 do

--- a/Geometry_Engine/Compute/BooleanIntersection.cs
+++ b/Geometry_Engine/Compute/BooleanIntersection.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -84,7 +85,7 @@ namespace BH.Engine.Geometry
                     double sqTol = tolerance * tolerance;
                     Point aPt = splitLine[0].ControlPoints().Average();
                     Point aRPt = refLine.ControlPoints().Average();
-                    return aRPt.SquareDistance(splitLine[0]) > sqTol && aPt.SquareDistance(refLine) > sqTol ? null : line.Clone();
+                    return aRPt.SquareDistance(splitLine[0]) > sqTol && aPt.SquareDistance(refLine) > sqTol ? null : line.DeepClone();
                 }
             }
 
@@ -116,7 +117,7 @@ namespace BH.Engine.Geometry
             if (lines[0].Length() <= tolerance)
                 return null;
 
-            Line result = lines[0].Clone();
+            Line result = lines[0].DeepClone();
             for (int i = 1; i < lines.Count; i++)
             {
                 result = result.BooleanIntersection(lines[i], tolerance);

--- a/Geometry_Engine/Compute/BooleanUnion.cs
+++ b/Geometry_Engine/Compute/BooleanUnion.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -63,14 +64,14 @@ namespace BH.Engine.Geometry
                 }
             }
 
-            return new List<Line> { line.Clone(), refLine.Clone() };
+            return new List<Line> { line.DeepClone(), refLine.DeepClone() };
         }
 
         /***************************************************/
 
         public static List<Line> BooleanUnion(this List<Line> lines, double tolerance = Tolerance.Distance)
         {
-            List<Line> result = lines.Select(l => l.Clone()).ToList();
+            List<Line> result = lines.Select(l => l.DeepClone()).ToList();
             bool union;
             do
             {

--- a/Geometry_Engine/Compute/ClusterCollinear.cs
+++ b/Geometry_Engine/Compute/ClusterCollinear.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
@@ -43,14 +44,14 @@ namespace BH.Engine.Geometry
                 {
                     if (l.IsCollinear(ll[0], tolerance))
                     {
-                        ll.Add(l.Clone());
+                        ll.Add(l.DeepClone());
                         collinear = true;
                         break;
                     }
                 }
 
                 if (!collinear)
-                    lineClusters.Add(new List<Line> { l.Clone() });
+                    lineClusters.Add(new List<Line> { l.DeepClone() });
             }
 
             return lineClusters;

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -25,6 +25,7 @@ using BH.oM.Reflection.Attributes;
 using BH.oM.Geometry;
 using System;
 using System.Linq;
+using BH.Engine.Base;
 
 namespace BH.Engine.Geometry
 {
@@ -67,8 +68,8 @@ namespace BH.Engine.Geometry
                     outlinesByType.Add(new Tuple<Polyline, bool>(o, true));
             }
 
-            List<Polyline> panelOutlines = outlinesByType.Where(x => x.Item2 == true).Select(x => x.Item1.Clone()).ToList();
-            List<Polyline> panelOpenings = outlinesByType.Where(x => x.Item2 == false).Select(x => x.Item1.Clone()).ToList();
+            List<Polyline> panelOutlines = outlinesByType.Where(x => x.Item2 == true).Select(x => x.Item1.DeepClone()).ToList();
+            List<Polyline> panelOpenings = outlinesByType.Where(x => x.Item2 == false).Select(x => x.Item1.DeepClone()).ToList();
             return panelOutlines.DistributeOpenings(panelOpenings, tolerance);
         }
 
@@ -106,8 +107,8 @@ namespace BH.Engine.Geometry
                 if (!assigned)
                     outlinesByType.Add(new Tuple<ICurve, bool>(o, true));
             }
-            List<ICurve> panelOutlines = outlinesByType.Where(x => x.Item2 == true).Select(x => x.Item1.IClone()).ToList();
-            List<ICurve> panelOpenings = outlinesByType.Where(x => x.Item2 == false).Select(x => x.Item1.IClone()).ToList();
+            List<ICurve> panelOutlines = outlinesByType.Where(x => x.Item2 == true).Select(x => x.Item1.DeepClone()).ToList();
+            List<ICurve> panelOpenings = outlinesByType.Where(x => x.Item2 == false).Select(x => x.Item1.DeepClone()).ToList();
             return panelOutlines.DistributeOpenings(panelOpenings, tolerance);
         }
 

--- a/Geometry_Engine/Compute/RowEchelonForm.cs
+++ b/Geometry_Engine/Compute/RowEchelonForm.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
@@ -36,7 +37,7 @@ namespace BH.Engine.Geometry
         {
             // Strongly inspired by https://rosettacode.org/wiki/Reduced_row_echelon_form
 
-            double[,] matrix = (double[,])imatrix.Clone();
+            double[,] matrix = (double[,])imatrix.DeepClone();
             int lead = 0, rowCount = matrix.GetLength(0), columnCount = matrix.GetLength(1);
 
             for (int r = 0; r < rowCount; r++)

--- a/Geometry_Engine/Compute/SortAlongCurve.cs
+++ b/Geometry_Engine/Compute/SortAlongCurve.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -37,9 +38,9 @@ namespace BH.Engine.Geometry
         public static List<Point> SortAlongCurve(this List<Point> points, Arc arc, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
             if (arc.Angle() <= angleTolerance)
-                return points.Select(p => p.Clone()).ToList();
+                return points.Select(p => p.DeepClone()).ToList();
 
-            List<Tuple<Point, double>> cData = points.Select(p => new Tuple<Point, double>(p.Clone(), arc.ParameterAtPoint(arc.ClosestPoint(p)))).ToList();
+            List<Tuple<Point, double>> cData = points.Select(p => new Tuple<Point, double>(p.DeepClone(), arc.ParameterAtPoint(arc.ClosestPoint(p)))).ToList();
 
             cData.Sort(delegate (Tuple<Point, double> d1, Tuple<Point, double> d2)
             {
@@ -54,9 +55,9 @@ namespace BH.Engine.Geometry
         public static List<Point> SortAlongCurve(this List<Point> points, Circle circle, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
             if (circle.Radius <= distanceTolerance)
-                return points.Select(p => p.Clone()).ToList();
+                return points.Select(p => p.DeepClone()).ToList();
 
-            List<Tuple<Point, double>> cData = points.Select(p => new Tuple<Point, double>(p.Clone(), circle.ParameterAtPoint(circle.ClosestPoint(p)))).ToList();
+            List<Tuple<Point, double>> cData = points.Select(p => new Tuple<Point, double>(p.DeepClone(), circle.ParameterAtPoint(circle.ClosestPoint(p)))).ToList();
 
             cData.Sort(delegate (Tuple<Point, double> d1, Tuple<Point, double> d2)
             {
@@ -71,10 +72,10 @@ namespace BH.Engine.Geometry
         public static List<Point> SortAlongCurve(this List<Point> points, Line line, double distanceTolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
             if (line.Length() <= distanceTolerance)
-                return points.Select(p => p.Clone()).ToList();
+                return points.Select(p => p.DeepClone()).ToList();
 
             Vector lDir = line.Direction();
-            List<Tuple<Point, Point>> cData = points.Select(p => new Tuple<Point, Point>(p.Clone(), (p.Project(line)))).ToList();
+            List<Tuple<Point, Point>> cData = points.Select(p => new Tuple<Point, Point>(p.DeepClone(), (p.Project(line)))).ToList();
 
             if ((Math.Abs(lDir.X)) > angleTolerance)
             {
@@ -115,7 +116,7 @@ namespace BH.Engine.Geometry
         public static List<Point> SortAlongCurve(this List<Point> points, PolyCurve curve, double tolerance = Tolerance.Distance, double angleTolerance = Tolerance.Angle)
         {
 
-            List<Tuple<Point, double>> cData = points.Select(p => new Tuple<Point, double>(p.Clone(), curve.ParameterAtPoint(curve.ClosestPoint(p)))).ToList();
+            List<Tuple<Point, double>> cData = points.Select(p => new Tuple<Point, double>(p.DeepClone(), curve.ParameterAtPoint(curve.ClosestPoint(p)))).ToList();
 
             cData.Sort(delegate (Tuple<Point, double> d1, Tuple<Point, double> d2)
             {

--- a/Geometry_Engine/Compute/SortCollinear.cs
+++ b/Geometry_Engine/Compute/SortCollinear.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
@@ -35,7 +36,7 @@ namespace BH.Engine.Geometry
 
         public static List<Point> SortCollinear(this List<Point> points, double tolerance = Tolerance.Distance)
         {
-            List<Point> cPoints = points.Select(p => p.Clone()).ToList();
+            List<Point> cPoints = points.Select(p => p.DeepClone()).ToList();
             for (int i = 1; i < cPoints.Count; i++)
             {
                 if (Math.Abs(cPoints[0].X - cPoints[i].X) > tolerance)

--- a/Geometry_Engine/Compute/WetBlanketInterpretation.cs
+++ b/Geometry_Engine/Compute/WetBlanketInterpretation.cs
@@ -27,6 +27,7 @@ using BH.oM.Geometry;
 using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Quantities.Attributes;
+using BH.Engine.Base;
 
 namespace BH.Engine.Geometry
 {
@@ -42,7 +43,7 @@ namespace BH.Engine.Geometry
         [Output("C", "A single Polyline oriented counter clockwise with the same area as the sum of all the polylines.")]
         public static Polyline WetBlanketInterpretation(List<Polyline> pLines, double tol = Tolerance.Distance)
         {
-            List<Polyline> clones = pLines.Select(x => x.RemoveShortSegments(tol, tol).Clone()).ToList();
+            List<Polyline> clones = pLines.Select(x => x.RemoveShortSegments(tol, tol).DeepClone()).ToList();
 
             int digits = (int)Math.Floor(-Math.Log10(tol));
 

--- a/Geometry_Engine/Convert/NurbsForm.cs
+++ b/Geometry_Engine/Convert/NurbsForm.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -149,7 +150,7 @@ namespace BH.Engine.Geometry
 
         public static NurbsCurve ToNurbsCurve(this NurbsCurve curve)
         {
-            return curve.Clone();
+            return curve.DeepClone();
         }
 
         /***************************************************/

--- a/Geometry_Engine/Create/Plane.cs
+++ b/Geometry_Engine/Create/Plane.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System;
 
@@ -41,7 +42,7 @@ namespace BH.Engine.Geometry
         public static Plane Plane(Point p1, Point p2, Point p3)
         {
             Vector normal = Query.CrossProduct(p2 - p1, p3 - p1).Normalise();
-            return new Plane { Origin = p1.Clone(), Normal = normal };
+            return new Plane { Origin = p1.DeepClone(), Normal = normal };
         }
 
 

--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -247,6 +247,10 @@
     <Compile Include="Query\PointAtX.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj">
+      <Project>{1AD45C88-DD54-48E5-951F-55EDFEB70E35}</Project>
+      <Name>BHoM_Engine</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Data_Engine\Data_Engine.csproj">
       <Project>{8082ca2a-ac5c-4690-9f09-960e0d3e4102}</Project>
       <Name>Data_Engine</Name>

--- a/Geometry_Engine/Modify/CollapseToPolyline.cs
+++ b/Geometry_Engine/Modify/CollapseToPolyline.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -57,7 +58,7 @@ namespace BH.Engine.Geometry
 
         public static Polyline CollapseToPolyline(this Polyline curve, double angleTolerance, int maxSegmentCount = 100)
         {
-            return curve.Clone();
+            return curve.DeepClone();
         }
 
         /***************************************************/
@@ -157,7 +158,7 @@ namespace BH.Engine.Geometry
 
         private static List<Point> CollapseToPolylineVertices(this Polyline curve, double angleTolerance, int maxSegmentCount = 100)
         {
-            return curve.ControlPoints.Select(p => p.Clone()).ToList();
+            return curve.ControlPoints.Select(p => p.DeepClone()).ToList();
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Flip.cs
+++ b/Geometry_Engine/Modify/Flip.cs
@@ -26,6 +26,7 @@ using BH.oM.Reflection.Attributes;
 using System;
 using System.Linq;
 using System.Collections.Generic;
+using BH.Engine.Base;
 
 namespace BH.Engine.Geometry
 {
@@ -60,7 +61,7 @@ namespace BH.Engine.Geometry
 
         public static NurbsCurve Flip(this NurbsCurve curve)
         {
-            NurbsCurve result = curve.Clone();
+            NurbsCurve result = curve.DeepClone();
 
             result.ControlPoints.Reverse();
             result.Weights.Reverse();

--- a/Geometry_Engine/Modify/MergeVertices.cs
+++ b/Geometry_Engine/Modify/MergeVertices.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
@@ -35,8 +36,8 @@ namespace BH.Engine.Geometry
 
         public static Mesh MergedVertices(this Mesh mesh, double tolerance = Tolerance.Distance) //TODO: use the point matrix 
         {
-            List<Face> faces = mesh.Faces.Select(x => x.Clone() as Face).ToList();
-            List<VertexIndex> vertices = mesh.Vertices.Select((x, i) => new VertexIndex(x.Clone() as Point, i)).ToList();
+            List<Face> faces = mesh.Faces.Select(x => x.DeepClone()).ToList();
+            List<VertexIndex> vertices = mesh.Vertices.Select((x, i) => new VertexIndex(x.DeepClone(), i)).ToList();
             
             foreach( Face face in faces)
             {

--- a/Geometry_Engine/Modify/Mirror.cs
+++ b/Geometry_Engine/Modify/Mirror.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Reflection.Attributes;
@@ -197,7 +198,7 @@ namespace BH.Engine.Geometry
 
         public static Mesh Mirror(this Mesh mesh, Plane p)
         {
-            return new Mesh { Vertices = mesh.Vertices.Select(x => x.Mirror(p)).ToList(), Faces = mesh.Faces.Select(x => x.Clone()).ToList() };
+            return new Mesh { Vertices = mesh.Vertices.Select(x => x.Mirror(p)).ToList(), Faces = mesh.Faces.Select(x => x.DeepClone()).ToList() };
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/Normalise.cs
+++ b/Geometry_Engine/Modify/Normalise.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System;
 
@@ -39,7 +40,7 @@ namespace BH.Engine.Geometry
             double d = Math.Sqrt(x * x + y * y + z * z);
 
             if (d == 0)
-                return vector.Clone();
+                return vector.DeepClone();
 
             return new Vector { X = x / d, Y = y / d, Z = z / d };
         }

--- a/Geometry_Engine/Modify/Offset.cs
+++ b/Geometry_Engine/Modify/Offset.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Reflection.Debugging;
@@ -70,7 +71,7 @@ namespace BH.Engine.Geometry
             else
                 radius -= offset;
 
-            Arc result = curve.Clone();
+            Arc result = curve.DeepClone();
 
             if (radius > 0)
             {
@@ -107,7 +108,7 @@ namespace BH.Engine.Geometry
             else
                 radius -= offset;
 
-            Circle result = curve.Clone();
+            Circle result = curve.DeepClone();
 
             if (radius > 0)
             {

--- a/Geometry_Engine/Modify/Project.cs
+++ b/Geometry_Engine/Modify/Project.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -101,7 +102,7 @@ namespace BH.Engine.Geometry
         public static ICurve Project(this Circle circle, Plane p)
         {
             if (circle.Normal.IsParallel(p.Normal) != 0)
-                return new Circle { Centre = circle.Centre.Project(p), Normal = circle.Normal.Clone(), Radius = circle.Radius };
+                return new Circle { Centre = circle.Centre.Project(p), Normal = circle.Normal.DeepClone(), Radius = circle.Radius };
 
             Vector axis1 = p.Normal.CrossProduct(circle.Normal);
             Vector axis2 = axis1.CrossProduct(p.Normal);
@@ -208,7 +209,7 @@ namespace BH.Engine.Geometry
 
         public static Mesh Project(this Mesh mesh, Plane p)
         {
-            return new Mesh { Vertices = mesh.Vertices.Select(x => x.Project(p)).ToList(), Faces = mesh.Faces.Select(x => x.Clone() as Face).ToList() };
+            return new Mesh { Vertices = mesh.Vertices.Select(x => x.Project(p)).ToList(), Faces = mesh.Faces.Select(x => x.DeepClone()).ToList() };
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/ProjectAlong.cs
+++ b/Geometry_Engine/Modify/ProjectAlong.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -78,7 +79,7 @@ namespace BH.Engine.Geometry
         public static ICurve ProjectAlong(this Circle circle, Plane plane, Vector vector)
         {
             if (circle.Normal.IsParallel(plane.Normal) != 0)
-                return new Circle { Centre = circle.Centre.ProjectAlong(plane, vector), Normal = circle.Normal.Clone(), Radius = circle.Radius };
+                return new Circle { Centre = circle.Centre.ProjectAlong(plane, vector), Normal = circle.Normal.DeepClone(), Radius = circle.Radius };
 
             TransformMatrix project = Create.ProjectionMatrix(plane, vector);
             return circle.Transform(project);
@@ -184,7 +185,7 @@ namespace BH.Engine.Geometry
 
         public static Mesh ProjectAlong(this Mesh mesh, Plane plane, Vector vector)
         {
-            return new Mesh { Vertices = mesh.Vertices.Select(x => x.ProjectAlong(plane, vector)).ToList(), Faces = mesh.Faces.Select(x => x.Clone() as Face).ToList() };
+            return new Mesh { Vertices = mesh.Vertices.Select(x => x.ProjectAlong(plane, vector)).ToList(), Faces = mesh.Faces.Select(x => x.DeepClone()).ToList() };
         }
 
         /***************************************************/

--- a/Geometry_Engine/Modify/SetGeometry.cs
+++ b/Geometry_Engine/Modify/SetGeometry.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Geometry.SettingOut;
 
@@ -33,64 +34,64 @@ namespace BH.Engine.Geometry
 
         public static Point SetGeometry(this Point point, Point newPoint)
         {
-            return newPoint.Clone();
+            return newPoint.DeepClone();
         }
 
         /***************************************************/
 
         public static ICurve SetGeometry(this Line curve, ICurve newCurve)
         {
-            return newCurve.IClone();
+            return newCurve.DeepClone();
         }
 
         /***************************************************/
 
         public static ICurve SetGeometry(this Arc curve, ICurve newCurve)
         {
-            return newCurve.IClone();
+            return newCurve.DeepClone();
         }
 
         /***************************************************/
 
         public static ICurve SetGeometry(this Circle curve, ICurve newCurve)
         {
-            return newCurve.IClone();
+            return newCurve.DeepClone();
         }
 
         /***************************************************/
 
         public static ICurve SetGeometry(this Ellipse curve, ICurve newCurve)
         {
-            return newCurve.IClone();
+            return newCurve.DeepClone();
         }
 
         /***************************************************/
 
         public static ICurve SetGeometry(this NurbsCurve curve, ICurve newCurve)
         {
-            return newCurve.IClone();
+            return newCurve.DeepClone();
         }
 
         /***************************************************/
 
         public static ICurve SetGeometry(this Polyline curve, ICurve newCurve)
         {
-            return newCurve.IClone();
+            return newCurve.DeepClone();
         }
 
         /***************************************************/
 
         public static ICurve SetGeometry(this PolyCurve curve, ICurve newCurve)
         {
-            return newCurve.IClone();
+            return newCurve.DeepClone();
         }
 
         /***************************************************/
 
         public static Grid SetGeometry(this Grid grid, ICurve curve)
         {
-            Grid clone = grid.GetShallowClone() as Grid;
-            clone.Curve = curve.IClone();
+            Grid clone = grid.ShallowClone();
+            clone.Curve = curve.DeepClone();
             return clone;
         }
 

--- a/Geometry_Engine/Modify/SortCurves.cs
+++ b/Geometry_Engine/Modify/SortCurves.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
@@ -36,9 +37,9 @@ namespace BH.Engine.Geometry
         public static PolyCurve SortCurves(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
             if (curve.Curves.Count < 2)
-                return curve.Clone() as PolyCurve;
+                return curve.DeepClone();
 
-            List<ICurve> pending = curve.Curves.Select(x => x.IClone()).ToList();
+            List<ICurve> pending = curve.Curves.Select(x => x.DeepClone()).ToList();
             PolyCurve result = new PolyCurve { Curves = new List<ICurve> { pending[0] } };
             pending.RemoveAt(0);
 

--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -26,6 +26,7 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using BH.oM.Reflection.Attributes;
+using BH.Engine.Base;
 
 namespace BH.Engine.Geometry
 {
@@ -38,7 +39,7 @@ namespace BH.Engine.Geometry
         public static List<Arc> SplitAtPoints(this Arc arc, List<Point> points, double tolerance = Tolerance.Distance)
         {
             if (!points.Any())
-                return new List<Arc> { arc.Clone() };
+                return new List<Arc> { arc.DeepClone() };
 
             List<Arc> result = new List<Arc>();
             List<Point> cPts = new List<Point>();
@@ -67,7 +68,7 @@ namespace BH.Engine.Geometry
 
                 for (int i = 1; i < cPts.Count; i++)
                 {
-                    tmpArc = arc.Clone();
+                    tmpArc = arc.DeepClone();
 
                     tmpArc.StartAngle = startAng;
                     tmpAng = (2 * Math.PI + (cPts[i - 1] - arc.Centre()).SignedAngle(cPts[i] - arc.Centre(), normal)) % (2 * Math.PI);
@@ -79,7 +80,7 @@ namespace BH.Engine.Geometry
 
             }
             else
-                result.Add(arc.Clone());
+                result.Add(arc.DeepClone());
             return result;
         }
 
@@ -131,7 +132,7 @@ namespace BH.Engine.Geometry
                 tmpArc = tmpArc.Rotate(cirCen, normal, rotAng);
                 tmpArc.StartAngle = 0;
                 tmpArc.EndAngle = enAng;
-                result.Add(tmpArc.Clone());
+                result.Add(tmpArc.DeepClone());
             }
             else
             {
@@ -146,7 +147,7 @@ namespace BH.Engine.Geometry
                     tmpArc = tmpArc.Rotate(cirCen, normal, rotAng);
                     tmpArc.StartAngle = 0;
                     tmpArc.EndAngle = enAng;
-                    result.Add(tmpArc.Clone());
+                    result.Add(tmpArc.DeepClone());
                 }
             }
             return result;
@@ -176,7 +177,7 @@ namespace BH.Engine.Geometry
                 }
             }
             else
-                result.Add(line.Clone());
+                result.Add(line.DeepClone());
 
             return result;
         }
@@ -186,7 +187,7 @@ namespace BH.Engine.Geometry
         public static List<PolyCurve> SplitAtPoints(this PolyCurve curve, List<Point> points, double tolerance = Tolerance.Distance)
         {
             if (points.Count == 0)
-                return new List<PolyCurve> { curve.Clone() };
+                return new List<PolyCurve> { curve.DeepClone() };
 
             List<PolyCurve> result = new List<PolyCurve>();
             List<ICurve> tmpResult = new List<ICurve>();
@@ -202,7 +203,7 @@ namespace BH.Engine.Geometry
             onCurvePoints = onCurvePoints.CullDuplicates(tolerance);
 
             if (onCurvePoints.Count == 0)
-                return new List<PolyCurve> { curve.Clone() };
+                return new List<PolyCurve> { curve.DeepClone() };
 
             onCurvePoints = onCurvePoints.SortAlongCurve(curve);
 
@@ -301,7 +302,7 @@ namespace BH.Engine.Geometry
         public static List<Polyline> SplitAtPoints(this Polyline curve, List<Point> points, double tolerance = Tolerance.Distance)
         {
             if (points.Count == 0)
-                return new List<Polyline> { curve.Clone() };
+                return new List<Polyline> { curve.DeepClone() };
 
             List<Polyline> result = new List<Polyline>();
             List<Line> segments = curve.SubParts();
@@ -331,7 +332,7 @@ namespace BH.Engine.Geometry
                 if (intStart && section.ControlPoints.Count > 1)
                 {
                     result.Add(section);
-                    section = new Polyline { ControlPoints = new List<Point> { l.Start.Clone() } };
+                    section = new Polyline { ControlPoints = new List<Point> { l.Start.DeepClone() } };
                 }
 
                 if (iPts.Count > 0)

--- a/Geometry_Engine/Modify/Transform.cs
+++ b/Geometry_Engine/Modify/Transform.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Reflection.Attributes;
@@ -245,7 +246,7 @@ namespace BH.Engine.Geometry
 
         public static Mesh Transform(this Mesh mesh, TransformMatrix transform)
         {
-            return new Mesh { Vertices = mesh.Vertices.Select(x => x.Transform(transform)).ToList(), Faces = mesh.Faces.Select(x => x.Clone() as Face).ToList() };
+            return new Mesh { Vertices = mesh.Vertices.Select(x => x.Transform(transform)).ToList(), Faces = mesh.Faces.Select(x => x.DeepClone()).ToList() };
         }
 
 

--- a/Geometry_Engine/Modify/Translate.cs
+++ b/Geometry_Engine/Modify/Translate.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Reflection.Attributes;
@@ -50,7 +51,7 @@ namespace BH.Engine.Geometry
 
         public static Plane Translate(this Plane plane, Vector transform)
         {
-            return new Plane { Origin = plane.Origin + transform, Normal = plane.Normal.Clone() as Vector };
+            return new Plane { Origin = plane.Origin + transform, Normal = plane.Normal.DeepClone() };
         }
 
         /***************************************************/
@@ -79,7 +80,7 @@ namespace BH.Engine.Geometry
 
         public static Circle Translate(this Circle curve, Vector transform)
         {
-            return new Circle { Centre = curve.Centre + transform, Normal = curve.Normal.Clone() as Vector, Radius = curve.Radius };
+            return new Circle { Centre = curve.Centre + transform, Normal = curve.Normal.DeepClone(), Radius = curve.Radius };
         }
 
         /***************************************************/
@@ -127,7 +128,7 @@ namespace BH.Engine.Geometry
 
         public static Extrusion Translate(this Extrusion surface, Vector transform)
         {
-            return new Extrusion { Curve = surface.Curve.ITranslate(transform), Direction = surface.Direction.Clone() as Vector, Capped = surface.Capped };
+            return new Extrusion { Curve = surface.Curve.ITranslate(transform), Direction = surface.Direction.DeepClone(), Capped = surface.Capped };
         }
 
         /***************************************************/
@@ -173,7 +174,7 @@ namespace BH.Engine.Geometry
 
         public static Mesh Translate(this Mesh mesh, Vector transform)
         {
-            return new Mesh { Vertices = mesh.Vertices.Select(x => x + transform).ToList(), Faces = mesh.Faces.Select(x => x.Clone() as Face).ToList() };
+            return new Mesh { Vertices = mesh.Vertices.Select(x => x + transform).ToList(), Faces = mesh.Faces.Select(x => x.DeepClone()).ToList() };
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -104,7 +105,7 @@ namespace BH.Engine.Geometry
                         area -= arcArea;
                 }
 
-                sPt = ePt.Clone();
+                sPt = ePt.DeepClone();
             }
 
             return Math.Abs(area);

--- a/Geometry_Engine/Query/Bounds.cs
+++ b/Geometry_Engine/Query/Bounds.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Reflection.Attributes;
@@ -76,7 +77,7 @@ namespace BH.Engine.Geometry
 
         public static BoundingBox Bounds(this BoundingBox boundingBox)
         {
-            return boundingBox == null ? null : boundingBox.Clone();
+            return boundingBox == null ? null : boundingBox.DeepClone();
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Clone.cs
+++ b/Geometry_Engine/Query/Clone.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Geometry.CoordinateSystem;
 using System.Collections.Generic;
@@ -35,7 +36,7 @@ namespace BH.Engine.Geometry
 
         public static Plane Clone(this Plane plane)
         {
-            return new Plane { Origin = plane.Origin.Clone(), Normal = plane.Normal.Clone() };
+            return new Plane { Origin = plane.Origin.DeepClone(), Normal = plane.Normal.DeepClone() };
         }
 
         /***************************************************/
@@ -56,7 +57,7 @@ namespace BH.Engine.Geometry
 
         public static Cartesian Clone(this Cartesian coordinateSystem)
         {
-            return new Cartesian(coordinateSystem.Origin.Clone(), coordinateSystem.X.Clone(), coordinateSystem.Y.Clone(), coordinateSystem.Z.Clone());
+            return new Cartesian(coordinateSystem.Origin.DeepClone(), coordinateSystem.X.DeepClone(), coordinateSystem.Y.DeepClone(), coordinateSystem.Z.DeepClone());
         }
 
         /***************************************************/
@@ -65,14 +66,14 @@ namespace BH.Engine.Geometry
 
         public static Arc Clone(this Arc arc)
         {
-            return new Arc { CoordinateSystem = arc.CoordinateSystem.Clone(), StartAngle = arc.StartAngle, EndAngle = arc.EndAngle, Radius = arc.Radius };
+            return new Arc { CoordinateSystem = arc.CoordinateSystem.DeepClone(), StartAngle = arc.StartAngle, EndAngle = arc.EndAngle, Radius = arc.Radius };
         }
 
         /***************************************************/
 
         public static Circle Clone(this Circle circle)
         {
-            return new Circle { Centre = circle.Centre.Clone(), Normal = circle.Normal.Clone(), Radius = circle.Radius };
+            return new Circle { Centre = circle.Centre.DeepClone(), Normal = circle.Normal.DeepClone(), Radius = circle.Radius };
         }
 
         /***************************************************/
@@ -86,28 +87,28 @@ namespace BH.Engine.Geometry
 
         public static Line Clone(this Line line)
         {
-            return new Line { Start = line.Start.Clone(), End = line.End.Clone(), Infinite = line.Infinite };
+            return new Line { Start = line.Start.DeepClone(), End = line.End.DeepClone(), Infinite = line.Infinite };
         }
 
         /***************************************************/
 
         public static NurbsCurve Clone(this NurbsCurve curve)
         {
-            return new NurbsCurve { ControlPoints = curve.ControlPoints.Select(x => x.Clone()).ToList(), Weights = curve.Weights.ToList(), Knots = curve.Knots.ToList() };
+            return new NurbsCurve { ControlPoints = curve.ControlPoints.Select(x => x.DeepClone()).ToList(), Weights = curve.Weights.ToList(), Knots = curve.Knots.ToList() };
         }
 
         /***************************************************/
 
         public static PolyCurve Clone(this PolyCurve curve)
         {
-            return new PolyCurve { Curves = curve.Curves.Select(x => x.IClone()).ToList() };
+            return new PolyCurve { Curves = curve.Curves.Select(x => x.DeepClone()).ToList() };
         }
 
         /***************************************************/
 
         public static Polyline Clone(this Polyline curve)
         {
-            return new Polyline { ControlPoints = curve.ControlPoints.Select(x => x.Clone()).ToList() };
+            return new Polyline { ControlPoints = curve.ControlPoints.Select(x => x.DeepClone()).ToList() };
         }
 
 
@@ -117,42 +118,42 @@ namespace BH.Engine.Geometry
 
         public static Extrusion Clone(this Extrusion surface)
         {
-            return new Extrusion { Curve = surface.Curve.IClone(), Direction = surface.Direction.Clone(), Capped = surface.Capped };
+            return new Extrusion { Curve = surface.Curve.DeepClone(), Direction = surface.Direction.DeepClone(), Capped = surface.Capped };
         }
 
         /***************************************************/
 
         public static Loft Clone(this Loft surface)
         {
-            return new Loft { Curves = surface.Curves.Select(x => x.IClone()).ToList() };
+            return new Loft { Curves = surface.Curves.Select(x => x.DeepClone()).ToList() };
         }
 
         /***************************************************/
 
         public static NurbsSurface Clone(this NurbsSurface surface)
         {
-            return new NurbsSurface(surface.ControlPoints.Select(x => x.Clone()), new List<double>(surface.Weights), new List<double>(surface.UKnots), new List<double>(surface.VKnots), surface.UDegree, surface.VDegree, surface.InnerTrims.Select(x => x.Clone()), surface.OuterTrims.Select(x => x.Clone()));
+            return new NurbsSurface(surface.ControlPoints.Select(x => x.DeepClone()), new List<double>(surface.Weights), new List<double>(surface.UKnots), new List<double>(surface.VKnots), surface.UDegree, surface.VDegree, surface.InnerTrims.Select(x => x.DeepClone()), surface.OuterTrims.Select(x => x.DeepClone()));
         }
 
         /***************************************************/
 
         public static PlanarSurface Clone(this PlanarSurface surface)
         {
-            return new PlanarSurface(surface.ExternalBoundary.IClone(), surface.InternalBoundaries.Select(x => x.IClone()).ToList());
+            return new PlanarSurface(surface.ExternalBoundary.DeepClone(), surface.InternalBoundaries.Select(x => x.DeepClone()).ToList());
         }
 
         /***************************************************/
 
         public static Pipe Clone(this Pipe surface)
         {
-            return new Pipe { Centreline = surface.Centreline.IClone(), Radius = surface.Radius, Capped = surface.Capped };
+            return new Pipe { Centreline = surface.Centreline.DeepClone(), Radius = surface.Radius, Capped = surface.Capped };
         }
 
         /***************************************************/
 
         public static PolySurface Clone(this PolySurface surface)
         {
-            return new PolySurface { Surfaces = surface.Surfaces.Select(x => x.IClone()).ToList() };
+            return new PolySurface { Surfaces = surface.Surfaces.Select(x => x.DeepClone()).ToList() };
         }
 
 
@@ -162,7 +163,7 @@ namespace BH.Engine.Geometry
 
         public static Mesh Clone(this Mesh mesh)
         {
-            return new Mesh { Vertices = mesh.Vertices.Select(x => x.Clone()).ToList(), Faces = mesh.Faces.Select(x => x.Clone()).ToList() };
+            return new Mesh { Vertices = mesh.Vertices.Select(x => x.DeepClone()).ToList(), Faces = mesh.Faces.Select(x => x.DeepClone()).ToList() };
         }
 
         /***************************************************/
@@ -176,14 +177,14 @@ namespace BH.Engine.Geometry
 
         public static BoundingBox Clone(this BoundingBox box)
         {
-            return new BoundingBox { Min = box.Min.Clone(), Max = box.Max.Clone() };
+            return new BoundingBox { Min = box.Min.DeepClone(), Max = box.Max.DeepClone() };
         }
 
         /***************************************************/
 
         public static CompositeGeometry Clone(this CompositeGeometry group)
         {
-            return new CompositeGeometry { Elements = group.Elements.Select(x => x.IClone()).ToList() };
+            return new CompositeGeometry { Elements = group.Elements.Select(x => x.DeepClone()).ToList() };
         }
 
         /***************************************************/
@@ -211,7 +212,7 @@ namespace BH.Engine.Geometry
 
         public static SurfaceTrim Clone(this SurfaceTrim trim)
         {
-            return new SurfaceTrim(trim.Curve3d.Clone(), trim.Curve2d.Clone());
+            return new SurfaceTrim(trim.Curve3d.DeepClone(), trim.Curve2d.DeepClone());
         }
 
 

--- a/Geometry_Engine/Query/ExternalEdges.cs
+++ b/Geometry_Engine/Query/ExternalEdges.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -43,7 +44,7 @@ namespace BH.Engine.Geometry
             if (!surface.Capped)
             {
                 edges.Add(curve);
-                ICurve other = curve.IClone();
+                ICurve other = curve.DeepClone();
                 edges.Add(other.ITranslate(direction));
             }
 

--- a/Geometry_Engine/Query/InternalEdges.cs
+++ b/Geometry_Engine/Query/InternalEdges.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,7 +41,7 @@ namespace BH.Engine.Geometry
             List<ICurve> edges = new List<ICurve>();
             if (surface.Capped)
             {
-                edges.Add(curve.IClone());
+                edges.Add(curve.DeepClone());
                 edges.Add(surface.Curve.ITranslate(surface.Direction));
             }
 

--- a/Geometry_Engine/Query/IsClockwise.cs
+++ b/Geometry_Engine/Query/IsClockwise.cs
@@ -24,6 +24,7 @@ using BH.oM.Geometry;
 using System.Linq;
 using System.Collections.Generic;
 using System;
+using BH.Engine.Base;
 
 namespace BH.Engine.Geometry
 {
@@ -47,7 +48,7 @@ namespace BH.Engine.Geometry
             {
                 dir2 = (cc[i] - cc[i - 1]).Normalise();
                 double signedAngle = dir1.SignedAngle(dir2, normal);
-                dir1 = dir2.Clone();
+                dir1 = dir2.DeepClone();
 
                 if (Math.PI - Math.Abs(signedAngle) <= Tolerance.Angle)
                 {

--- a/Geometry_Engine/Query/IsCoplanar.cs
+++ b/Geometry_Engine/Query/IsCoplanar.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
@@ -87,8 +88,8 @@ namespace BH.Engine.Geometry
 
         public static bool IsCoplanar(this Polyline curve1, Polyline curve2, double tolerance = Tolerance.Distance)
         {
-            List<Point> cPts = curve1.Clone().ControlPoints;
-            cPts.AddRange(curve2.Clone().ControlPoints);
+            List<Point> cPts = curve1.DeepClone().ControlPoints;
+            cPts.AddRange(curve2.DeepClone().ControlPoints);
             return cPts.IsCoplanar(tolerance);
         }
 

--- a/Geometry_Engine/Query/LineIntersections.cs
+++ b/Geometry_Engine/Query/LineIntersections.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Geometry;
 using BH.oM.Reflection.Attributes;
 using System;
@@ -38,8 +39,8 @@ namespace BH.Engine.Geometry
         {
             double sqTol = tolerance * tolerance;
 
-            Line l1 = line1.Clone();
-            Line l2 = line2.Clone();
+            Line l1 = line1.DeepClone();
+            Line l2 = line2.DeepClone();
             l1.Infinite |= useInfiniteLines;
             l2.Infinite |= useInfiniteLines;
             BH.oM.Reflection.Output<double, double> intParamsOutput = l1.SkewLineProximity(l2, angleTolerance);
@@ -142,7 +143,7 @@ namespace BH.Engine.Geometry
 
         public static List<Point> LineIntersections(this Arc arc, Line line, bool useInfiniteLine = false, double tolerance = Tolerance.Distance)
         {
-            Line l = line.Clone();
+            Line l = line.DeepClone();
             l.Infinite = useInfiniteLine ? true : l.Infinite;
 
             List<Point> iPts = new List<Point>();
@@ -185,7 +186,7 @@ namespace BH.Engine.Geometry
 
         public static List<Point> LineIntersections(this Circle circle, Line line, bool useInfiniteLine = false, double tolerance = Tolerance.Distance)
         {
-            Line l = line.Clone();
+            Line l = line.DeepClone();
             l.Infinite = useInfiniteLine ? true : l.Infinite;
 
             List<Point> iPts = new List<Point>();
@@ -230,7 +231,7 @@ namespace BH.Engine.Geometry
 
         public static List<Point> LineIntersections(this Polyline curve, Line line, bool useInfiniteLine = false, double tolerance = Tolerance.Distance)
         {
-            Line l = line.Clone();
+            Line l = line.DeepClone();
             l.Infinite = useInfiniteLine ? true : line.Infinite;
 
             List<Point> iPts = new List<Point>();
@@ -248,7 +249,7 @@ namespace BH.Engine.Geometry
 
         public static List<Point> LineIntersections(this PolyCurve curve, Line line, bool useInfiniteLine = false, double tolerance = Tolerance.Distance)
         {
-            Line l = line.Clone();
+            Line l = line.DeepClone();
             l.Infinite = useInfiniteLine ? true : line.Infinite;
 
             List<Point> iPts = new List<Point>();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2067

Here's the procedure that I have followed:
- Replace calls to `Geometry.Clone` and `Geometry.IClone` to calls to `Engine.Base.DeepClone()`. Feel free to use `Engine.Base.ShallowClone()` where you feel appropriate.
- Replace calls to `GetShallowClone` with calls to `Engine.Base.ShallowClone()`
- Remove the `as X` conversion after the cloning since casting is not necessary anymore


### Test files
- Review the code itself to make sure it compiles and makes sense
- Run the standard testing procedure that involve the geometry engine

### Additional comments
After a few back and forth regarding the scope of this task, I have decided to keep it really simple for now. Turning the `Modify` methods into mutable methods has been pushed to later as it needs more coordination than expected. So I have instead focused on making sure that only the two methods `Engine.Base.DeepClone()` and `Engine.Base.ShallowClone()` are used for cloning. This solves the critical and original point of constant `BHoMGuid` which is what matters for now.