### PR TITLE
Spatial_Engine: Add fallback method to Query.IsNearGrid()

### DIFF
--- a/Spatial_Engine/Query/IsNearGrid.cs
+++ b/Spatial_Engine/Query/IsNearGrid.cs
@@ -98,6 +98,16 @@ namespace BH.Engine.Spatial
             return IsNearGrid(element as dynamic, grid, maxDistance);
         }
 
+        /***************************************************/
+        /**** Private Fallback Methods                  ****/
+        /***************************************************/
+
+        private static bool IsNearGrid(this IElement element, Grid grid, double maxDistance)
+        {
+            Reflection.Compute.RecordError($"IsNearGrid is not implemented for IElements of type: {element.GetType().Name}.");
+            return false;
+        }
+
         /******************************************/
 
     }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add short description of what has been fixed -->
Adds a fallback method to IsNearGrid, which was originally merged into master with pull request #2093, and currently does not have one. See that and issue #2055 for general details.
