### PR TITLE
Spatial_Engine: Align centroid with origin when creating profiles

### DIFF
--- a/Spatial_Engine/Create/ShapeProfiles/AngleProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/AngleProfile.cs
@@ -115,11 +115,10 @@ namespace BH.Engine.Spatial
             if (toeRadius > 0) perimeter.Add(BH.Engine.Geometry.Create.ArcByCentre(p - xAxis * (toeRadius), p, p = p + new Vector { X = -toeRadius, Y = toeRadius, Z = 0 }));
             perimeter.Add(new Line { Start = p, End = p = p - xAxis * (webThickness - toeRadius) });
             perimeter.Add(new Line { Start = p, End = p = p - yAxis * (depth) });
-            List<ICurve> translatedCurves = new List<ICurve>();
 
             Point centroid = perimeter.IJoin().Centroid();
-            Vector tranlation = Point.Origin - centroid;
-            return perimeter.Select(x => x.ITranslate(tranlation)).ToList();
+            Vector translation = Point.Origin - centroid;
+            return perimeter.Select(x => x.ITranslate(translation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/AngleProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/AngleProfile.cs
@@ -90,10 +90,6 @@ namespace BH.Engine.Spatial
             if (mirrorAboutLocalY)
                 curves = curves.MirrorAboutLocalY();
 
-            Point centroid = curves.IJoin().Centroid();
-            Vector tranlation = Point.Origin-centroid;
-            curves = curves.Select(x => x.ITranslate(tranlation)).ToList();
-
             return new AngleProfile(height, width, webThickness, flangeThickness, rootRadius, toeRadius, mirrorAboutLocalZ, mirrorAboutLocalY, curves);
         }
 
@@ -121,10 +117,9 @@ namespace BH.Engine.Spatial
             perimeter.Add(new Line { Start = p, End = p = p - yAxis * (depth) });
             List<ICurve> translatedCurves = new List<ICurve>();
 
-            foreach (ICurve crv in perimeter)
-                translatedCurves.Add(crv.ITranslate(new Vector { X = -width / 2, Y = -depth / 2, Z = 0 }));
-
-            return translatedCurves;
+            Point centroid = perimeter.IJoin().Centroid();
+            Vector tranlation = Point.Origin - centroid;
+            return perimeter.Select(x => x.ITranslate(tranlation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/AngleProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/AngleProfile.cs
@@ -90,6 +90,10 @@ namespace BH.Engine.Spatial
             if (mirrorAboutLocalY)
                 curves = curves.MirrorAboutLocalY();
 
+            Point centroid = curves.IJoin().Centroid();
+            Vector tranlation = Point.Origin-centroid;
+            curves = curves.Select(x => x.ITranslate(tranlation)).ToList();
+
             return new AngleProfile(height, width, webThickness, flangeThickness, rootRadius, toeRadius, mirrorAboutLocalZ, mirrorAboutLocalY, curves);
         }
 

--- a/Spatial_Engine/Create/ShapeProfiles/ChannelProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/ChannelProfile.cs
@@ -81,6 +81,10 @@ namespace BH.Engine.Spatial
             if (mirrorAboutLocalZ)
                 curves = curves.MirrorAboutLocalZ();
 
+            Point centroid = curves.IJoin().Centroid();
+            Vector tranlation = Point.Origin - centroid;
+            curves = curves.Select(x => x.ITranslate(tranlation)).ToList();
+
             return new ChannelProfile(height, flangeWidth, webThickness, flangeThickness, rootRadius, toeRadius, mirrorAboutLocalZ, curves);
         }
 

--- a/Spatial_Engine/Create/ShapeProfiles/ChannelProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/ChannelProfile.cs
@@ -108,8 +108,8 @@ namespace BH.Engine.Spatial
             }
 
             Point centroid = edges.IJoin().Centroid();
