### PR TITLE
BHoM_Engine: Added global & property-specific fractional precision in `Query.Hash()`

### DIFF
--- a/BHoM_Engine/BHoM_Engine.csproj
+++ b/BHoM_Engine/BHoM_Engine.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Management.Automation" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/BHoM_Engine/Query/Hash.cs
+++ b/BHoM_Engine/Query/Hash.cs
@@ -34,6 +34,7 @@ using System.ComponentModel;
 using BH.Engine.Base;
 using System.Collections;
 using System.Data;
+using System.Management.Automation;
 
 namespace BH.Engine.Base
 {
@@ -47,7 +48,7 @@ namespace BH.Engine.Base
         [Input("iObj", "iObject the hash code should be calculated for.")]
         public static string Hash(this IObject iObj)
         {
-            return Hash(iObj, null, null, null, null, 100);
+            return Hash(iObj, null);
         }
 
         /***************************************************/
@@ -60,20 +61,25 @@ namespace BH.Engine.Base
         [Input("namespaceExceptions", "(Optional) e.g. `BH.oM.Structure`. Any corresponding namespace is ignored.")]
         [Input("typeExceptions", "(Optional) e.g. `typeof(Guid)`. Any corresponding type is ignored.")]
         [Input("maxNesting", "(Optional) e.g. `100`. If any property is nested into the object over that level, it is ignored.")]
+        [Input("fractionalDigits", "(Optional) Defaults to 12. Number of digits retained after the comma; applies rounding.")]
+        [Input("fractionalDigitsPerProperty", "(Optional) e.g. `{ { StartNode.Point.X, 2 } }`. If a property name matches this, applies a rounding to the corresponding number of digits specified.\nSupports * wildcard.")]
         public static string Hash(
             this IObject iObj,
-            List<string> propertyNameExceptions = null, //e.g. `Fragments`
-            List<string> propertyFullNameExceptions = null, //e.g. `BH.oM.Structure.Elements.Bar.Fragments`
+            List<string> propertyNameExceptions = null, //e.g. `BHoM_Guid`
+            List<string> propertyFullNameExceptions = null, //e.g. `BH.oM.Structure.Elements.Bar.Fragments` – can use * wildcard here.
             List<string> namespaceExceptions = null, //e.g. `BH.oM.Structure`
             List<Type> typeExceptions = null, //e.g. `typeof(Guid)`
-            int maxNesting = 100)
+            int maxNesting = 100,
+            int fractionalDigits = 12,
+            Dictionary<string, int> fractionalDigitsPerProperty = null // e.g. { { StartNode.Point.X, 2 } } – can use * wildcard here.
+            )
         {
             // Make sure that "BHoM_Guid" is added to the propertyNameExceptions.
             propertyNameExceptions = propertyNameExceptions ?? new List<string>();
             if (!propertyNameExceptions.Contains(nameof(BHoMObject.BHoM_Guid)))
                 propertyNameExceptions.Add(nameof(BHoMObject.BHoM_Guid));
 
-            string hashString = DefiningString(iObj, 0, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions);
+            string hashString = DefiningString(iObj, 0, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions, fractionalDigits, fractionalDigitsPerProperty);
 
             return SHA256Hash(hashString);
         }
@@ -102,19 +108,26 @@ namespace BH.Engine.Base
 
         [Description("Generates a string representing the whole structure of the object with its assigned values.")]
         [Input("obj", "Objects the string should be calculated for.")]
+        [Input("nestingLevel", "Nesting level of the property.")]
+        [Input("maxNesting", "(Optional) e.g. `100`. If any property is nested into the object over that level, it is ignored.")]
         [Input("propertyNameExceptions", "(Optional) e.g. `Fragments`. If you want to exclude a property that many objects have.")]
         [Input("propertyFullNameExceptions", "(Optional) e.g. `BH.oM.Structure.Elements.Bar.Fragments`. If you want to exclude a specific property of an object.")]
         [Input("namespaceExceptions", "(Optional) e.g. `BH.oM.Structure`. Any corresponding namespace is ignored.")]
         [Input("typeExceptions", "(Optional) e.g. `typeof(Guid)`. Any corresponding type is ignored.")]
