### PR TITLE
Physical_Engine: Query the top/bottom centreline of an IFramingElement

### DIFF
--- a/Physical_Engine/Physical_Engine.csproj
+++ b/Physical_Engine/Physical_Engine.csproj
@@ -100,6 +100,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Query\AverageProfileArea.cs" />
     <Compile Include="Query\ConstructionByName.cs" />
+    <Compile Include="Query\BottomCentreline.cs" />
+    <Compile Include="Query\TopCentreline.cs" />
     <Compile Include="Query\ExternalPolyline.cs" />
     <Compile Include="Query\HasMergeablePropertiesWith.cs" />
     <Compile Include="Query\InternalElements2D.cs" />

--- a/Physical_Engine/Query/BottomCentreline.cs
+++ b/Physical_Engine/Query/BottomCentreline.cs
@@ -45,12 +45,11 @@ namespace BH.Engine.Physical
         [Description("Returns the bottom centreline of an IFramingElement.")]
         [Input("element", "The IFramingElement to query the bottom centreline of.")]
         [Output("curve", "The bottom centreline of the IFramingElement.")]
-
         public static ICurve BottomCentreline(this BH.oM.Physical.Elements.IFramingElement element)
         {
             ICurve location = element.Location;
 
-            Vector normal;
+            Vector normal = null;
 
             try
             {
@@ -88,7 +87,7 @@ namespace BH.Engine.Physical
             }
             else
             {
-                Engine.Reflection.Compute.RecordError("Element does not have ConstantFramingProperty, was not able to compute section height.");
+                Engine.Reflection.Compute.RecordError("Element does not have a suitable framing property, so the section height could not be calculated.");
                 return null;
             }
         }

--- a/Physical_Engine/Query/BottomCentreline.cs
+++ b/Physical_Engine/Query/BottomCentreline.cs
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.Engine.Reflection;
+using BH.Engine.Spatial;
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Physical.FramingProperties;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Physical
+{
+    public static partial class Query
+    {
+
+        [Description("Returns the bottom centreline of an IFramingElement.")]
+        [Input("element", "The IFramingElement to query the bottom centreline of.")]
+        [Output("curve", "The bottom centreline of the IFramingElement.")]
+
+        public static ICurve BottomCentreline(this BH.oM.Physical.Elements.IFramingElement element)
+        {
+            ICurve location = element.Location;
+
+            Vector normal;
+
+            normal = BH.Engine.Physical.Query.Normal(element);
+
+            if (normal == null)
+            {
+                Engine.Reflection.Compute.RecordError("Can only extract bottom centrelines from a linear IFramingElement.");
+                return null;
+            }
+
+            double height = 0;
+
+            object heightProperty = element.PropertyValue("Property.Profile.Height");
+
+            if (heightProperty is IConvertible)
+            {
+                height = ((IConvertible)heightProperty).ToDouble(null);
+
+                ICurve bottomCentreline = location.ITranslate(normal * -0.5 * height);
+
+                return bottomCentreline;
+            }
+            else
+            {
+                Engine.Reflection.Compute.RecordError("Was not able to either extract height property or convert into double.");
+                return null;
+            }
+
+        }
+
+    }
+
+}

--- a/Physical_Engine/Query/BottomCentreline.cs
+++ b/Physical_Engine/Query/BottomCentreline.cs
@@ -52,7 +52,15 @@ namespace BH.Engine.Physical
 
             Vector normal;
 
-            normal = BH.Engine.Physical.Query.Normal(element);
+            try
+            {
+                normal = BH.Engine.Physical.Query.Normal(element);
+            }
+            catch
+            {
+                Engine.Reflection.Compute.RecordError("IFramingElement must have linear location line.");
+                return null;
+            }
 
             if (normal == null)
             {
@@ -80,7 +88,7 @@ namespace BH.Engine.Physical
             }
             else
             {
-                Engine.Reflection.Compute.RecordError("Element does not have ConstantFramingProperty, ");
+                Engine.Reflection.Compute.RecordError("Element does not have ConstantFramingProperty, was not able to compute section height.");
                 return null;
             }
         }

