### PR TITLE
BHoM_Enigne: Remove duplicate FindFragment method

### DIFF
--- a/BHoM_Engine/Query/FindFragment.cs
+++ b/BHoM_Engine/Query/FindFragment.cs
@@ -52,16 +52,7 @@ namespace BH.Engine.Base
             return (T)System.Convert.ChangeType(fragment, fragmentType);
         }
 
-        [Description("Returns an instance of a BHoM Fragment if it exists on the object")]
-        [Input("iBHoMObject", "A generic IBHoMObject object")]
-        [Input("fragmentType", "The type of fragment to be queried and returned. If not specified, the generic type is taken.")]
-        [Output("fragment", "The instance of that Fragment if it exists on the object, null otherwise")]
-        public static IFragment FindFragment(this IBHoMObject iBHoMObject, Type fragmentType)
-        {
-            IFragment fragment;
-            iBHoMObject.Fragments.TryGetValue(fragmentType, out fragment);
+        /***************************************************/
 
-            return fragment;
-        }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2211

<!-- Add short description of what has been fixed -->

Removing the added duplicate non-generic method for FindFragment. Having both causes the UI to crash.

@alelom could not find it used anywhere?

### Test files
<!-- Link to test files to validate the proposed changes -->

Any script that uses find fragment, or try to create a ne one

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->