### PR TITLE
Physical_Engine: Add query method moving location line to the centre of the IFramingElement's section bounding box

### DIFF
--- a/Physical_Engine/Physical_Engine.csproj
+++ b/Physical_Engine/Physical_Engine.csproj
@@ -101,6 +101,7 @@
     <Compile Include="Query\AverageProfileArea.cs" />
     <Compile Include="Query\ConstructionByName.cs" />
     <Compile Include="Query\BottomCentreline.cs" />
+    <Compile Include="Query\GeometricalCentreline.cs" />
     <Compile Include="Query\TopCentreline.cs" />
     <Compile Include="Query\ExternalPolyline.cs" />
     <Compile Include="Query\HasMergeablePropertiesWith.cs" />

--- a/Physical_Engine/Physical_Engine.csproj
+++ b/Physical_Engine/Physical_Engine.csproj
@@ -101,7 +101,7 @@
     <Compile Include="Query\AverageProfileArea.cs" />
     <Compile Include="Query\ConstructionByName.cs" />
     <Compile Include="Query\BottomCentreline.cs" />
-    <Compile Include="Query\GeometricalCentreline.cs" />
+    <Compile Include="Query\BoundingBoxCentreline.cs" />
     <Compile Include="Query\TopCentreline.cs" />
     <Compile Include="Query\ExternalPolyline.cs" />
     <Compile Include="Query\HasMergeablePropertiesWith.cs" />

