### PR TITLE
Reflection_Engine: Adding nullchecks for lists in DistinctProperties

### DIFF
--- a/Reflection_Engine/Query/DistinctProperties.cs
+++ b/Reflection_Engine/Query/DistinctProperties.cs
@@ -98,7 +98,7 @@ namespace BH.Engine.Reflection
                 Func<T, List<P>> getProp = (Func<T, List<P>>)Delegate.CreateDelegate(typeof(Func<T, List<P>>), property.GetGetMethod());
 
                 // Collect the objects from this property
-                propertyObjects.AddRange(objects.SelectMany(x => getProp(x)));
+                propertyObjects.AddRange(objects.SelectMany(x => (getProp(x) ?? new List<P>()).Where(p => p != null)));
             }
 
             //Get the distinct properties for the group value properties
@@ -108,7 +108,7 @@ namespace BH.Engine.Reflection
                 Func<T, BH.oM.Base.BHoMGroup<P>> getProp = (Func<T, BHoMGroup<P>>)Delegate.CreateDelegate(typeof(Func<T, BHoMGroup<P>>), property.GetGetMethod());
 
                 // Collect the objects from this property
-                propertyObjects.AddRange(objects.SelectMany(x => getProp(x).Elements));
+                propertyObjects.AddRange(objects.SelectMany(x => (getProp(x)?.Elements ?? new List<P>()).Where(p => p != null)));
             }
 
             //Return the disticnt property objects


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2088 

<!-- Add short description of what has been fixed -->

Adding null checks for extraction of list and group properties.

Without the checks this could cause some really bad memory exceptions, causing Rhino to crash for cases where null lists where put on an object.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EsrZ8NzoZutMvj0WdoqWyQwBiorw88q9EBneNlaBCTTIeA?e=aKnruv

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->