### PR TITLE
Geometry_Engine: Add null check to Area(pSurf)

### DIFF
--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -177,7 +177,12 @@ namespace BH.Engine.Geometry
         public static double Area(this PlanarSurface pSurf)
         {
             double area = pSurf.ExternalBoundary.IArea();
-            area -= pSurf.InternalBoundaries.Sum(x => x.IArea());
+
+            if (pSurf.InternalBoundaries != null)
+            {
+                area -= pSurf.InternalBoundaries.Sum(x => x.IArea());
+            }
+
             return area;
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2219 

<!-- Add short description of what has been fixed -->
Added null check to `Area(pSurf)` to allow calculations to continue if there are no openings found within the sample. 

### Test files
<!-- Link to test files to validate the proposed changes -->
[Test File](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Geometry_Engine/%232220-Element2DAreaQuery.gh?csf=1&web=1&e=ETPGtS)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Update `Area()`

### Additional comments
<!-- As required -->