### PR TITLE
Serialiser_Engine: Treat ReadOnlyDictionary as Dictionary in Convention

### DIFF
--- a/Serialiser_Engine/Objects/MemberMapConventions/BHoMDictionaryConvention.cs
+++ b/Serialiser_Engine/Objects/MemberMapConventions/BHoMDictionaryConvention.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Serialiser.Conventions
             Type memberType = memberMap.MemberType;
             TypeInfo typeInfo = memberType.GetTypeInfo();
 
-            if (typeInfo.Name == "Dictionary`2")
+            if (typeInfo.Name == "Dictionary`2" || typeInfo.Name == "ReadOnlyDictionary`2")
             {
                 Type keyType = typeInfo.GenericTypeArguments[0];
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2196 

<!-- Add short description of what has been fixed -->

Adding `ReadOnlyDictionary` type to the `BHoMDictionaryConvention` to allow for it to (de)serialise properly. Was causing issues with versioning that could be seen in https://github.com/BHoM/Versioning_Toolkit/pull/105

### Test files
<!-- Link to test files to validate the proposed changes -->

See https://github.com/BHoM/Versioning_Toolkit/pull/105 and general serialisation test here https://burohappold.sharepoint.com/:u:/s/BHoM/EWw_delJFgdHhDvtUCu4yWsBSYSs2QpDks-Wd2obaPte3g?e=oh5JLf

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->