### PR TITLE
Geometry_Engine: Normal() returns null with a warning instead of an error

### DIFF
--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -102,16 +102,16 @@ namespace BH.Engine.Geometry
 
             if (!curve.IsPlanar(tolerance))
             {
-                Reflection.Compute.RecordError("Input must be planar.");
+                Reflection.Compute.RecordError("Input curve must be planar.");
                 return null;
             }
             else if (!curve.IsClosed(tolerance))
             {
-                Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
+                Reflection.Compute.RecordError("Input curve is not closed. Input must be a polygon");
                 return null;
             }
             else if (curve.IsSelfIntersecting(tolerance))
-                Reflection.Compute.RecordWarning("Input curve is self intersecting. Resulting normal vector might be incorrect.");
+                Reflection.Compute.RecordWarning("Input curve is self-intersecting. Resulting normal vector might be flipped.");
 
             Point avg = curve.ControlPoints.Average();
             Vector normal = new Vector();
@@ -119,7 +119,7 @@ namespace BH.Engine.Geometry
             //Get out normal, from cross products between vectors from the average point to adjecent controlpoints on the curve
             for (int i = 0; i < curve.ControlPoints.Count - 1; i++)
                 normal += (curve.ControlPoints[i] - avg).CrossProduct(curve.ControlPoints[i + 1] - avg);
-
+            
             normal = normal.Normalise();
 
             //Check if normal needs to be flipped from the right hand rule
@@ -137,16 +137,16 @@ namespace BH.Engine.Geometry
 
             if (!curve.IsPlanar(tolerance))
             {
-                Reflection.Compute.RecordError("Input must be planar.");
+                Reflection.Compute.RecordError("Input curve must be planar.");
                 return null;
             }
             else if (!curve.IsClosed(tolerance))
             {
-                Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
+                Reflection.Compute.RecordError("Input curve is not closed. Input must be a polygon");
                 return null;
             }
             else if (curve.IsSelfIntersecting(tolerance))
-                Reflection.Compute.RecordWarning("Input curve is self intersecting. Resulting normal vector might be incorrect.");
+                Reflection.Compute.RecordWarning("Input curve is self-intersecting. Resulting normal vector might be flipped.");
 
             List<ICurve> crvs = new List<ICurve>(curve.ISubParts());
 

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -111,10 +111,7 @@ namespace BH.Engine.Geometry
                 return null;
             }
             else if (curve.IsSelfIntersecting(tolerance))
-            {
-                Reflection.Compute.RecordWarning("Curve is self intersecting");
-                return null;
-            }
+                Reflection.Compute.RecordWarning("Input curve is self intersecting. Resulting normal vector might be incorrect.");
 
             Point avg = curve.ControlPoints.Average();
             Vector normal = new Vector();
@@ -149,13 +146,10 @@ namespace BH.Engine.Geometry
                 return null;
             }
             else if (curve.IsSelfIntersecting(tolerance))
-            {
-                Reflection.Compute.RecordWarning("Curve is self intersecting");
-                return null;
-            }
+                Reflection.Compute.RecordWarning("Input curve is self intersecting. Resulting normal vector might be incorrect.");
+
 
             List<ICurve> crvs = new List<ICurve>(curve.ISubParts());
-
 
             if (crvs.Count() == 0)
                 return null;

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -119,7 +119,13 @@ namespace BH.Engine.Geometry
             //Get out normal, from cross products between vectors from the average point to adjecent controlpoints on the curve
             for (int i = 0; i < curve.ControlPoints.Count - 1; i++)
                 normal += (curve.ControlPoints[i] - avg).CrossProduct(curve.ControlPoints[i + 1] - avg);
-            
+
+            if (normal.Length() < tolerance)
+            {
+                Reflection.Compute.RecordError("Couldn't calculate a normal vector of the given curve");
+                return null;
+            }
+
             normal = normal.Normalise();
 
             //Check if normal needs to be flipped from the right hand rule
@@ -182,6 +188,12 @@ namespace BH.Engine.Geometry
                 //Get out normal, from cross products between vectors from the average point to adjecent controlpoints on the curve
                 for (int i = 0; i < points.Count - 1; i++)
                     normal += (points[i] - avg).CrossProduct(points[i + 1] - avg);
+
+                if (normal.Length() < tolerance)
+                {
+                    Reflection.Compute.RecordError("Couldn't calculate a normal vector of the given curve");
+                    return null;
+                }
 
                 normal = normal.Normalise();
 

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -148,7 +148,6 @@ namespace BH.Engine.Geometry
             else if (curve.IsSelfIntersecting(tolerance))
                 Reflection.Compute.RecordWarning("Input curve is self intersecting. Resulting normal vector might be incorrect.");
 
-
             List<ICurve> crvs = new List<ICurve>(curve.ISubParts());
 
             if (crvs.Count() == 0)
@@ -176,7 +175,6 @@ namespace BH.Engine.Geometry
                         return null;
                     }
                 }
-
 
                 Point avg = points.Average();
                 Vector normal = new Vector();


### PR DESCRIPTION

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2179

<!-- Add short description of what has been fixed -->
Changing the `Normal()` for `Polyline` and `PolyCurve` so it'll return a results even for self intersecting curves (with a proper warning).

The reason for that is because there exist some cases when the curve is distorted and is read as self-intesecting (because of e.g. tiny overlapping segments) but calculating correct normal vector is possible despites the distortion. 

On the other hand, failing other checks (closure and planarity) makes it always impossible to calculate normal. In these cases error is raised and null returned.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Issue specific](https://burohappold.sharepoint.com/:f:/s/BHoM/Ev0hASsgYEFMtKvjgKEDinQB8e5CMzNdL_kl9JiuU7cwgw?e=ucs0iE) - BooleanUnion was crashing because of missing Normal of a distorted region. Now should work as expected.
[General test for Normal](https://burohappold.sharepoint.com/:f:/s/BHoM/Esd2eZj9Hc1Mkh5tar8m-NsBlIxJtyJ40zXatKwF4D3uOQ?e=9Sseg9) (Normal.gh).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Changing the `Normal()` for `Polyline` and `PolyCurve` so it'll return a results even for self intersecting curve (with a proper warning)