--- a/Physical_Engine/Query/BottomCentreline.cs
+++ b/Physical_Engine/Query/BottomCentreline.cs
@@ -27,6 +27,7 @@ using BH.oM.Base;
 using BH.oM.Geometry;
 using BH.oM.Physical.FramingProperties;
 using BH.oM.Reflection.Attributes;
+using BH.oM.Spatial.ShapeProfiles;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -55,17 +56,23 @@ namespace BH.Engine.Physical
 
             if (normal == null)
             {
-                Engine.Reflection.Compute.RecordError("Can only extract bottom centrelines from a linear IFramingElement.");
+                Engine.Reflection.Compute.RecordError("Was not able to compute element normal.");
                 return null;
             }
 
-            double height = 0;
-
-            object heightProperty = element.PropertyValue("Property.Profile.Height");
-
-            if (heightProperty is IConvertible)
+            if(element.Property is ConstantFramingProperty)
             {
-                height = ((IConvertible)heightProperty).ToDouble(null);
+                ConstantFramingProperty constantProperty = element.Property as ConstantFramingProperty;
+
+                IProfile profile = constantProperty.Profile;
+
+                BoundingBox profileBounds = profile.Edges.Bounds();
+
+                Point profileMax = profileBounds.Max;
+
+                Point profileMin = profileBounds.Min;
+
+                double height = profileMax.Y - profileMin.Y;
 
                 ICurve bottomCentreline = location.ITranslate(normal * -0.5 * height);
 
@@ -73,7 +80,7 @@ namespace BH.Engine.Physical
             }
             else
             {
-                Engine.Reflection.Compute.RecordError("Was not able to either extract height property or convert into double.");
+                Engine.Reflection.Compute.RecordError("Element does not have ConstantFramingProperty, ");
                 return null;
             }
         }

--- a/Physical_Engine/Query/BottomCentreline.cs
+++ b/Physical_Engine/Query/BottomCentreline.cs
@@ -76,9 +76,6 @@ namespace BH.Engine.Physical
                 Engine.Reflection.Compute.RecordError("Was not able to either extract height property or convert into double.");
                 return null;
             }
-
         }
-
     }
-
 }

--- a/Physical_Engine/Query/BottomCentreline.cs
+++ b/Physical_Engine/Query/BottomCentreline.cs
@@ -36,16 +36,16 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Physical.Elements;
 
 namespace BH.Engine.Physical
 {
     public static partial class Query
     {
-
         [Description("Returns the bottom centreline of an IFramingElement.")]
         [Input("element", "The IFramingElement to query the bottom centreline of.")]
         [Output("curve", "The bottom centreline of the IFramingElement.")]
-        public static ICurve BottomCentreline(this BH.oM.Physical.Elements.IFramingElement element)
+        public static ICurve BottomCentreline(this IFramingElement element)
         {
             ICurve location = element.Location;
 

--- a/Physical_Engine/Query/TopCentreline.cs
+++ b/Physical_Engine/Query/TopCentreline.cs
@@ -51,11 +51,13 @@ namespace BH.Engine.Physical
 
             Vector normal;
 
-            normal = BH.Engine.Physical.Query.Normal(element);
-
-            if (normal == null)
+            try
             {
-                Engine.Reflection.Compute.RecordError("Was not able to compute element normal.");
+                normal = BH.Engine.Physical.Query.Normal(element);
+            }
+            catch
+            {
+                Engine.Reflection.Compute.RecordError("IFramingElement must have linear location line.");
                 return null;
             }
 
@@ -79,7 +81,7 @@ namespace BH.Engine.Physical
             }
             else
             {
-                Engine.Reflection.Compute.RecordError("Element does not have ConstantFramingProperty, ");
+                Engine.Reflection.Compute.RecordError("Element does not have ConstantFramingProperty, was not able to compute section height.");
                 return null;
             }
         }

--- a/Physical_Engine/Query/TopCentreline.cs
+++ b/Physical_Engine/Query/TopCentreline.cs
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.Engine.Reflection;
+using BH.Engine.Spatial;
+using BH.oM.Base;
+using BH.oM.Geometry;
+using BH.oM.Physical.FramingProperties;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Configuration;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Engine.Physical
+{
+    public static partial class Query
+    {
+        [Description("Returns the top centreline of an IFramingElement.")]
+        [Input("element", "The IFramingElement to query the top centreline of.")]
+        [Output("curve", "The top centreline of the IFramingElement.")]
+
+        public static ICurve TopCentreline(this BH.oM.Physical.Elements.IFramingElement element)
+        {
+            ICurve location = element.Location;
+
+            Vector normal;
+
+            normal = BH.Engine.Physical.Query.Normal(element);
+
+            if (normal == null)
+            {
+                Engine.Reflection.Compute.RecordError("Can only extract top centrelines from a linear IFramingElement.");
+                return null;
+            }
+
+            double height = 0;
+
+            object heightProperty = element.PropertyValue("Property.Profile.Height");
+
+            if (heightProperty is IConvertible)
+            {
+                height = ((IConvertible)heightProperty).ToDouble(null);
+
+                ICurve topCentreline = location.ITranslate(normal * 0.5 * height);
+
+                return topCentreline;
+            }
+            else
+            {
+                Engine.Reflection.Compute.RecordError("Was not able to either extract height property or convert into double.");
+                return null;
+            }
+
+        }
+
+    }
+}

--- a/Physical_Engine/Query/TopCentreline.cs
+++ b/Physical_Engine/Query/TopCentreline.cs
@@ -75,8 +75,6 @@ namespace BH.Engine.Physical
                 Engine.Reflection.Compute.RecordError("Was not able to either extract height property or convert into double.");
                 return null;
             }
