### PR TITLE
Align with changes to Structure_oM with removal of EmbodiedCarbon from MaterialFragments

### DIFF
--- a/Structure_Engine/Create/MaterialFragments/Aluminium.cs
+++ b/Structure_Engine/Create/MaterialFragments/Aluminium.cs
@@ -44,8 +44,8 @@ namespace BH.Engine.Structure
         [InputFromProperty("thermalExpansionCoeff")]
         [InputFromProperty("density")]
         [InputFromProperty("dampingRatio")]
-        [InputFromProperty("embodiedCarbon")]
         [Output("aluminium", "The created structural Aluminium material fragment.")]
+        [PreviousVersion("4.0","BH.Engine.Structure.Create.Aluminium(System.String, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double)")]
         public static Aluminium Aluminium(string name, double youngsModulus = 70000000000, double poissonsRatio = 0.34, double thermalExpansionCoeff = 0.000023, double density = 2710, double dampingRatio = 0, double embodiedCarbon = 7.9)
         {
             return new Aluminium()
@@ -56,7 +56,6 @@ namespace BH.Engine.Structure
                 PoissonsRatio = poissonsRatio,
                 ThermalExpansionCoeff = thermalExpansionCoeff,
                 DampingRatio = dampingRatio,
-                EmbodiedCarbon = embodiedCarbon,
             };
         }
 

--- a/Structure_Engine/Create/MaterialFragments/Aluminium.cs
+++ b/Structure_Engine/Create/MaterialFragments/Aluminium.cs
@@ -46,7 +46,7 @@ namespace BH.Engine.Structure
         [InputFromProperty("dampingRatio")]
         [Output("aluminium", "The created structural Aluminium material fragment.")]
         [PreviousVersion("4.0","BH.Engine.Structure.Create.Aluminium(System.String, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double)")]