-            Vector tranlation = Point.Origin - centroid;
-            return edges.Select(x => x.ITranslate(tranlation)).ToList();
+            Vector translation = Point.Origin - centroid;
+            return edges.Select(x => x.ITranslate(translation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/ChannelProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/ChannelProfile.cs
@@ -81,10 +81,6 @@ namespace BH.Engine.Spatial
             if (mirrorAboutLocalZ)
                 curves = curves.MirrorAboutLocalZ();
 
-            Point centroid = curves.IJoin().Centroid();
-            Vector tranlation = Point.Origin - centroid;
-            curves = curves.Select(x => x.ITranslate(tranlation)).ToList();
-
             return new ChannelProfile(height, flangeWidth, webThickness, flangeThickness, rootRadius, toeRadius, mirrorAboutLocalZ, curves);
         }
 
@@ -111,7 +107,9 @@ namespace BH.Engine.Spatial
                 edges.Add(edges[i].IMirror(new Plane { Origin = oM.Geometry.Point.Origin, Normal = oM.Geometry.Vector.YAxis }));
             }
 
-            return edges;
+            Point centroid = edges.IJoin().Centroid();
+            Vector tranlation = Point.Origin - centroid;
+            return edges.Select(x => x.ITranslate(tranlation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/FabricatedBoxProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/FabricatedBoxProfile.cs
@@ -70,6 +70,8 @@ namespace BH.Engine.Spatial
             }
 
             List<ICurve> curves = FabricatedBoxProfileCurves(width, height, webThickness, topFlangeThickness, botFlangeThickness, weldSize);
+
+
             return new FabricatedBoxProfile(height, width, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }
 
@@ -90,22 +92,29 @@ namespace BH.Engine.Spatial
             Vector wx = new Vector { X = weldLength, Y = 0, Z = 0 };
             Vector wy = new Vector { X = 0, Y = weldLength, Z = 0 };
 
+            List<ICurve> innerBox = new List<ICurve>();
+
             if (weldSize > 0)
             {
                 welds.Add(new Line { Start = q1 - wx, End = q1 - wy });
                 welds.Add(new Line { Start = q2 + wx, End = q2 - wy });
                 welds.Add(new Line { Start = q3 + wx, End = q3 + wy });
                 welds.Add(new Line { Start = q4 - wx, End = q4 + wy });
-                box.AddRange(welds);
+                innerBox.AddRange(welds);
             }
 
-            List<ICurve> innerBox = new List<ICurve>();
+
             innerBox.Add(new Line { Start = q1 - wy, End = q4 + wy });
             innerBox.Add(new Line { Start = q4 - wx, End = q3 + wx });
             innerBox.Add(new Line { Start = q3 + wy, End = q2 - wy });
             innerBox.Add(new Line { Start = q2 + wx, End = q1 - wx });
 
+            Point centroid = box.IJoin().Centroid(innerBox.IJoin());
+            Vector tranlation = Point.Origin - centroid;
+
             box.AddRange(innerBox);
+
+            box = box.Select(x => x.ITranslate(tranlation)).ToList();
 
             return box;
         }

--- a/Spatial_Engine/Create/ShapeProfiles/FabricatedBoxProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/FabricatedBoxProfile.cs
@@ -108,11 +108,11 @@ namespace BH.Engine.Spatial
             innerBox.Add(new Line { Start = q2 + wx, End = q1 - wx });
 
             Point centroid = box.IJoin().Centroid(innerBox.IJoin());
-            Vector tranlation = Point.Origin - centroid;
+            Vector translation = Point.Origin - centroid;
 
             box.AddRange(innerBox);
 
