### PR TITLE
Reflection_Engine: Extraction of MemberInfo/ParameterInfo description without type description enabled

### DIFF
--- a/Reflection_Engine/Query/Description.cs
+++ b/Reflection_Engine/Query/Description.cs
@@ -38,8 +38,9 @@ namespace BH.Engine.Reflection
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [PreviousVersion("4.0", "BH.Engine.Reflection.Query.Description(System.Reflection.MemberInfo)")]
         [Description("Return the custom description of a C# class member (e.g. property, method, field)")]
-        public static string Description(this MemberInfo member)
+        public static string Description(this MemberInfo member, bool addTypeDescription = true)
         {
             DescriptionAttribute descriptionAttribute = member.GetCustomAttribute<DescriptionAttribute>();
             QuantityAttribute quantityAttribute = member.GetCustomAttribute<QuantityAttribute>();
@@ -48,7 +49,7 @@ namespace BH.Engine.Reflection
             if (descriptionAttribute != null && !string.IsNullOrWhiteSpace(descriptionAttribute.Description))
                 desc = descriptionAttribute.Description + Environment.NewLine;
 
-            if (member is PropertyInfo && (typeof(IObject).IsAssignableFrom(((PropertyInfo)member).PropertyType)))
+            if (addTypeDescription && member is PropertyInfo && (typeof(IObject).IsAssignableFrom(((PropertyInfo)member).PropertyType)))
             {
                 desc += ((PropertyInfo)member).PropertyType.Description(quantityAttribute) + Environment.NewLine;
             }
@@ -58,8 +59,9 @@ namespace BH.Engine.Reflection
 
         /***************************************************/
 
+        [PreviousVersion("4.0", "BH.Engine.Reflection.Query.Description(System.Reflection.ParameterInfo)")]
         [Description("Return the custom description of a C# method argument")]
-        public static string Description(this ParameterInfo parameter)
+        public static string Description(this ParameterInfo parameter, bool addTypeDescription = true)
         {
             IEnumerable<InputAttribute> inputDesc = parameter.Member.GetCustomAttributes<InputAttribute>().Where(x => x.Name == parameter.Name);
             QuantityAttribute quantityAttribute = null;
@@ -90,7 +92,7 @@ namespace BH.Engine.Reflection
                     }
                 }
             }
-            if (parameter.ParameterType != null)
+            if (addTypeDescription && parameter.ParameterType != null)
             {
                 desc += parameter.ParameterType.Description(quantityAttribute);
             }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2097

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed I think. Rather a simple change, seems not to break things in GH (one simply needs to remember about rebuilding BHoM_UI and Grasshopper_Toolkit @IsakNaslundBh 😆), but would be good to double check by more educated ones.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
This PR should not conflict neither with #1805 nor with #2062.

I would like to get the approval of @adecler before this gets merged - just to make sure we do not blow up the UI 😉 