### PR TITLE
Spatial_Engine: Updating Area calls to Geometry_Engine instead of Spatial_Engine

### DIFF
--- a/Spatial_Engine/Compute/DistributeOutlines.cs
+++ b/Spatial_Engine/Compute/DistributeOutlines.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Spatial
             
             outlineCurves.Sort(delegate (Tuple<PolyCurve, List<IElement1D>> t1, Tuple<PolyCurve, List<IElement1D>> t2)
             {
-                return t1.Item1.Area().CompareTo(t2.Item1.Area());
+                return Geometry.Query.Area(t1.Item1).CompareTo(Geometry.Query.Area(t2.Item1));
             });
             outlineCurves.Reverse();
 
@@ -94,7 +94,7 @@ namespace BH.Engine.Spatial
             {
                 for (int i = 0; i < result.Count; i++)
                 {
-                    if (result[i][0].Item1.IsContaining(opening.Item1, true, tolerance) && result[i][0].Item1.Area() - opening.Item1.Area() > sqTolerance)
+                    if (result[i][0].Item1.IsContaining(opening.Item1, true, tolerance) && Geometry.Query.Area(result[i][0].Item1) - Geometry.Query.Area(opening.Item1) > sqTolerance)
                     {
                         result[i].Add(opening);
                         break;

--- a/Spatial_Engine/Create/ShapeProfiles/FreeFormProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/FreeFormProfile.cs
@@ -65,7 +65,7 @@ namespace BH.Engine.Spatial
                     try
                     {
                         // Get biggest contributing curve and fit a plane to it
-                        plane = Geometry.Compute.IJoin(edges.ToList()).OrderBy(x => x.Area()).Last().ControlPoints().FitPlane();
+                        plane = Geometry.Compute.IJoin(edges.ToList()).OrderBy(x => Geometry.Query.Area(x)).Last().ControlPoints().FitPlane();
 
                         result = edges.Select(x => x.IProject(plane)).ToList();
                         Reflection.Compute.RecordWarning("The Profiles curves have been projected onto a plane fitted through the biggest curve's control points.");

--- a/Spatial_Engine/Query/PointLayout.cs
+++ b/Spatial_Engine/Query/PointLayout.cs
@@ -397,7 +397,7 @@ namespace BH.Engine.Spatial
                 foreach (ICurve o in openings)
                 {
                     Point oTmp = Geometry.Query.ICentroid(o);
-                    double oArea = o.IArea();
+                    double oArea = Geometry.Query.IArea(o);
                     x -= oTmp.X * oArea;
                     y -= oTmp.Y * oArea;
                     z -= oTmp.Z * oArea;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2085 

<!-- Add short description of what has been fixed -->

Fixing wrong area methods being called in Spatial_Engine. Putting as critical as this is currently stopping some quite key methods from at all working, so would be good to get this merged ASAP.

Even more incentive to get rid of the Area method for `IElement1D` as I am sure we will stumble upon this again in the future. Issue for it raised here:

https://github.com/BHoM/BHoM_Engine/issues/2086

before the above is resolved, resorting to explicit calls to the geometry engine.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->