### PR TITLE
Reflection_Engine: Access fragment properties

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -108,9 +108,19 @@ namespace BH.Engine.Reflection
             if (obj == null) return false;
 
             if (!obj.CustomData.ContainsKey(propName))
-                Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data");
+            {
+                if (value is IFragment)
+                {
+                    obj.Fragments.Add(value as IFragment);
+                    Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as a fragment.");
+                }
+                else
+                {
+                    obj.CustomData[propName] = value;
+                    Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data.");
+                }
+            }
 
-            obj.CustomData[propName] = value;
             return true;
         }
 

--- a/Reflection_Engine/Query/PropertyValue.cs
+++ b/Reflection_Engine/Query/PropertyValue.cs
@@ -81,9 +81,17 @@ namespace BH.Engine.Reflection
             }
             else
             {
-                IFragment fragment = obj.Fragments.FirstOrDefault(x => x.GetType().Name == propName);
+                IFragment fragment = null;
+                Type fragmentType = Create.Type(propName, true);
+                if (fragmentType != null)
+                {
+                    List<IFragment> matches = bhom.Fragments.Where(fr => fragmentType.IsAssignableFrom(fr.GetType())).ToList();
+                    if (matches.Count > 1)
+                        Compute.RecordWarning($"{bhom} contains more than one fragment of type {fragmentType.IToText()}. The first one will be returned.");
+                    fragment = matches.FirstOrDefault();
+                }
                 if (fragment == null)
-                    Compute.RecordWarning($"{bhom} does not contain a property: {propName}, or: CustomData[{propName}]");
+                    Compute.RecordWarning($"{bhom} does not contain a property: {propName}, or: CustomData[{propName}], or fragment of type {propName}.");
 
                 return fragment;
             }

--- a/Reflection_Engine/Query/PropertyValue.cs
+++ b/Reflection_Engine/Query/PropertyValue.cs
@@ -81,8 +81,11 @@ namespace BH.Engine.Reflection
             }
             else
             {
-                Compute.RecordWarning($"{bhom} does not contain a property: {propName}, or: CustomData[{propName}]");
-                return null;
+                IFragment fragment = obj.Fragments.FirstOrDefault(x => x.GetType().Name == propName);
+                if (fragment == null)
+                    Compute.RecordWarning($"{bhom} does not contain a property: {propName}, or: CustomData[{propName}]");
+
+                return fragment;
             }
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/BHoM/issues/477

We can now access fragments through `GetProperty` by providing the name of the fragment type.

I have also mirrored that behaviour in SetProperty. This is a bit weirder because of the `name` input but this, at least, provide a functioning solution for those that don't know about `AddFragment`.


### Test files
Definitely recommend trying your own thing but here's what I did:

![image](https://user-images.githubusercontent.com/16853390/98916294-f88d3500-2505-11eb-96f3-24432fd19527.png)

### Additional comments
I would prefer if https://github.com/BHoM/BHoM_Engine/pull/2142 was merged first as the two PRs are modifying the same file (although not the same lines) and this one is easier to fix if rebase doesn't work.