### PR TITLE
Spatial_Engine: Replace clone methods

### DIFF
--- a/Spatial_Engine/Query/PointLayout.cs
+++ b/Spatial_Engine/Query/PointLayout.cs
@@ -25,9 +25,9 @@ using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Base;
 using BH.oM.Geometry;
 using BH.oM.Spatial.Layouts;
+using BH.Engine.Base;
 using BH.Engine.Geometry;
 
 namespace BH.Engine.Spatial
@@ -413,7 +413,7 @@ namespace BH.Engine.Spatial
         private static Vector AlignOffsetVector(Vector offsetVector, Point referencePoint, Point centre)
         {
             //Make the offset vector always point towards the centre when reference point is on the boundary
-            Vector clone = offsetVector.Clone();
+            Vector clone = offsetVector.ShallowClone();
 
             Vector refVector = centre - referencePoint;
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2153 

<!-- Add short description of what has been fixed -->
Replacing the only `Spatial_Engine` call to Clone with a call to ShallowClone

### Test files
<!-- Link to test files to validate the proposed changes -->
Original test file for PointLayout method is [here](https://burohappold.sharepoint.com/:f:/s/BHoM/Emvmzm2j1xBNhG1JBGXJhUwBfpkHzOg5NOSmEexzbWxDBw?e=m1CT07) named `Spatial_Engine-#1608-AddPointLayoutMethodsToLayoutObjects.gh`.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- call to `Clone` replaced with `ShallowClone`
