### PR TITLE
Spatial_Engine: Add Query.IsNearLevel() method

### DIFF
--- a/Spatial_Engine/Query/IsNearLevel.cs
+++ b/Spatial_Engine/Query/IsNearLevel.cs
@@ -100,6 +100,16 @@ namespace BH.Engine.Spatial
             return IsNearLevel(element as dynamic, level, maxDistance);
         }
 
+        /***************************************************/
+        /**** Private Fallback Methods                  ****/
+        /***************************************************/
+
+        private static bool IsNearLevel(this IElement element, Level level, double maxDistance)
+        {
+            Reflection.Compute.RecordError($"IsNearLevel is not implemented for IElements of type: {element.GetType().Name}.");
+            return false;
+        }
+
         /******************************************/
 
     }

--- a/Spatial_Engine/Query/IsNearLevel.cs
+++ b/Spatial_Engine/Query/IsNearLevel.cs
@@ -53,11 +53,11 @@ namespace BH.Engine.Spatial
 
         /******************************************/
 
-        [Description("Checks if the geometrical representation of an IElement1D, projected onto the XY Plane, is within a set distance from a level line.")]
+        [Description("Checks if the geometrical representation of an IElement1D is within a set distance from a level elevation.")]
         [Input("element1D", "The IElement1D that will be checked for proximity to the Level.")]
         [Input("level", "The Level to use for evaulation.")]
         [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]
