### PR TITLE
Serialiser_Engine: Fix serialisation of non upgraded objects with modified properties

### DIFF
--- a/Serialiser_Engine/Objects/BsonSerializers/CustomObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/CustomObjectSerializer.cs
@@ -120,7 +120,7 @@ namespace BH.Engine.Serialiser.BsonSerializers
                                 {
                                     Dictionary<string, object> customData = value as Dictionary<string, object>;
                                     if (customData.Count > 0)
-                                        dic["AdditionalData"] = value;
+                                        dic["CustomData"] = value;
                                 }
                                 break;
                             default:

--- a/Serialiser_Engine/Objects/BsonSerializers/DeprecatedSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/DeprecatedSerializer.cs
@@ -60,12 +60,27 @@ namespace BH.Engine.Serialiser.BsonSerializers
             bool overflow = false;
             if (doc.Contains("BHoM_Guid"))
             {
-                Guid objectId = doc.GetElement("BHoM_Guid").Value.AsGuid;
-                if (m_StackCounter.ContainsKey(objectId))
-                    m_StackCounter[objectId] += 1;
+                string objectId = "";
+                BsonValue value = doc.GetElement("BHoM_Guid").Value;
+                
+                if (value.BsonType == BsonType.String)
+                    objectId = value.AsString;
                 else
-                    m_StackCounter[objectId] = 1;
-                overflow = m_StackCounter[objectId] > 5;
+                {
+                    try
+                    {
+                        objectId = value.AsGuid.ToString();
+                    }
+                    catch { }
+                }
+                if (!string.IsNullOrWhiteSpace(objectId))
+                {
+                    if (m_StackCounter.ContainsKey(objectId))
+                        m_StackCounter[objectId] += 1;
+                    else
+                        m_StackCounter[objectId] = 1;
+                    overflow = m_StackCounter[objectId] > 10;
+                }
             }
 
             if (newDoc == null || doc == newDoc || overflow)
@@ -84,7 +99,7 @@ namespace BH.Engine.Serialiser.BsonSerializers
         /**** Private Fields                            ****/
         /***************************************************/
 
-        private static Dictionary<Guid, int> m_StackCounter = new Dictionary<Guid, int>();
+        private static Dictionary<string, int> m_StackCounter = new Dictionary<string, int>();
 
         /*******************************************/
     }

--- a/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
@@ -181,7 +181,9 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 case BsonType.String:
                     return reader.ReadString();
             }
-            throw new FormatException($"ObjectSerializer does not support BSON type '{currentBsonType}'.");
+
+            Engine.Reflection.Compute.RecordError($"ObjectSerializer does not support BSON type '{currentBsonType}'.");
+            return null;
         }
 
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2200

The serialiser was not calling the versioning toolkit for classes that had only seen a change of their properties. This PR fixes that.


### Test files
See issue