-            return box.Select(x => x.ITranslate(tranlation)).ToList();
+            return box.Select(x => x.ITranslate(translation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/FabricatedBoxProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/FabricatedBoxProfile.cs
@@ -70,8 +70,6 @@ namespace BH.Engine.Spatial
             }
 
             List<ICurve> curves = FabricatedBoxProfileCurves(width, height, webThickness, topFlangeThickness, botFlangeThickness, weldSize);
-
-
             return new FabricatedBoxProfile(height, width, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }
 
@@ -114,9 +112,7 @@ namespace BH.Engine.Spatial
 
             box.AddRange(innerBox);
 
-            box = box.Select(x => x.ITranslate(tranlation)).ToList();
-
-            return box;
+            return box.Select(x => x.ITranslate(tranlation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/FabricatedISectionProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/FabricatedISectionProfile.cs
@@ -77,6 +77,11 @@ namespace BH.Engine.Spatial
             }
 
             List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness, 0, 0, weldSize);
+
+            Point centroid = curves.IJoin().Centroid();
+            Vector tranlation = Point.Origin - centroid;
+            curves = curves.Select(x => x.ITranslate(tranlation)).ToList();
+
             return new FabricatedISectionProfile(height, topFlangeWidth, botFlangeWidth, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }
 

--- a/Spatial_Engine/Create/ShapeProfiles/FabricatedISectionProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/FabricatedISectionProfile.cs
@@ -79,8 +79,8 @@ namespace BH.Engine.Spatial
             List<ICurve> curves = IProfileCurves(topFlangeThickness, topFlangeWidth, botFlangeThickness, botFlangeWidth, webThickness, height - botFlangeThickness - topFlangeThickness, 0, 0, weldSize);
 
             Point centroid = curves.IJoin().Centroid();
-            Vector tranlation = Point.Origin - centroid;
-            curves = curves.Select(x => x.ITranslate(tranlation)).ToList();
+            Vector translation = Point.Origin - centroid;
+            curves = curves.Select(x => x.ITranslate(translation)).ToList();
 
             return new FabricatedISectionProfile(height, topFlangeWidth, botFlangeWidth, webThickness, topFlangeThickness, botFlangeThickness, weldSize, curves);
         }

--- a/Spatial_Engine/Create/ShapeProfiles/GeneralisedFabricatedBoxProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/GeneralisedFabricatedBoxProfile.cs
@@ -117,12 +117,12 @@ namespace BH.Engine.Spatial
             }
 
             Point centroid = externalEdges.IJoin().Centroid(internalEdges.IJoin());
-            Vector tranlation = Point.Origin - centroid;
+            Vector translation = Point.Origin - centroid;
 
             group.AddRange(externalEdges);
             group.AddRange(internalEdges);
 
-            return group.Select(x => x.ITranslate(tranlation)).ToList();
+            return group.Select(x => x.ITranslate(translation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/GeneralisedFabricatedBoxProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/GeneralisedFabricatedBoxProfile.cs
@@ -116,8 +116,13 @@ namespace BH.Engine.Spatial
                 internalEdges.Add(internalEdges[i].IMirror(new Plane { Origin = origin, Normal = xAxis }));
             }
 
+            Point centroid = externalEdges.IJoin().Centroid(internalEdges.IJoin());
+            Vector tranlation = Point.Origin - centroid;
+
             group.AddRange(externalEdges);
             group.AddRange(internalEdges);
+
+            group = group.Select(x => x.ITranslate(tranlation)).ToList();
 
             return group;
         }

--- a/Spatial_Engine/Create/ShapeProfiles/GeneralisedFabricatedBoxProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/GeneralisedFabricatedBoxProfile.cs
@@ -122,9 +122,7 @@ namespace BH.Engine.Spatial
             group.AddRange(externalEdges);
             group.AddRange(internalEdges);
 
