### PR TITLE
BHoM_Engine: Correctly assign CustomObject properties like Name and Tags

### DIFF
--- a/BHoM_Engine/Create/CustomObject.cs
+++ b/BHoM_Engine/Create/CustomObject.cs
@@ -69,7 +69,7 @@ namespace BH.Engine.Base
             else
                 throw new System.Exception("The list of property names must be the same length as the list of property values when creating a Custon object.");
 
-            if (name != "")
+            if (!string.IsNullOrEmpty(name))
                 result.Name = name;
 
             return result;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #1981

Assigning properties like `Name`, `BHoM_Guid`, `Tags`, and `Fragments` now tries to assign it to the corresponding property (if type is valid) instead of directly into the `CustomData` dictionary.


### Test files
<!-- Link to test files to validate the proposed changes -->
![image](https://user-images.githubusercontent.com/16853390/97959079-8c198400-1de9-11eb-9cf9-03e96f8dbe35.png)