-        [Input("maxNesting", "(Optional) e.g. `100`. If any property is nested into the object over that level, it is ignored.")]
+        [Input("fractionalDigits", "(Optional) Defaults to 12. Number of digits retained after the comma; applies rounding.")]
+        [Input("fractionalDigitsPerProperty", "(Optional) e.g. `{ { StartNode.Point.X, 2 } }`. If a property name matches this, applies a rounding to the corresponding number of digits specified.")]
+        [Input("propertyPath", "(Optional) Indicates the 'property path' of the current object, e.g. `BH.oM.Structure.Elements.Bar.StartNode.Point.X`")]
         private static string DefiningString(
             object obj,
             int nestingLevel,
             int maxNesting = 100,
-            List<string> propertyNameExceptions = null, //e.g. "Fragments"
+            List<string> propertyNameExceptions = null, //e.g. "BHoM_Guid"
             List<string> propertyFullNameExceptions = null, //e.g. "BH.oM.Structure.Elements.Bar.Fragments"
             List<string> namespaceExceptions = null, //e.g. "BH.oM.Structure"
-            List<Type> typeExceptions = null) //e.g. typeof(Guid)
+            List<Type> typeExceptions = null, //e.g. typeof(Guid)
+            int fractionalDigits = 12,
+            Dictionary<string, int> fractionalDigitsPerProperty = null, // e.g. { { StartNode.Point.X, 2 } } – can use * wildcard here.
+            string propertyPath = null) // Indicates the "property path" of the current object, e.g. BH.oM.Structure.Elements.Bar.StartNode.Point.X
         {
             string composedString = "";
             string tabs = new String('\t', nestingLevel);
@@ -128,27 +141,30 @@ namespace BH.Engine.Base
             {
                 return composedString;
             }
-            else if (type.IsPrimitive || type == typeof(Decimal) || type == typeof(String))
+            else if (type.IsPrimitive || type == typeof(decimal) || type == typeof(String))
             {
+                if (type == typeof(double) || type == typeof(decimal) || type == typeof(float))
+                    obj = Math.Round(obj as dynamic, fractionalDigits);
+
                 composedString += $"\n{tabs}" + obj?.ToString() ?? "";
             }
             else if (type.IsArray)
             {
                 foreach (var element in (obj as dynamic))
-                    composedString += $"\n{tabs}" + DefiningString(element, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions);
+                    composedString += $"\n{tabs}" + DefiningString(element, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions, fractionalDigits, fractionalDigitsPerProperty, propertyPath);
             }
             else if (typeof(IDictionary).IsAssignableFrom(type))
             {
                 IDictionary dic = obj as IDictionary;
                 foreach (DictionaryEntry entry in dic)
                 {
-                    composedString += $"\n{tabs}" + $"[{entry.Key.GetType().FullName}]\n{tabs}{entry.Key}:\n { DefiningString(entry.Value, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions)}";
+                    composedString += $"\n{tabs}" + $"[{entry.Key.GetType().FullName}]\n{tabs}{entry.Key}:\n { DefiningString(entry.Value, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions, fractionalDigits, fractionalDigitsPerProperty, propertyPath)}";
                 }
             }
             else if (typeof(IEnumerable).IsAssignableFrom(type) || typeof(IList).IsAssignableFrom(type) || typeof(ICollection).IsAssignableFrom(type))
             {
                 foreach (var element in (obj as dynamic))
-                    composedString += $"\n{tabs}" + DefiningString(element, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions);
+                    composedString += $"\n{tabs}" + DefiningString(element, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions, fractionalDigits, fractionalDigitsPerProperty, propertyPath);
             }
             else if (type.FullName.Contains("System.Collections.Generic.ObjectEqualityComparer`1"))
             {
@@ -157,7 +173,7 @@ namespace BH.Engine.Base
             else if (type == typeof(System.Data.DataTable))
             {
                 DataTable dt = obj as DataTable;
-                return composedString += $"{type.FullName} {string.Join(", ", dt.Columns.OfType<DataColumn>().Select(c => c.ColumnName))}\n{tabs}" + DefiningString(dt.AsEnumerable(), nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions);
+                return composedString += $"{type.FullName} {string.Join(", ", dt.Columns.OfType<DataColumn>().Select(c => c.ColumnName))}\n{tabs}" + DefiningString(dt.AsEnumerable(), nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions, fractionalDigits, fractionalDigitsPerProperty, propertyPath);
             }
             else if (typeof(IObject).IsAssignableFrom(type))
             {
@@ -165,18 +181,46 @@ namespace BH.Engine.Base
 
                 foreach (PropertyInfo prop in properties)
                 {
-                    bool isInPropertyNameExceptions = (propertyNameExceptions != null && propertyNameExceptions.Where(ex => prop.Name.Contains(ex)).Any());
-                    bool isInPropertyFullNameExceptions = isInPropertyNameExceptions || (propertyNameExceptions != null && propertyNameExceptions.Where(ex => prop.Name.Contains(ex)).Any());
+                    bool isInPropertyNameExceptions = propertyNameExceptions != null && propertyNameExceptions.Where(ex => prop.Name.Contains(ex)).Any();
+                    bool isInPropertyFullNameExceptions = propertyFullNameExceptions != null && propertyFullNameExceptions.Where(ex => new WildcardPattern(ex).IsMatch(prop.Name + "." + prop.DeclaringType.FullName)).Any();
 
                     if (isInPropertyNameExceptions || isInPropertyFullNameExceptions)
-                    {
                         continue;
-                    }
 
                     object propValue = prop.GetValue(obj);
                     if (propValue != null)
                     {
-                        string outString = DefiningString(propValue, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions) ?? "";
+                        if (string.IsNullOrWhiteSpace(propertyPath))
+                            propertyPath = type.FullName + "." + prop.Name;
+                        else if (prop.PropertyType.IsClass)
+                            propertyPath += "." + prop.Name;
+
+                        string outString = "";
+
+                        if (fractionalDigitsPerProperty != null &&
+                            prop.PropertyType == typeof(double) || prop.PropertyType == typeof(decimal) || prop.PropertyType == typeof(float))
+                        {
+                            Dictionary<string, int> matches = new Dictionary<string, int>();
+
+                            string path = propertyPath + "." + prop.Name;
+
+                            foreach (var kv in fractionalDigitsPerProperty)
+                            {
+                                if (path.Contains(kv.Key) ||
+                                new WildcardPattern(kv.Key).IsMatch(path))
+                                    matches.Add(kv.Key, kv.Value);
+                            }
+
+                            if (matches.Count() > 1)
+                                throw new ArgumentException($"Too many matching results obtained with specified {nameof(fractionalDigitsPerProperty)}.");
+
+                            int fracDigits = matches.Count() == 1 ? matches.FirstOrDefault().Value : fractionalDigits;
+
+                            outString = DefiningString(propValue, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions, fracDigits, fractionalDigitsPerProperty, path) ?? "";
+                        }
+                        else
+                            outString = DefiningString(propValue, nestingLevel + 1, maxNesting, propertyNameExceptions, propertyFullNameExceptions, namespaceExceptions, typeExceptions, fractionalDigits, fractionalDigitsPerProperty, propertyPath) ?? "";
+
                         if (!string.IsNullOrWhiteSpace(outString))
                             composedString += $"\n{tabs}" + $"{type.FullName}.{prop.Name}:\n{tabs}{outString} ";
                     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2103 
Closes #2104

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/s/BHoM/EqKWsGEj8cNCuWm1KsWSMSIBiRBvjfLusj572G0zq62exA?e=9AdD5w

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->