-            group = group.Select(x => x.ITranslate(tranlation)).ToList();
-
-            return group;
+            return group.Select(x => x.ITranslate(tranlation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/GeneralisedTSectionProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/GeneralisedTSectionProfile.cs
@@ -116,9 +116,7 @@ namespace BH.Engine.Spatial
             Point centroid = perimeter.IJoin().Centroid();
             Vector tranlation = Point.Origin - centroid;
 
-            perimeter = perimeter.Select(x => x.ITranslate(tranlation)).ToList();
-
-            return perimeter;
+            return perimeter.Select(x => x.ITranslate(tranlation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/GeneralisedTSectionProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/GeneralisedTSectionProfile.cs
@@ -113,6 +113,11 @@ namespace BH.Engine.Spatial
             perimeter.Add(new Line { Start = p, End = p = p + yAxis * (-height + rightOutstandThickness) });
             perimeter.Add(new Line { Start = p, End = p = p + xAxis * (-webThickness) });
 
+            Point centroid = perimeter.IJoin().Centroid();
+            Vector tranlation = Point.Origin - centroid;
+
+            perimeter = perimeter.Select(x => x.ITranslate(tranlation)).ToList();
+
             return perimeter;
         }
 

--- a/Spatial_Engine/Create/ShapeProfiles/GeneralisedTSectionProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/GeneralisedTSectionProfile.cs
@@ -114,9 +114,9 @@ namespace BH.Engine.Spatial
             perimeter.Add(new Line { Start = p, End = p = p + xAxis * (-webThickness) });
 
             Point centroid = perimeter.IJoin().Centroid();
-            Vector tranlation = Point.Origin - centroid;
+            Vector translation = Point.Origin - centroid;
 
-            return perimeter.Select(x => x.ITranslate(tranlation)).ToList();
+            return perimeter.Select(x => x.ITranslate(translation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/KiteProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/KiteProfile.cs
@@ -115,9 +115,7 @@ namespace BH.Engine.Spatial
             group.AddRange(externalEdges);
             group.AddRange(internalEdges);
 
-            group = group.Select(x => x.ITranslate(tranlation)).ToList();
-
-            return group;
+            return group.Select(x => x.ITranslate(tranlation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/KiteProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/KiteProfile.cs
@@ -110,12 +110,12 @@ namespace BH.Engine.Spatial
             }
 
             Point centroid = externalEdges.IJoin().Centroid(internalEdges.IJoin());
-            Vector tranlation = Point.Origin - centroid;
+            Vector translation = Point.Origin - centroid;
 
             group.AddRange(externalEdges);
             group.AddRange(internalEdges);
 
-            return group.Select(x => x.ITranslate(tranlation)).ToList();
+            return group.Select(x => x.ITranslate(translation)).ToList();
         }
 
         /***************************************************/

--- a/Spatial_Engine/Create/ShapeProfiles/KiteProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/KiteProfile.cs
@@ -109,8 +109,13 @@ namespace BH.Engine.Spatial
                 internalEdges.Add(internalEdges[i].IMirror(new Plane { Origin = origin, Normal = yAxis }));
             }
 
+            Point centroid = externalEdges.IJoin().Centroid(internalEdges.IJoin());
+            Vector tranlation = Point.Origin - centroid;
+
             group.AddRange(externalEdges);
             group.AddRange(internalEdges);
+
+            group = group.Select(x => x.ITranslate(tranlation)).ToList();
 
             return group;
         }

--- a/Spatial_Engine/Create/ShapeProfiles/TSectionProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/TSectionProfile.cs
@@ -113,9 +113,9 @@ namespace BH.Engine.Spatial
             perimeter.Add(new Line { Start = origin + xAxis * (-wt / 2), End = origin + xAxis * (wt / 2) });
 
             Point centroid = perimeter.IJoin().Centroid();
-            Vector tranlation = Point.Origin - centroid;
+            Vector translation = Point.Origin - centroid;
 
-            return perimeter.Select(x => x.ITranslate(tranlation)).ToList();
+            return perimeter.Select(x => x.ITranslate(translation)).ToList();
         }
 
 

--- a/Spatial_Engine/Create/ShapeProfiles/TSectionProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/TSectionProfile.cs
@@ -112,6 +112,11 @@ namespace BH.Engine.Spatial
             perimeter.Add(new Line { Start = p, End = p - xAxis * (tfw) });
             perimeter.Add(new Line { Start = origin + xAxis * (-wt / 2), End = origin + xAxis * (wt / 2) });
 
+            Point centroid = perimeter.IJoin().Centroid();
+            Vector tranlation = Point.Origin - centroid;
+
+            perimeter = perimeter.Select(x => x.ITranslate(tranlation)).ToList();
+
             return perimeter;
         }
 

--- a/Spatial_Engine/Create/ShapeProfiles/TSectionProfile.cs
+++ b/Spatial_Engine/Create/ShapeProfiles/TSectionProfile.cs
@@ -115,9 +115,7 @@ namespace BH.Engine.Spatial
             Point centroid = perimeter.IJoin().Centroid();
             Vector tranlation = Point.Origin - centroid;
 
-            perimeter = perimeter.Select(x => x.ITranslate(tranlation)).ToList();
-
-            return perimeter;
+            return perimeter.Select(x => x.ITranslate(tranlation)).ToList();
         }
 
 


### PR DESCRIPTION


<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2148 

<!-- Add short description of what has been fixed -->

Making sure all non-symmetrical profiles have their centroid of the curves aligned with the origin
### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EvwQushTTIdBnbiI0b_XPD0BtYWuomLySsxlJY6Yb6W7IQ?e=OFgPjD

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->