### PR TITLE
Geometry_Engine: Add null checks to certain Vector methods

### DIFF
--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -45,6 +45,12 @@ namespace BH.Engine.Geometry
 
         public static Vector Rotate(this Vector vector, double rad, Vector axis)
         {
+            if (vector == null || axis == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot rotate vector as it and/or the axis vector is null");
+                return null;
+            }
+
             // using Rodrigues' rotation formula
             axis = axis.Normalise();
 

--- a/Geometry_Engine/Modify/Rotate.cs
+++ b/Geometry_Engine/Modify/Rotate.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Geometry
         {
             if (vector == null || axis == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot rotate vector as it and/or the axis vector is null");
+                BH.Engine.Reflection.Compute.RecordError("Cannot rotate vector as it and/or the axis vector is null.");
                 return null;
             }
 

--- a/Geometry_Engine/Query/Angle.cs
+++ b/Geometry_Engine/Query/Angle.cs
@@ -36,6 +36,12 @@ namespace BH.Engine.Geometry
 
         public static double Angle(this Vector v1, Vector v2)
         {
+            if (v1 == null || v2 == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot compute angle as one or both vectors are null");
+                return 0;
+            }
+
             double dotProduct = v1.DotProduct(v2);
             double length = v1.Length() * v2.Length();
 

--- a/Geometry_Engine/Query/Angle.cs
+++ b/Geometry_Engine/Query/Angle.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Geometry
         {
             if (v1 == null || v2 == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot compute angle as one or both vectors are null");
+                BH.Engine.Reflection.Compute.RecordError("Cannot compute angle as one or both vectors are null.");
                 return 0;
             }
 
@@ -113,4 +113,3 @@ namespace BH.Engine.Geometry
         }
     }
 }
-

--- a/Geometry_Engine/Query/Product.cs
+++ b/Geometry_Engine/Query/Product.cs
@@ -32,28 +32,28 @@ namespace BH.Engine.Geometry
 
         public static double DotProduct(this Vector a, Vector b)
         {
-            return (a.X * b.X + a.Y * b.Y + a.Z * b.Z);
+            return a != null && b != null ? (a.X * b.X + a.Y * b.Y + a.Z * b.Z) : double.NaN;
         }
 
         /***************************************************/
 
         public static Vector CrossProduct(this Vector a, Vector b)
         {
-            return new Vector { X = a.Y * b.Z - a.Z * b.Y, Y = a.Z * b.X - a.X * b.Z, Z = a.X * b.Y - a.Y * b.X };
+            return a != null && b != null ? new Vector { X = a.Y * b.Z - a.Z * b.Y, Y = a.Z * b.X - a.X * b.Z, Z = a.X * b.Y - a.Y * b.X } : null;
         }
 
         /***************************************************/
 
         public static Vector CrossProduct(this Point a, Point b)
         {
-            return new Vector { X = a.Y * b.Z - a.Z * b.Y, Y = a.Z * b.X - a.X * b.Z, Z = a.X * b.Y - a.Y * b.X };
+            return a != null && b != null ? new Vector { X = a.Y * b.Z - a.Z * b.Y, Y = a.Z * b.X - a.X * b.Z, Z = a.X * b.Y - a.Y * b.X } : null;
         }
 
         /***************************************************/
 
         public static Quaternion Product(this Quaternion q1, Quaternion q2)
         {
-            return q1 * q2;
+            return q1 != null && q2 != null ? q1 * q2 : null;
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Product.cs
+++ b/Geometry_Engine/Query/Product.cs
@@ -32,28 +32,52 @@ namespace BH.Engine.Geometry
 
         public static double DotProduct(this Vector a, Vector b)
         {
-            return a != null && b != null ? (a.X * b.X + a.Y * b.Y + a.Z * b.Z) : double.NaN;
+            if (a == null || b == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Could not compute Dot Product because one or both Vectors are null.");
+                return double.NaN;
+            }
+            
+            return (a.X * b.X + a.Y * b.Y + a.Z * b.Z);
         }
 
         /***************************************************/
 
         public static Vector CrossProduct(this Vector a, Vector b)
         {
-            return a != null && b != null ? new Vector { X = a.Y * b.Z - a.Z * b.Y, Y = a.Z * b.X - a.X * b.Z, Z = a.X * b.Y - a.Y * b.X } : null;
+            if (a == null || b == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Could not compute Cross Product because one or both Vectors are null.");
+                return null;
+            }
+            
+            return new Vector { X = a.Y * b.Z - a.Z * b.Y, Y = a.Z * b.X - a.X * b.Z, Z = a.X * b.Y - a.Y * b.X };
         }
 
         /***************************************************/
 
         public static Vector CrossProduct(this Point a, Point b)
         {
-            return a != null && b != null ? new Vector { X = a.Y * b.Z - a.Z * b.Y, Y = a.Z * b.X - a.X * b.Z, Z = a.X * b.Y - a.Y * b.X } : null;
+            if (a == null || b == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Could not compute Cross Product because one or both Points are null.");
+                return null;
+            }
+            
+            return new Vector { X = a.Y * b.Z - a.Z * b.Y, Y = a.Z * b.X - a.X * b.Z, Z = a.X * b.Y - a.Y * b.X };
         }
 
         /***************************************************/
 
         public static Quaternion Product(this Quaternion q1, Quaternion q2)
         {
-            return q1 != null && q2 != null ? q1 * q2 : null;
+            if (q1 == null || q2 == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Could not compute Product because one or both Quaternions are null.");
+                return null;
+            }
+            
+            return q1 * q2;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
Does not strictly speaking depend on, but solves an issue in conjunction with #2149 
   
### Issues addressed by this PR
Relates to #2109

<!-- Add short description of what has been fixed -->
Adds null checks to certain Vector methods in the Geometry_Engine:

* `Modify.Rotate()`
* `Query.Product()`
* `Query.Angle()`

This helps fix crashes related to pulling in Structures_Engine Panels, in conjunction with the fixes on the Structures side of things as adressed by #2149

<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->