--- a/Physical_Engine/Query/BoundingBoxCentreline.cs
+++ b/Physical_Engine/Query/BoundingBoxCentreline.cs
@@ -32,10 +32,10 @@ namespace BH.Engine.Physical
 {
     public static partial class Query
     {
-        [Description("Returns the centreline of an IFramingElement's section bounding box.")]
-        [Input("element", "The IFramingElement to query the geometrical centreline of.")]
-        [Output("curve", "The geometrical centreline of the IFramingElement.")]
-        public static ICurve GeometricalCentreline(this IFramingElement element)
+        [Description("Returns the centreline of an IFramingElement's bounding box. The bounding box is aligned to the local coordinate system of the IFramingElement.")]
+        [Input("element", "The IFramingElement to query the bounding box centreline of.")]
+        [Output("curve", "The bounding box centreline of the IFramingElement.")]
+        public static ICurve BoundingBoxCentreline(this IFramingElement element)
         {   
             ICurve location = element?.Location;
             if (location == null)
@@ -51,18 +51,18 @@ namespace BH.Engine.Physical
 
             Vector tangent = (location.IEndPoint() - location.IStartPoint()).Normalise();
 
-            Vector thirdAxis = tangent.CrossProduct(normal);
+            Vector localx = tangent.CrossProduct(normal);
 
             if (element.Property is ConstantFramingProperty)
             {
-                Point geometricalCentre = (element.Property as ConstantFramingProperty)?.Profile?.Edges?.Bounds()?.Centre();
+                Point centre = (element.Property as ConstantFramingProperty)?.Profile?.Edges?.Bounds()?.Centre();
 
-                if (geometricalCentre == null)
+                if (centre == null)
                     return null;
 
-                Vector sectionTranslate = geometricalCentre - Point.Origin;
+                Vector sectionTranslate = centre - Point.Origin;
 
-                return location.ITranslate(- thirdAxis * sectionTranslate.X + normal * sectionTranslate.Y);
+                return location.ITranslate(- localx * sectionTranslate.X + normal * sectionTranslate.Y);
 
             }
             else

--- a/Physical_Engine/Query/GeometricalCentreline.cs
+++ b/Physical_Engine/Query/GeometricalCentreline.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.Physical
 {
     public static partial class Query
     {
-        [Description("Returns the geometrical centreline of an IFramingElement.")]
+        [Description("Returns the centreline of an IFramingElement's section bounding box.")]
         [Input("element", "The IFramingElement to query the geometrical centreline of.")]
         [Output("curve", "The geometrical centreline of the IFramingElement.")]
         public static ICurve GeometricalCentreline(this IFramingElement element)

--- a/Physical_Engine/Query/GeometricalCentreline.cs
+++ b/Physical_Engine/Query/GeometricalCentreline.cs
@@ -38,25 +38,22 @@ namespace BH.Engine.Physical
         [Output("curve", "The geometrical centreline of the IFramingElement.")]
         public static ICurve GeometricalCentreline(this IFramingElement element)
         {   
-            ICurve location = element.Location;
+            ICurve location = element?.Location;
+            if (location == null)
+                return null;
 
             if (element.Property is ConstantFramingProperty)
             {
-                ConstantFramingProperty constantProperty = element.Property as ConstantFramingProperty;
+                Point geometricalCentre = (element.Property as ConstantFramingProperty)?.Profile?.Edges?.Bounds()?.Centre();
 
-                IProfile profile = constantProperty.Profile; 
+                if (geometricalCentre == null)
+                    return null;
 
-                Point geometricalCentre = profile.Edges.Bounds().Centre();
-
-                Vector translate = geometricalCentre - Point.Origin;
-
-                ICurve geometricalCentreline = location.ITranslate(translate);
-
-                return geometricalCentreline;
+                return location.ITranslate(geometricalCentre - Point.Origin);
             }
             else
             {
-                Engine.Reflection.Compute.RecordError("Element does not have a suitable framing property, was not able to extract section bounding box.");
+                Engine.Reflection.Compute.RecordError("Only suitable framing property for the IFramingElement is ConstantFramingProperty.");
                 return null;
             }
         }

--- a/Physical_Engine/Query/GeometricalCentreline.cs
+++ b/Physical_Engine/Query/GeometricalCentreline.cs
@@ -49,10 +49,7 @@ namespace BH.Engine.Physical
                 return null;
             }
 
-            Vector tangent = null;
-            tangent = location.ITangentAtPoint(location.ICentroid());
-            if (tangent == null)
-                return null;
+            Vector tangent = (location.IEndPoint() - location.IStartPoint()).Normalise();
 
             Vector thirdAxis = tangent.CrossProduct(normal);
 
@@ -70,7 +67,7 @@ namespace BH.Engine.Physical
             }
             else
             {
-                Engine.Reflection.Compute.RecordError("Only suitable framing property for the IFramingElement is ConstantFramingProperty.");
+                Engine.Reflection.Compute.RecordError("Only suitable framing property for the action is ConstantFramingProperty.");
                 return null;
             }
         }

--- a/Physical_Engine/Query/GeometricalCentreline.cs
+++ b/Physical_Engine/Query/GeometricalCentreline.cs
@@ -65,7 +65,7 @@ namespace BH.Engine.Physical
 
                 Vector sectionTranslate = geometricalCentre - Point.Origin;
 
-                return location.ITranslate(tangent * sectionTranslate.X + thirdAxis * sectionTranslate.Y + normal * sectionTranslate.Z);
+                return location.ITranslate(- thirdAxis * sectionTranslate.X + normal * sectionTranslate.Y);
 
             }
             else

--- a/Physical_Engine/Query/GeometricalCentreline.cs
+++ b/Physical_Engine/Query/GeometricalCentreline.cs
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2020, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.oM.Geometry;
+using BH.oM.Physical.Elements;
+using BH.oM.Physical.FramingProperties;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Spatial.ShapeProfiles;
+using System.ComponentModel;
+
+namespace BH.Engine.Physical
+{
+    public static partial class Query
+    {
+        [Description("Returns the geometrical centreline of an IFramingElement.")]
+        [Input("element", "The IFramingElement to query the geometrical centreline of.")]
+        [Output("curve", "The geometrical centreline of the IFramingElement.")]
+        public static ICurve GeometricalCentreline(this IFramingElement element)
+        {   
+            ICurve location = element.Location;
+
+            Vector normal = null;
+
+            try
+            {
+                normal = BH.Engine.Physical.Query.Normal(element);
+            }
+            catch
+            {
+                Engine.Reflection.Compute.RecordError("IFramingElement must have linear location line.");
+                return null;
+            }
+
+            if (normal == null)
+            {
+                Engine.Reflection.Compute.RecordError("Was not able to compute element normal.");
+                return null;
+            }
+
+            if (element.Property is ConstantFramingProperty)
+            {
+                ConstantFramingProperty constantProperty = element.Property as ConstantFramingProperty;
+
+                IProfile profile = constantProperty.Profile;
+
+                BoundingBox profileBounds = profile.Edges.Bounds();
+
+                Point profileCentre = profileBounds.Centre();
+
+                Point locationPoint = element.Location.Centroid();
+
+                ICurve geometricalCentreline = location.ITranslate(profileCentre - locationPoint);
+
+                return geometricalCentreline;
+            }
+            else
+            {
+                Engine.Reflection.Compute.RecordError("Element does not have a suitable framing property, was not able to extract section bounding box.");
+                return null;
+            }
+        }
+    }
+}

--- a/Physical_Engine/Query/GeometricalCentreline.cs
+++ b/Physical_Engine/Query/GeometricalCentreline.cs
@@ -40,37 +40,17 @@ namespace BH.Engine.Physical
         {   
             ICurve location = element.Location;
 
-            Vector normal = null;
-
-            try
-            {
-                normal = BH.Engine.Physical.Query.Normal(element);
-            }
-            catch
-            {
-                Engine.Reflection.Compute.RecordError("IFramingElement must have linear location line.");
-                return null;
-            }
-
-            if (normal == null)
-            {
-                Engine.Reflection.Compute.RecordError("Was not able to compute element normal.");
-                return null;
-            }
-
             if (element.Property is ConstantFramingProperty)
             {
                 ConstantFramingProperty constantProperty = element.Property as ConstantFramingProperty;
 
-                IProfile profile = constantProperty.Profile;
+                IProfile profile = constantProperty.Profile; 
 
-                BoundingBox profileBounds = profile.Edges.Bounds();
+                Point geometricalCentre = profile.Edges.Bounds().Centre();
 
-                Point profileCentre = profileBounds.Centre();
+                Vector translate = geometricalCentre - Point.Origin;
 
-                Point locationPoint = element.Location.Centroid();
-
-                ICurve geometricalCentreline = location.ITranslate(profileCentre - locationPoint);
+                ICurve geometricalCentreline = location.ITranslate(translate);
 
                 return geometricalCentreline;
             }

--- a/Physical_Engine/Query/GeometricalCentreline.cs
+++ b/Physical_Engine/Query/GeometricalCentreline.cs
@@ -26,7 +26,6 @@ using BH.oM.Geometry;
 using BH.oM.Physical.Elements;
 using BH.oM.Physical.FramingProperties;
 using BH.oM.Reflection.Attributes;
-using BH.oM.Spatial.ShapeProfiles;
 using System.ComponentModel;
 
 namespace BH.Engine.Physical
@@ -42,6 +41,21 @@ namespace BH.Engine.Physical
             if (location == null)
                 return null;
 
+            Vector normal = null;
+            normal = element.Normal();
+            if (normal == null)
+            {
+                Engine.Reflection.Compute.RecordError("IFramingElement must have linear location line.");
+                return null;
+            }
+
+            Vector tangent = null;
+            tangent = location.ITangentAtPoint(location.ICentroid());
+            if (tangent == null)
+                return null;
+
+            Vector thirdAxis = tangent.CrossProduct(normal);
+
             if (element.Property is ConstantFramingProperty)
             {
                 Point geometricalCentre = (element.Property as ConstantFramingProperty)?.Profile?.Edges?.Bounds()?.Centre();
@@ -49,7 +63,10 @@ namespace BH.Engine.Physical
                 if (geometricalCentre == null)
                     return null;
 
-                return location.ITranslate(geometricalCentre - Point.Origin);
+                Vector sectionTranslate = geometricalCentre - Point.Origin;
+
+                return location.ITranslate(tangent * sectionTranslate.X + thirdAxis * sectionTranslate.Y + normal * sectionTranslate.Z);
+
             }
             else
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM_Engine/Physical_Engine/Query/GeometricalCentreline.gh?csf=1&web=1&e=lFOaJv)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
Additional method to be used in the [Revit_Toolkit PR #895](https://github.com/BHoM/Revit_Toolkit/pull/895). Creating an additional method similar to the TopCentreline and BottomCentreline methods. Returns the element's section bounding box geometrical centreline. 