### PR TITLE
Analytical_Engine: Replace calls to Clone methods with calls to Base DeepClone or ShallowClone

### DIFF
--- a/Analytical_Engine/Modify/SetGeometry.cs
+++ b/Analytical_Engine/Modify/SetGeometry.cs
@@ -28,7 +28,7 @@ using BH.oM.Reflection.Attributes;
 using BH.oM.Analytical.Elements;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
-using BH.oM.Base;
+using BH.Engine.Base;
 
 namespace BH.Engine.Analytical
 {
@@ -45,7 +45,7 @@ namespace BH.Engine.Analytical
         [Output("node", "The INode with updated geometry.")]
         public static INode SetGeometry(this INode node, Point point)
         {
-            INode clone = node.GetShallowClone(true) as INode;
+            INode clone = node.ShallowClone(true);
             clone.Position = point.Clone();
             return clone;
         }
@@ -68,7 +68,7 @@ namespace BH.Engine.Analytical
                 return null;
             }
 
-            ILink<TNode> clone = link.GetShallowClone(true) as ILink<TNode>;
+            ILink<TNode> clone = link.ShallowClone(true);
             clone.StartNode = (TNode)clone.StartNode.SetGeometry(curve.IStartPoint());
             clone.EndNode = (TNode)clone.EndNode.SetGeometry(curve.IEndPoint());
             return clone;
@@ -83,7 +83,7 @@ namespace BH.Engine.Analytical
         [Output("edge", "The IEdge with updated geometry.")]
         public static IEdge SetGeometry(this IEdge edge, ICurve curve)
         {
-            IEdge clone = edge.GetShallowClone(true) as IEdge;
+            IEdge clone = edge.ShallowClone(true);
             clone.Curve = curve.IClone();
             return clone;
         }

--- a/Analytical_Engine/Modify/SetGeometry.cs
+++ b/Analytical_Engine/Modify/SetGeometry.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Analytical
         [Output("node", "The INode with updated geometry.")]
         public static INode SetGeometry(this INode node, Point point)
         {
-            INode clone = node.ShallowClone(true);
+            INode clone = node.ShallowClone();
             clone.Position = point.Clone();
             return clone;
         }
@@ -68,7 +68,7 @@ namespace BH.Engine.Analytical
                 return null;
             }
 
-            ILink<TNode> clone = link.ShallowClone(true);
+            ILink<TNode> clone = link.ShallowClone();
             clone.StartNode = (TNode)clone.StartNode.SetGeometry(curve.IStartPoint());
             clone.EndNode = (TNode)clone.EndNode.SetGeometry(curve.IEndPoint());
             return clone;
@@ -83,7 +83,7 @@ namespace BH.Engine.Analytical
         [Output("edge", "The IEdge with updated geometry.")]
         public static IEdge SetGeometry(this IEdge edge, ICurve curve)
         {
-            IEdge clone = edge.ShallowClone(true);
+            IEdge clone = edge.ShallowClone();
             clone.Curve = curve.IClone();
             return clone;
         }

--- a/Analytical_Engine/Modify/SetInternalElements2D.cs
+++ b/Analytical_Engine/Modify/SetInternalElements2D.cs
@@ -27,6 +27,7 @@ using System.Collections.Generic;
 using System.Linq;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
+using BH.Engine.Base;
 
 
 namespace BH.Engine.Analytical
@@ -46,7 +47,7 @@ namespace BH.Engine.Analytical
     where TEdge : IEdge
     where TOpening : IOpening<TEdge>
         {
-            IPanel<TEdge, TOpening> pp = panel.GetShallowClone() as IPanel<TEdge, TOpening>;
+            IPanel<TEdge, TOpening> pp = panel.ShallowClone();
             pp.Openings = new List<TOpening>(openings.Cast<TOpening>().ToList());
             return pp;
         }

--- a/Analytical_Engine/Modify/SetOutlineElements1D.cs
+++ b/Analytical_Engine/Modify/SetOutlineElements1D.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Analytical
         public static IOpening<TEdge> SetOutlineElements1D<TEdge>(this IOpening<TEdge> opening, IEnumerable<IElement1D> edges)
                 where TEdge : IEdge
         {
-            IOpening<TEdge> o = opening.ShallowClone(true);
+            IOpening<TEdge> o = opening.ShallowClone();
 
             o.Edges = ConvertToEdges<TEdge>(edges);
             return o;
@@ -67,7 +67,7 @@ namespace BH.Engine.Analytical
             where TEdge : IEdge
             where TOpening : IOpening<TEdge>
         {
-            IPanel<TEdge, TOpening> pp = panel.ShallowClone(true);
+            IPanel<TEdge, TOpening> pp = panel.ShallowClone();
 
             pp.ExternalEdges = ConvertToEdges<TEdge>(edges);
             return pp;
@@ -81,7 +81,7 @@ namespace BH.Engine.Analytical
         [Output("region", "The region with updated perimiter.")]
         public static IRegion SetOutlineElements1D(this IRegion region, IEnumerable<IElement1D> outlineElements)
         {
-            IRegion r = region.ShallowClone(true);
+            IRegion r = region.ShallowClone();
 
             IEnumerable<ICurve> joinedCurves = outlineElements.Cast<ICurve>();
             if (outlineElements.Count() != 1)

--- a/Analytical_Engine/Modify/SetOutlineElements1D.cs
+++ b/Analytical_Engine/Modify/SetOutlineElements1D.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Analytical
         public static IOpening<TEdge> SetOutlineElements1D<TEdge>(this IOpening<TEdge> opening, IEnumerable<IElement1D> edges)
                 where TEdge : IEdge
         {
-            IOpening<TEdge> o = opening.GetShallowClone(true) as IOpening<TEdge>;
+            IOpening<TEdge> o = opening.ShallowClone(true);
 
             o.Edges = ConvertToEdges<TEdge>(edges);
             return o;
@@ -67,7 +67,7 @@ namespace BH.Engine.Analytical
             where TEdge : IEdge
             where TOpening : IOpening<TEdge>
         {
-            IPanel<TEdge, TOpening> pp = panel.GetShallowClone(true) as IPanel<TEdge, TOpening>;
+            IPanel<TEdge, TOpening> pp = panel.ShallowClone(true);
 
             pp.ExternalEdges = ConvertToEdges<TEdge>(edges);
             return pp;
@@ -81,7 +81,7 @@ namespace BH.Engine.Analytical
         [Output("region", "The region with updated perimiter.")]
         public static IRegion SetOutlineElements1D(this IRegion region, IEnumerable<IElement1D> outlineElements)
         {
-            IRegion r = region.GetShallowClone(true) as IRegion;
+            IRegion r = region.ShallowClone(true);
 
             IEnumerable<ICurve> joinedCurves = outlineElements.Cast<ICurve>();
             if (outlineElements.Count() != 1)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2167

See BHoM/admin#9


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
Note that the behaviour of `SetGeometry` and `SetOutlineElements1D` has now been updated to no longer update Guid in line with compliance and our strategy for persistency of the BHoM_Guids 

### Additional comments
<!-- As required -->

Noting @rolyhudson - your PR on Analytical Engine here https://github.com/BHoM/BHoM_Engine/pull/2145 - but touching different files.