-        public static Aluminium Aluminium(string name, double youngsModulus = 70000000000, double poissonsRatio = 0.34, double thermalExpansionCoeff = 0.000023, double density = 2710, double dampingRatio = 0, double embodiedCarbon = 7.9)
+        public static Aluminium Aluminium(string name, double youngsModulus = 70000000000, double poissonsRatio = 0.34, double thermalExpansionCoeff = 0.000023, double density = 2710, double dampingRatio = 0)
         {
             return new Aluminium()
             {

--- a/Structure_Engine/Create/MaterialFragments/Concrete.cs
+++ b/Structure_Engine/Create/MaterialFragments/Concrete.cs
@@ -46,7 +46,7 @@ namespace BH.Engine.Structure
         [InputFromProperty("dampingRatio")]
         [Output("concrete", "The created structural Concrete material fragment.")]
         [PreviousVersion("4.0", "BH.Engine.Structure.Create.Concrete(System.String, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double)")]
-        public static Concrete Concrete(string name, double youngsModulus = 33000000000, double poissonsRatio = 0.2, double thermalExpansionCoeff = 0.00001, double density = 2550, double dampingRatio = 0, double cubeStrength = 0, double cylinderStrength = 0, double embodiedCarbon = 0.12)
+        public static Concrete Concrete(string name, double youngsModulus = 33000000000, double poissonsRatio = 0.2, double thermalExpansionCoeff = 0.00001, double density = 2550, double dampingRatio = 0, double cubeStrength = 0, double cylinderStrength = 0)
         {
             return new Concrete()
             {

--- a/Structure_Engine/Create/MaterialFragments/Concrete.cs
+++ b/Structure_Engine/Create/MaterialFragments/Concrete.cs
@@ -44,8 +44,8 @@ namespace BH.Engine.Structure
         [InputFromProperty("thermalExpansionCoeff")]
         [InputFromProperty("density")]
         [InputFromProperty("dampingRatio")]
-        [InputFromProperty("embodiedCarbon")]
         [Output("concrete", "The created structural Concrete material fragment.")]
+        [PreviousVersion("4.0", "BH.Engine.Structure.Create.Concrete(System.String, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double)")]
         public static Concrete Concrete(string name, double youngsModulus = 33000000000, double poissonsRatio = 0.2, double thermalExpansionCoeff = 0.00001, double density = 2550, double dampingRatio = 0, double cubeStrength = 0, double cylinderStrength = 0, double embodiedCarbon = 0.12)
         {
             return new Concrete()
@@ -58,7 +58,6 @@ namespace BH.Engine.Structure
                 CubeStrength = cubeStrength,
                 DampingRatio = dampingRatio,
                 CylinderStrength = cylinderStrength,
-                EmbodiedCarbon = embodiedCarbon,
             };
         }
 

--- a/Structure_Engine/Create/MaterialFragments/Steel.cs
+++ b/Structure_Engine/Create/MaterialFragments/Steel.cs
@@ -46,7 +46,7 @@ namespace BH.Engine.Structure
         [InputFromProperty("dampingRatio")]
         [Output("steel", "The created structural Steel material fragment.")]
         [PreviousVersion("4.0", "BH.Engine.Structure.Create.Steel(System.String, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double)")]
-        public static Steel Steel(string name, double youngsModulus = 210000000000, double poissonsRatio = 0.3, double thermalExpansionCoeff = 0.000012, double density = 7850, double dampingRatio = 0, double yieldStress = 0, double ultimateStress = 0, double embodiedCarbon = 1.3)
+        public static Steel Steel(string name, double youngsModulus = 210000000000, double poissonsRatio = 0.3, double thermalExpansionCoeff = 0.000012, double density = 7850, double dampingRatio = 0, double yieldStress = 0, double ultimateStress = 0)
         {
             return new Steel()
             {

--- a/Structure_Engine/Create/MaterialFragments/Steel.cs
+++ b/Structure_Engine/Create/MaterialFragments/Steel.cs
@@ -44,8 +44,8 @@ namespace BH.Engine.Structure
         [InputFromProperty("thermalExpansionCoeff")]
         [InputFromProperty("density")]
         [InputFromProperty("dampingRatio")]
-        [InputFromProperty("embodiedCarbon")]
         [Output("steel", "The created structural Steel material fragment.")]
+        [PreviousVersion("4.0", "BH.Engine.Structure.Create.Steel(System.String, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double, System.Double)")]
         public static Steel Steel(string name, double youngsModulus = 210000000000, double poissonsRatio = 0.3, double thermalExpansionCoeff = 0.000012, double density = 7850, double dampingRatio = 0, double yieldStress = 0, double ultimateStress = 0, double embodiedCarbon = 1.3)
         {
             return new Steel()
@@ -58,7 +58,6 @@ namespace BH.Engine.Structure
                 DampingRatio = dampingRatio,
                 YieldStress = yieldStress,
                 UltimateStress = ultimateStress,
-                EmbodiedCarbon = embodiedCarbon,
             };
         }
 

--- a/Structure_Engine/Create/MaterialFragments/Timber.cs
+++ b/Structure_Engine/Create/MaterialFragments/Timber.cs
@@ -45,8 +45,8 @@ namespace BH.Engine.Structure
         [InputFromProperty("thermalExpansionCoeff")]
         [InputFromProperty("density")]
         [InputFromProperty("dampingRatio")]
-        [InputFromProperty("embodiedCarbon")]
         [Output("timber", "The created structural Timber material fragment.")]
+        [PreviousVersion("4.0", "BH.Engine.Structure.Create.Timber(System.String, BH.oM.Geometry.Vector, BH.oM.Geometry.Vector, BH.oM.Geometry.Vector, BH.oM.Geometry.Vector, System.Double, System.Double, System.Double)")]
         public static Timber Timber(string name, Vector youngsModulus, Vector poissonsRatio, Vector shearModulus, Vector thermalExpansionCoeff, double density, double dampingRatio, double embodiedCarbon = 0.4)
         {
             return new Timber()
@@ -58,7 +58,6 @@ namespace BH.Engine.Structure
                 ShearModulus = shearModulus,
                 ThermalExpansionCoeff = thermalExpansionCoeff,
                 DampingRatio = dampingRatio,
-                EmbodiedCarbon = embodiedCarbon,
             };
 
         }

--- a/Structure_Engine/Create/MaterialFragments/Timber.cs
+++ b/Structure_Engine/Create/MaterialFragments/Timber.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Structure
         [InputFromProperty("dampingRatio")]
         [Output("timber", "The created structural Timber material fragment.")]
         [PreviousVersion("4.0", "BH.Engine.Structure.Create.Timber(System.String, BH.oM.Geometry.Vector, BH.oM.Geometry.Vector, BH.oM.Geometry.Vector, BH.oM.Geometry.Vector, System.Double, System.Double, System.Double)")]
-        public static Timber Timber(string name, Vector youngsModulus, Vector poissonsRatio, Vector shearModulus, Vector thermalExpansionCoeff, double density, double dampingRatio, double embodiedCarbon = 0.4)
+        public static Timber Timber(string name, Vector youngsModulus, Vector poissonsRatio, Vector shearModulus, Vector thermalExpansionCoeff, double density, double dampingRatio)
         {
             return new Timber()
             {

--- a/Structure_Engine/Query/EmbodiedCarbon.cs
+++ b/Structure_Engine/Query/EmbodiedCarbon.cs
@@ -34,22 +34,26 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [ToBeRemoved("4.0","Method deprecated as part of removal of EmbodiedCarbon from MaterialFragments to avoid conflicts and overlap with LCA_Toolkit.")]
         [Description("Calculates the total amount of embodied carbon of a Bar by getting the mass of the Bar (generally as section area*length*density) multiplied by the EmbodiedCarbon value of the material.")]
         [Input("bar", "The Bar to get the total embodied carbon from.")]
         [Output("embodiedCarbon", "The total embodied carbon of the Bar.", typeof(Mass))]
         public static double EmbodiedCarbon(this Bar bar)
         {
-            return bar.Mass() * bar.SectionProperty.Material.EmbodiedCarbon;
+            Engine.Reflection.Compute.RecordWarning("Method deprecated as part of removal of EmbodiedCarbon from MaterialFragments to avoid conflicts and overlap with LCA_Toolkit.");
+            return 0;
         }
 
         /***************************************************/
 
+        [ToBeRemoved("4.0", "Method deprecated as part of removal of EmbodiedCarbon from MaterialFragments to avoid conflicts and overlap with LCA_Toolkit.")]
         [Description("Calculates the total amount of embodied carbon of a Panel by getting the mass of the Panel (generally as area*thickness*density) multiplied by the EmbodiedCarbon value of the material.")]
         [Input("panel", "The Panel to get the total embodied carbon from.")]
         [Output("embodiedCarbon", "The total embodied carbon of the Panel.", typeof(Mass))]
         public static double EmbodiedCarbon(this Panel panel)
         {
-            return panel.Mass() * panel.Property.Material.EmbodiedCarbon;
+            Engine.Reflection.Compute.RecordWarning("Method deprecated as part of removal of EmbodiedCarbon from MaterialFragments to avoid conflicts and overlap with LCA_Toolkit.");
+            return 0;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1121

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/BHoM/Structure_oM/Issue1070-RemoveEmbodiedCarbonFromMaterialFragments?csf=1&web=1&e=A2B66W

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Removed `EmbodiedCarbon` from `Create` methods for `MaterialFragments` 
- Added `PreviousVersion` attribute for `MaterialFragments` `Create` methods
- Removed Engine methods that calculate the embodied carbon of `Bar` and `Panel` objects
