### PR TITLE
Geometry_Engine: Addition of Query.Volume methods for ISolids

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -247,6 +247,7 @@
     <Compile Include="Modify\Orient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\PointAtX.cs" />
+    <Compile Include="Query\Volume.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj">

--- a/Geometry_Engine/Query/Volume.cs
+++ b/Geometry_Engine/Query/Volume.cs
@@ -33,20 +33,6 @@ namespace BH.Engine.Geometry
     public static partial class Query
     {
         /***************************************************/
-        /**** Public Methods - Interfaces               ****/
-        /***************************************************/
-
-
-        [Description("Gets the enclosed volume of a solid.")]
-        [Input("solid", "The solid to query the volume from.")]
-        [Output("volume", "", typeof(Volume))]
-        public static double IVolume(this ISolid solid)
-        {
-            return Volume(solid as dynamic);
-        }
-
-
-        /***************************************************/
         /**** Public Methods - Solids                   ****/
         /***************************************************/
 
@@ -109,7 +95,20 @@ namespace BH.Engine.Geometry
             return 2.0 * Math.Pow(Math.PI, 2) * Math.Pow(torus.RadiusMinor, 2) * torus.RadiusMajor;
         }
 
- 
+
+        /***************************************************/
+        /**** Public Methods - Interfaces               ****/
+        /***************************************************/
+
+        [Description("Gets the enclosed volume of a solid.")]
+        [Input("solid", "The solid to query the volume from.")]
+        [Output("volume", "", typeof(Volume))]
+        public static double IVolume(this ISolid solid)
+        {
+            return Volume(solid as dynamic);
+        }
+
+
         /***************************************************/
         /**** Private Fallback Methods                  ****/
         /***************************************************/

--- a/Geometry_Engine/Query/Volume.cs
+++ b/Geometry_Engine/Query/Volume.cs
@@ -1,0 +1,114 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ComponentModel;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods - Interfaces               ****/
+        /***************************************************/
+
+
+        [Description("Gets the enclosed volume of a solid.")]
+        [Input("solid", "The solid to query the volume from.")]
+        [Output("volume", "", typeof(Volume))]
+        public static double IVolume(this ISolid solid)
+        {
+            return Volume(solid as dynamic);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods - Solids                   ****/
+        /***************************************************/
+
+        [Description("Gets the enclosed volume created by the BoundaryRepresentation Surfaces. This value is retrieved from the immutable property stored on the object itself.")]
+        [Input("solid","The solid BoundaryRepresentaion to query the volume from.")]
+        [Output("volume", "", typeof(Volume))]
+        public static double Volume(this BoundaryRepresentation solid)
+        {
+            return solid.Volume;
+        }
+
+        /***************************************************/
+
+        [Description("Calculates the analytical solid volume.")]
+        [Input("cone", "The solid cone to query the volume from.")]
+        [Output("volume", "", typeof(Volume))]
+        public static double Volume(this Cone cone)
+        {
+            return (1.0 / 3.0) * Math.PI * Math.Pow(cone.Radius, 2) * cone.Height;
+        }
+
+        /***************************************************/
+
+        [Description("Calculates the analytical solid volume.")]
+        [Input("cuboid", "The cuboid to query the volume from.")]
+        [Output("volume", "", typeof(Volume))]
+        public static double Volume(this Cuboid cuboid)
+        {
+            return cuboid.Length * cuboid.Depth * cuboid.Height;
+        }
+
+        /***************************************************/
+
+        [Description("Calculates the analytical solid volume.")]
+        [Input("cylinder", "The cylinder to query the volume from.")]
+        [Output("volume", "", typeof(Volume))]
+        public static double Volume(this Cylinder cylinder)
+        {
+            return Math.PI * Math.Pow(cylinder.Radius, 2) * cylinder.Height;
+        }
+
+        /***************************************************/
+
+        [Description("Calculates the analytical solid volume.")]
+        [Input("sphere", "The sphere to query the volume from.")]
+        [Output("volume", "", typeof(Volume))]
+        public static double Volume(this Sphere sphere)
+        {
+            return (4.0 / 3.0) * Math.PI * Math.Pow(sphere.Radius, 3);
+        }
+
+
+        /***************************************************/
+
+        [Description("Calculates the analytical solid volume.")]
+        [Input("torus", "The torus to query the volume from.")]
+        [Output("volume", "", typeof(Volume))]
+        public static double Volume(this Torus torus)
+        {
+            return 2.0 * Math.Pow(Math.PI, 2) * Math.Pow(torus.RadiusMinor, 2) * torus.RadiusMajor;
+        }
+
+        /***************************************************/
+    }
+}

--- a/Geometry_Engine/Query/Volume.cs
+++ b/Geometry_Engine/Query/Volume.cs
@@ -109,6 +109,17 @@ namespace BH.Engine.Geometry
             return 2.0 * Math.Pow(Math.PI, 2) * Math.Pow(torus.RadiusMinor, 2) * torus.RadiusMajor;
         }
 
+ 
+        /***************************************************/
+        /**** Private Fallback Methods                  ****/
+        /***************************************************/
+
+        private static double Volume(this ISolid solid)
+        {
+            Reflection.Compute.RecordError($"Volume is not implemented for ISolids of type: {solid.GetType().Name}.");
+            return double.NaN;
+        }
+
         /***************************************************/
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2046 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->

See test file here:
https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FGeometry%5FEngine%2FGeometryEngine%2D%232046%2DVolumeQueryForISolids&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Volume for BoundaryRepresentation is a straight exposure of the Get only Volume Property stored on the object and set at conversion
- All other ISolid volumes are derived from the analytical formulae comprised from defining properties.

### Additional comments
<!-- As required -->