### PR TITLE
Environment_Engine: Remove boolean input for ShallowClone

### DIFF
--- a/Environment_Engine/Modify/Copy.cs
+++ b/Environment_Engine/Modify/Copy.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Environment
         [Output("panel", "The copied Environment Panel")]
         public static Panel Copy(this Panel panel)
         {
-            Panel aPanel = panel.ShallowClone(true);
+            Panel aPanel = panel.ShallowClone();
             aPanel.ExternalEdges = new List<Edge>(panel.ExternalEdges);
             aPanel.Openings = new List<Opening>(panel.Openings);
             aPanel.ConnectedSpaces = new List<string>(panel.ConnectedSpaces);

--- a/Environment_Engine/Modify/RemoveOpening.cs
+++ b/Environment_Engine/Modify/RemoveOpening.cs
@@ -42,7 +42,7 @@ namespace BH.Engine.Environment
 
             foreach (Panel p in panels)
             {
-                Panel pan = p.ShallowClone(true);
+                Panel pan = p.ShallowClone();
                 pan.Openings = new List<Opening>();
                 rtnPanels.Add(pan);
             }

--- a/Environment_Engine/Modify/RemoveOpeningsByName.cs
+++ b/Environment_Engine/Modify/RemoveOpeningsByName.cs
@@ -43,12 +43,12 @@ namespace BH.Engine.Environment
 
             foreach (Panel p in panels)
             {
-                Panel pan = p.ShallowClone(true);
+                Panel pan = p.ShallowClone();
                 pan.Openings = new List<Opening>();
                 foreach (Opening o in p.Openings)
                 {
                     if (o.Name != openingName)
-                        pan.Openings.Add(o.ShallowClone(true));
+                        pan.Openings.Add(o.ShallowClone());
                 }
 
                 rtnPanels.Add(pan);

--- a/Environment_Engine/Modify/SetGeometry.cs
+++ b/Environment_Engine/Modify/SetGeometry.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Environment
         [Output("node", "The Node with updated geometry")]
         public static Node SetGeometry(this Node node, Point point)
         {
-            Node clone = node.ShallowClone(true);
+            Node clone = node.ShallowClone();
             clone.Position = point.DeepClone();
             return clone;
         }

--- a/Environment_Engine/Modify/SplitOpeningByGeometry.cs
+++ b/Environment_Engine/Modify/SplitOpeningByGeometry.cs
@@ -48,7 +48,7 @@ namespace BH.Engine.Environment
 
             foreach (Polyline p in polylines)
             {
-                Opening pan = opening.ShallowClone(true);
+                Opening pan = opening.ShallowClone();
                 pan.Edges = p.ToEdges();
                 openings.Add(pan);
             }

--- a/Environment_Engine/Modify/SplitPanelByGeometry.cs
+++ b/Environment_Engine/Modify/SplitPanelByGeometry.cs
@@ -51,7 +51,7 @@ namespace BH.Engine.Environment
 
             foreach (Polyline p in polylines)
             {
-                Panel pan = panel.ShallowClone(true);
+                Panel pan = panel.ShallowClone();
                 pan.ExternalEdges = p.ToEdges();
                 panels.Add(pan);
             }

--- a/MEP_Engine/Modify/SetGeometry.cs
+++ b/MEP_Engine/Modify/SetGeometry.cs
@@ -26,6 +26,7 @@ using BH.oM.MEP.System;
 using BH.oM.MEP.Fixtures;
 using BH.oM.Geometry;
 using BH.Engine.Geometry;
+using BH.Engine.Base;
 
 namespace BH.Engine.MEP
 {
@@ -47,7 +48,7 @@ namespace BH.Engine.MEP
                 return null;
             }
 
-            IFlow clone = flowObj.GetShallowClone(true) as IFlow;
+            IFlow clone = flowObj.ShallowClone();
             clone.StartPoint = clone.StartPoint.SetGeometry(curve.IStartPoint());
             clone.EndPoint = clone.EndPoint.SetGeometry(curve.IEndPoint());
             return clone;


### PR DESCRIPTION
   
### Issues addressed by this PR

Closes #2173 

Removes the boolean input for ShallowClone in Environment_Engine and MEP_Engine 
