### PR TITLE
Physical_Engine: TopCentreline and BottomCentreline fixed to return correct curves

### DIFF
--- a/Physical_Engine/Query/BottomCentreline.cs
+++ b/Physical_Engine/Query/BottomCentreline.cs
@@ -75,15 +75,7 @@ namespace BH.Engine.Physical
 
                 BoundingBox profileBounds = profile.Edges.Bounds();
 
-                Point profileMax = profileBounds.Max;
-
-                Point profileMin = profileBounds.Min;
-
-                double height = profileMax.Y - profileMin.Y;
-
-                ICurve bottomCentreline = location.ITranslate(normal * -0.5 * height);
-
-                return bottomCentreline;
+                return location.ITranslate(normal * profileBounds.Min.Y);
             }
             else
             {

--- a/Physical_Engine/Query/TopCentreline.cs
+++ b/Physical_Engine/Query/TopCentreline.cs
@@ -75,15 +75,7 @@ namespace BH.Engine.Physical
 
                 BoundingBox profileBounds = profile.Edges.Bounds();
 
-                Point profileMax = profileBounds.Max;
-
-                Point profileMin = profileBounds.Min;
-
-                double height = profileMax.Y - profileMin.Y;
-
-                ICurve topCentreline = location.ITranslate(normal * 0.5 * height);
-
-                return topCentreline;
+                return location.ITranslate(normal * profileBounds.Max.Y);
             }
             else
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2190

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FTest%20Scripts%2FBHoM%5FEngine%2FPhysical%5FEngine%2FPhysical%5FEngine%2D%232190%2DTopBottomCenterlineBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - both curves should be exactly at 0, minor offset is caused by the difference in centroid calculation in Revit and BHoM.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `TopCentreline` and `BottomCentreline` fixed to return correct curves