-
         }
-
     }
 }

--- a/Physical_Engine/Query/TopCentreline.cs
+++ b/Physical_Engine/Query/TopCentreline.cs
@@ -44,12 +44,11 @@ namespace BH.Engine.Physical
         [Description("Returns the top centreline of an IFramingElement.")]
         [Input("element", "The IFramingElement to query the top centreline of.")]
         [Output("curve", "The top centreline of the IFramingElement.")]
-
         public static ICurve TopCentreline(this BH.oM.Physical.Elements.IFramingElement element)
         {   
             ICurve location = element.Location;
 
-            Vector normal;
+            Vector normal = null;
 
             try
             {
@@ -75,13 +74,13 @@ namespace BH.Engine.Physical
 
                 double height = profileMax.Y - profileMin.Y;
 
-                ICurve topCentreline = location.ITranslate(normal * -0.5 * height);
+                ICurve topCentreline = location.ITranslate(normal * 0.5 * height);
 
                 return topCentreline;
             }
             else
             {
-                Engine.Reflection.Compute.RecordError("Element does not have ConstantFramingProperty, was not able to compute section height.");
+                Engine.Reflection.Compute.RecordError("Element does not have a suitable framing property, so the section height could not be calculated.");
                 return null;
             }
         }

--- a/Physical_Engine/Query/TopCentreline.cs
+++ b/Physical_Engine/Query/TopCentreline.cs
@@ -36,6 +36,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
+using BH.oM.Physical.Elements;
 
 namespace BH.Engine.Physical
 {
@@ -44,7 +45,7 @@ namespace BH.Engine.Physical
         [Description("Returns the top centreline of an IFramingElement.")]
         [Input("element", "The IFramingElement to query the top centreline of.")]
         [Output("curve", "The top centreline of the IFramingElement.")]
-        public static ICurve TopCentreline(this BH.oM.Physical.Elements.IFramingElement element)
+        public static ICurve TopCentreline(this IFramingElement element)
         {   
             ICurve location = element.Location;
 
@@ -57,6 +58,12 @@ namespace BH.Engine.Physical
             catch
             {
                 Engine.Reflection.Compute.RecordError("IFramingElement must have linear location line.");
+                return null;
+            }
+
+            if (normal == null)
+            {
+                Engine.Reflection.Compute.RecordError("Was not able to compute element normal.");
                 return null;
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2079 

[https://github.com/BHoM/BHoM_Engine/pull/2115](url)

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[Spatial_Engin#2115_Test File.zip](https://github.com/BHoM/BHoM_Engine/files/5475190/Spatial_Engin.2115_Test.File.zip)



### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
Creating two query methods returning the top/ bottom centreline of an IFramingElement.