-        [Output("isNearLevel", "A boolean which is true if the geometrical representation of an IElement1D is within a set distance from the level line.")]
+        [Output("isNearLevel", "A boolean which is true if the geometrical representation of an IElement1D is within a set distance from the level elevation.")]
         public static bool IsNearLevel(this IElement1D element1D, Level level, double maxDistance)
         {
 
@@ -71,11 +71,11 @@ namespace BH.Engine.Spatial
 
         /******************************************/
 
-        [Description("Checks if the geometrical representation of an IElement2D, projected onto the XY Plane, is within a set distance from a level line.")]
+        [Description("Checks if the geometrical representation of an IElement2D is within a set distance from a level elevation.")]
         [Input("element2D", "The IElement2D that will be checked for proximity to the Level.")]
         [Input("level", "The Level to use for evaulation.")]
         [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]
-        [Output("isNearLevel", "A boolean which is true if the geometrical representation of an IElement2D is within a set distance from the level line.")]
+        [Output("isNearLevel", "A boolean which is true if the geometrical representation of an IElement2D is within a set distance from the level elevation.")]
         public static bool IsNearLevel(this IElement2D element2D, Level level, double maxDistance)
         {
 
@@ -92,11 +92,11 @@ namespace BH.Engine.Spatial
         /****   Public Methods - Interfaces    ****/
         /******************************************/
 
-        [Description("Checks if the geometrical representation of an IElement, projected onto the XY Plane, is within a set distance from a level line.")]
+        [Description("Checks if the geometrical representation of an IElement is within a set distance from a level elevation.")]
         [Input("element", "The IElement that will be checked for proximity to the Level.")]
         [Input("level", "The Level to use for evaulation.")]
         [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]
-        [Output("isNearLevel", "A boolean which is true if the geometrical representation of the IElement is within a set distance from the level line.")]
+        [Output("isNearLevel", "A boolean which is true if the geometrical representation of the IElement is within a set distance from the level elevation.")]
         public static bool IIsNearLevel(this IElement element, Level level, double maxDistance)
         {
             return IsNearLevel(element as dynamic, level, maxDistance);

--- a/Spatial_Engine/Query/IsNearLevel.cs
+++ b/Spatial_Engine/Query/IsNearLevel.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Spatial
         /****  Public Methods                  ****/
         /******************************************/
 
-        [Description("Checks if the geometrical representation of an IElement0D, projected onto the XY Plane, is within a set distance from a level line.")]
+        [Description("Checks if the geometrical representation of an IElement0D is within a set distance from a level elevation.")]
         [Input("element0D", "The IElement0D that will be checked for proximity to the Level.")]
         [Input("level", "The Level to use for evaulation.")]
         [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]

--- a/Spatial_Engine/Query/IsNearLevel.cs
+++ b/Spatial_Engine/Query/IsNearLevel.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Spatial
         [Input("element0D", "The IElement0D that will be checked for proximity to the Level.")]
         [Input("level", "The Level to use for evaulation.")]
         [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]
-        [Output("isNearLevel", "A boolean which is true if the geometrical representation of the IElement0D is within a set distance from the level line.")]
+        [Output("isNearLevel", "A boolean which is true if the geometrical representation of the IElement0D is within a set distance from the level elevation.")]
         public static bool IsNearLevel(this IElement0D element0D, Level level, double maxDistance)
         {
             Point position = element0D.IGeometry();

--- a/Spatial_Engine/Query/IsNearLevel.cs
+++ b/Spatial_Engine/Query/IsNearLevel.cs
@@ -60,13 +60,10 @@ namespace BH.Engine.Spatial
         [Output("isNearLevel", "A boolean which is true if the geometrical representation of an IElement1D is within a set distance from the level elevation.")]
         public static bool IsNearLevel(this IElement1D element1D, Level level, double maxDistance)
         {
-
             ICurve curve = element1D.IGeometry();
-
             BoundingBox bBox = curve.IBounds();
 
             return bBox.Min.Z - maxDistance <= level.Elevation && level.Elevation <= bBox.Max.Z + maxDistance;
-
         }
 
         /******************************************/
@@ -78,12 +75,13 @@ namespace BH.Engine.Spatial
         [Output("isNearLevel", "A boolean which is true if the geometrical representation of an IElement2D is within a set distance from the level elevation.")]
         public static bool IsNearLevel(this IElement2D element2D, Level level, double maxDistance)
         {
-
             List<IElement1D> elements1D = element2D.IOutlineElements1D();
 
             foreach (IElement1D e1D in elements1D)
+            {
                 if (IsNearLevel(e1D, level, maxDistance))
                     return true;
+            }
             
             return false;
         }

--- a/Spatial_Engine/Query/IsNearLevel.cs
+++ b/Spatial_Engine/Query/IsNearLevel.cs
@@ -1,0 +1,108 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.oM.Dimensional;
+using BH.oM.Geometry;
+using BH.oM.Quantities.Attributes;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Geometry.SettingOut;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.Engine.Base;
+using System;
+
+namespace BH.Engine.Spatial
+{
+    public static partial class Query
+    {
+        /******************************************/
+        /****  Public Methods                  ****/
+        /******************************************/
+
+        [Description("Checks if the geometrical representation of an IElement0D, projected onto the XY Plane, is within a set distance from a level line.")]
+        [Input("element0D", "The IElement0D that will be checked for proximity to the Level.")]
+        [Input("level", "The Level to use for evaulation.")]
+        [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]
+        [Output("isNearLevel", "A boolean which is true if the geometrical representation of the IElement0D is within a set distance from the level line.")]
+        public static bool IsNearLevel(this IElement0D element0D, Level level, double maxDistance)
+        {
+            Point position = element0D.IGeometry();
+
+            return Math.Abs(level.Elevation - position.Z) <= maxDistance;
+        }
+
+        /******************************************/
+
+        [Description("Checks if the geometrical representation of an IElement1D, projected onto the XY Plane, is within a set distance from a level line.")]
+        [Input("element1D", "The IElement1D that will be checked for proximity to the Level.")]
+        [Input("level", "The Level to use for evaulation.")]
+        [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]
+        [Output("isNearLevel", "A boolean which is true if the geometrical representation of an IElement1D is within a set distance from the level line.")]
+        public static bool IsNearLevel(this IElement1D element1D, Level level, double maxDistance)
+        {
+
+            ICurve curve = element1D.IGeometry();
+
+            BoundingBox bBox = curve.IBounds();
+
+            return bBox.Min.Z - maxDistance <= level.Elevation && level.Elevation <= bBox.Max.Z + maxDistance;
+
+        }
+
+        /******************************************/
+
+        [Description("Checks if the geometrical representation of an IElement2D, projected onto the XY Plane, is within a set distance from a level line.")]
+        [Input("element2D", "The IElement2D that will be checked for proximity to the Level.")]
+        [Input("level", "The Level to use for evaulation.")]
+        [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]
+        [Output("isNearLevel", "A boolean which is true if the geometrical representation of an IElement2D is within a set distance from the level line.")]
+        public static bool IsNearLevel(this IElement2D element2D, Level level, double maxDistance)
+        {
+
+            List<IElement1D> elements1D = element2D.IOutlineElements1D();
+
+            foreach (IElement1D e1D in elements1D)
+                if (IsNearLevel(e1D, level, maxDistance))
+                    return true;
+            
+            return false;
+        }
+
+        /******************************************/
+        /****   Public Methods - Interfaces    ****/
+        /******************************************/
+
+        [Description("Checks if the geometrical representation of an IElement, projected onto the XY Plane, is within a set distance from a level line.")]
+        [Input("element", "The IElement that will be checked for proximity to the Level.")]
+        [Input("level", "The Level to use for evaulation.")]
+        [Input("maxDistance", "The maximum distance allowed from the Level for this method to return true.", typeof(Length))]
+        [Output("isNearLevel", "A boolean which is true if the geometrical representation of the IElement is within a set distance from the level line.")]
+        public static bool IIsNearLevel(this IElement element, Level level, double maxDistance)
+        {
+            return IsNearLevel(element as dynamic, level, maxDistance);
+        }
+
+        /******************************************/
+
+    }
+}

--- a/Spatial_Engine/Spatial_Engine.csproj
+++ b/Spatial_Engine/Spatial_Engine.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Query\ElementVertices.cs" />
     <Compile Include="Query\InternalElements2D.cs" />
     <Compile Include="Query\IsNearGrid.cs" />
+    <Compile Include="Query\IsNearLevel.cs" />
     <Compile Include="Query\IsSelfIntersecting.cs" />
     <Compile Include="Query\Length.cs" />
     <Compile Include="Query\Normal.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2054 

<!-- Add short description of what has been fixed -->

Adds Query.IsNearLevel() method to Spatial_Engine. This method accepts an IElement, a Level, and a double maxDistance as input, and tests the IElement for proximity to the Level, returning true if the distance is lower than or equal to maxDistance.

### Test files
<!-- Link to test files to validate the proposed changes -->
[IsNearLevel-Test.zip](https://github.com/BHoM/BHoM_Engine/files/5486948/IsNearLevel-Test.zip)

### Changelog
`Query.IsNearLevel()` Query method added in the `Spatial_Engine` for `IElement` class

### Additional comments
While this method is heavily based on IsNearGrid(), creating it was not as straightforward, as there are no existing methods to measure the distance to a Level or even a Plane as far as I could tell. I tried to find a reasonably simple approach using the methods that were available, but I would like your feedback and suggestions if you have any.