### PR TITLE
Structure_Engine: Remove guid from comparers

### DIFF
--- a/BHoM_Engine/Objects/EqualityComparers/BHoMObjectNameComparer.cs
+++ b/BHoM_Engine/Objects/EqualityComparers/BHoMObjectNameComparer.cs
@@ -41,10 +41,6 @@ namespace BH.Engine.Base.Objects
             if (Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null))
                 return false;
 
-            //Check if the GUIDs are the same
-            if (x.BHoM_Guid == y.BHoM_Guid)
-                return true;
-
             return x.Name == y.Name;
         }
 

--- a/BHoM_Engine/Objects/EqualityComparers/BHoMObjectNameOrToStringComparer.cs
+++ b/BHoM_Engine/Objects/EqualityComparers/BHoMObjectNameOrToStringComparer.cs
@@ -41,10 +41,6 @@ namespace BH.Engine.Base.Objects
             if (Object.ReferenceEquals(x, null) || Object.ReferenceEquals(y, null))
                 return false;
 
-            //Check if the GUIDs are the same
-            if (x.BHoM_Guid == y.BHoM_Guid)
-                return true;
-
             string xName = !string.IsNullOrWhiteSpace(x.Name) ? x.Name : x.ToString();
             string yName = !string.IsNullOrWhiteSpace(y.Name) ? y.Name : y.ToString();
 

--- a/Structure_Engine/Objects/EqualityComparers/BarEndNodesDistanceComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/BarEndNodesDistanceComparer.cs
@@ -58,10 +58,6 @@ namespace BH.Engine.Structure
             if (Object.ReferenceEquals(bar1, null) || Object.ReferenceEquals(bar2, null))
                 return false;
 
-            //Check if the GUIDs are the same
-            if (bar1.BHoM_Guid == bar2.BHoM_Guid)
-                return true;
-
             if (m_nodeComparer.Equals(bar1.StartNode, bar2.StartNode))
             {
                 return m_nodeComparer.Equals(bar1.EndNode, bar2.EndNode);
@@ -81,7 +77,7 @@ namespace BH.Engine.Structure
             //Check whether the object is null
             if (Object.ReferenceEquals(bar, null)) return 0;
 
-            return bar.StartNode.GetHashCode() ^ bar.EndNode.GetHashCode();
+            return m_nodeComparer.GetHashCode(bar.StartNode) ^ m_nodeComparer.GetHashCode(bar.EndNode);
         }
 
 

--- a/Structure_Engine/Objects/EqualityComparers/Constraint4DOFComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/Constraint4DOFComparer.cs
@@ -43,9 +43,6 @@ namespace BH.Engine.Structure
             if (Object.ReferenceEquals(linearRelease1, null) || Object.ReferenceEquals(linearRelease2, null))
                 return false;
 
-            //Check if the GUIDs are the same
-            if (linearRelease1.BHoM_Guid == linearRelease2.BHoM_Guid)
-                return true;
 
             if (linearRelease1.Name == linearRelease2.Name &&
                 linearRelease1.TranslationX == linearRelease2.TranslationX &&

--- a/Structure_Engine/Objects/EqualityComparers/Constraint6DOFComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/Constraint6DOFComparer.cs
@@ -43,9 +43,6 @@ namespace BH.Engine.Structure
             if (Object.ReferenceEquals(support1, null) || Object.ReferenceEquals(support2, null))
                 return false;
 
-            //Check if the GUIDs are the same
-            if (support1.BHoM_Guid == support2.BHoM_Guid)
-                return true;
 
             if (support1.Name == support2.Name &&
                 support1.TranslationX == support2.TranslationX &&

--- a/Structure_Engine/Objects/EqualityComparers/NameOrDescriptionComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/NameOrDescriptionComparer.cs
@@ -50,8 +50,14 @@ namespace BH.Engine.Structure
             if (prop1 == null || prop2 == null)
                 return false;
 
+            string desc1 = prop1.DescriptionOrName();
+            string desc2 = prop2.DescriptionOrName();
+
+            if (desc1 == null || desc2 == null)
+                return false;
+
             //Return true if name or description string for both objects are the same
-            return prop1.DescriptionOrName() == prop2.DescriptionOrName();
+            return desc1 == desc2;
         }
 
         /***************************************************/

--- a/Structure_Engine/Objects/EqualityComparers/NodeDistanceComparer.cs
+++ b/Structure_Engine/Objects/EqualityComparers/NodeDistanceComparer.cs
@@ -59,9 +59,9 @@ namespace BH.Engine.Structure
             if (Object.ReferenceEquals(node1, null) || Object.ReferenceEquals(node2, null))
                 return false;
 
-            //Check if the GUIDs are the same
-            if (node1.BHoM_Guid == node2.BHoM_Guid)
-                return true;
+            //Check whether any of the compared objects nodes are null.
+            if (Object.ReferenceEquals(node1.Position, null) || Object.ReferenceEquals(node2.Position, null))
+                return false;
 
             if ((int)Math.Round(node1.Position.X * m_multiplier) != (int)Math.Round(node2.Position.X * m_multiplier))
                 return false;
@@ -81,6 +81,9 @@ namespace BH.Engine.Structure
         {
             //Check whether the object is null
             if (Object.ReferenceEquals(node, null)) return 0;
+
+            //Check whether the position is null
+            if (Object.ReferenceEquals(node.Position, null)) return 0;
 
             int x = ((int)Math.Round(node.Position.X * m_multiplier)).GetHashCode();
             int y = ((int)Math.Round(node.Position.Y * m_multiplier)).GetHashCode();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2029 

<!-- Add short description of what has been fixed -->

- Removes references to BHoM_Guids from comparers
- Additional null checks added
- Fixes wrong GetHashCode method used for the BarEndNodeDistanceComparer

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->