### PR TITLE
CI: Add CI test for Serialiser_Engine

### DIFF
--- a/.ci/code/Serialiser_Test/Helpers/TestObjects.cs
+++ b/.ci/code/Serialiser_Test/Helpers/TestObjects.cs
@@ -1,0 +1,55 @@
+﻿using BH.Engine.Reflection;
+using BH.Engine.Serialiser;
+using BH.Engine.Test;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Serialiser
+{
+    public static partial class Helpers
+    {
+        /*************************************/
+        /**** Public Methods              ****/
+        /*************************************/
+
+        public static List<object> TestObjects(Type type)
+        {
+            if (m_TestObjects.ContainsKey(type))
+                return m_TestObjects[type];
+            else
+                return new List<object>();
+        }
+
+        /*************************************/
+
+        public static void AddTestObjects(Type type, List<object> objects)
+        {
+            if (m_TestObjects.ContainsKey(type))
+                m_TestObjects[type].AddRange(objects);
+            else
+                m_TestObjects[type] = objects.ToList();
+        }
+
+        /*************************************/
+
+        public static void ClearTestObjects(Type type = null)
+        {
+            if (type == null)
+                m_TestObjects.Clear();
+            else if (m_TestObjects.ContainsKey(type))
+                m_TestObjects[type].Clear();
+        }
+
+
+        /*************************************/
+        /**** Private Fields              ****/
+        /*************************************/
+
+        private static Dictionary<Type, List<object>> m_TestObjects = new Dictionary<Type, List<object>>();
+
+        /*************************************/
+    }
+}

--- a/.ci/code/Serialiser_Test/Helpers/TypesToTest.cs
+++ b/.ci/code/Serialiser_Test/Helpers/TypesToTest.cs
@@ -1,0 +1,33 @@
+﻿using BH.Engine.Reflection;
+using BH.Engine.Serialiser;
+using BH.Engine.Test;
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Serialiser
+{
+    public static partial class Helpers
+    {
+        /*************************************/
+        /**** Public Methods              ****/
+        /*************************************/
+
+        public static List<Type> TypesToTest()
+        {
+            Engine.Reflection.Compute.LoadAllAssemblies();
+
+            // It feels like the BHoMTypeList method should already return a clean list of Type but it doesn't at the moment
+            return Engine.Reflection.Query.BHoMTypeList().Where(x => {
+                return typeof(IObject).IsAssignableFrom(x)
+                  && !x.IsAbstract
+                  && !x.IsDeprecated();
+            }).ToList();
+        }
+
+        /*************************************/
+    }
+}

--- a/.ci/code/Serialiser_Test/Properties/AssemblyInfo.cs
+++ b/.ci/code/Serialiser_Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Serialiser_Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Serialiser_Test")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("92f35a76-1a04-4194-9249-d459460de328")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/.ci/code/Serialiser_Test/Serialiser_Test.csproj
+++ b/.ci/code/Serialiser_Test/Serialiser_Test.csproj
@@ -32,19 +32,19 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BHoM">
-      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_Engine">
-      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Reflection_oM">
-      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Serialiser_Engine">
-      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -56,11 +56,11 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="Test_Engine">
-      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Test_Engine.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Test_Engine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Test_oM">
-      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Test_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Test_oM.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/.ci/code/Serialiser_Test/Serialiser_Test.csproj
+++ b/.ci/code/Serialiser_Test/Serialiser_Test.csproj
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{92F35A76-1A04-4194-9249-D459460DE328}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.Test.Serialiser</RootNamespace>
+    <AssemblyName>Serialiser_Test</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BHoM">
+      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Reflection_Engine">
+      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Reflection_oM">
+      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Serialiser_Engine">
+      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Test_Engine">
+      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Test_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Test_oM">
+      <HintPath>..\..\..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Test_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Helpers\TestObjects.cs" />
+    <Compile Include="Helpers\TypesToTest.cs" />
+    <Compile Include="Verify\ToFromJson.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/.ci/code/Serialiser_Test/Verify/ToFromJson.cs
+++ b/.ci/code/Serialiser_Test/Verify/ToFromJson.cs
@@ -1,0 +1,90 @@
+﻿using BH.Engine.Reflection;
+using BH.Engine.Serialiser;
+using BH.Engine.Test;
+using BH.oM.Reflection.Debugging;
+using BH.oM.Test.Results;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Serialiser
+{
+    public static partial class Verify
+    {
+        /*************************************/
+        /**** Test Methods                ****/
+        /*************************************/
+
+        public static TestResult ToFromJson()
+        {
+            // Test all the BHoM types available
+            List<Type> types = Helpers.TypesToTest();
+            List<TestResult> results = types.Select(x => ToFromJson(x)).ToList();
+
+            // Returns a summary result 
+            List<TestResult> fails = results.Where(x => x.Status == ResultStatus.Fail).ToList();
+            string description = $"{results.Count} types of objects available in BH.oM.";
+            if (fails.Count == 0)
+                return Engine.Test.Create.PassResult(description);
+            else
+                return new TestResult(ResultStatus.Fail, fails.SelectMany(x => x.Events).ToList(), description);
+        }
+
+        /*************************************/
+
+        public static TestResult ToFromJson(Type type)
+        {
+            string typeDescription = type.IToText(true);
+
+            // Create the test objects of the given type
+            List<object> testObjects = Helpers.TestObjects(type);
+            if (testObjects.Count == 0)
+            {
+                object dummy = null;
+                try
+                {
+                    dummy = Engine.Test.Compute.DummyObject(type);
+                }
+                catch { }
+
+                if (dummy == null)
+                    return Engine.Test.Create.FailResult($"Failed to create a dummy object of type {typeDescription}.", typeDescription);
+                else
+                    testObjects.Add(dummy);
+            }
+
+            // Test each object in the list
+            foreach (object testObject in testObjects)
+            {
+                // To Json
+                string json = "";
+                try
+                {
+                    json = testObject.ToJson();
+                }
+                catch { }
+
+                if (string.IsNullOrWhiteSpace(json))
+                    return Engine.Test.Create.FailResult($"Failed to convert object of type {typeDescription} to json.", typeDescription);
+
+                // From Json
+                object copy = null;
+                try
+                {
+                    copy = Engine.Serialiser.Convert.FromJson(json);
+                }
+                catch { }
+
+                if (!copy.IsEqual(testObject))
+                    return Engine.Test.Create.FailResult($"Object of type {typeDescription} is not equal to the original after serialisation.", typeDescription);
+            }
+
+            // All test objects passed the test
+            return Engine.Test.Create.PassResult(typeDescription);
+        }
+
+        /*************************************/
+    }
+}

--- a/.ci/code/Verification.sln
+++ b/.ci/code/Verification.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1259
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serialiser_Test", "Serialiser_Test\Serialiser_Test.csproj", "{92F35A76-1A04-4194-9249-D459460DE328}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestRunner", "TestRunner\TestRunner.csproj", "{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{92F35A76-1A04-4194-9249-D459460DE328}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{92F35A76-1A04-4194-9249-D459460DE328}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{92F35A76-1A04-4194-9249-D459460DE328}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{92F35A76-1A04-4194-9249-D459460DE328}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BB913D3B-3FD1-489E-BDF7-F8408A2DD120}
+	EndGlobalSection
+EndGlobal

--- a/.ci/code/Verification.sln
+++ b/.ci/code/Verification.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 15.0.28307.1259
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serialiser_Test", "Serialiser_Test\Serialiser_Test.csproj", "{92F35A76-1A04-4194-9249-D459460DE328}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestRunner", "TestRunner\TestRunner.csproj", "{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,10 +15,6 @@ Global
 		{92F35A76-1A04-4194-9249-D459460DE328}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{92F35A76-1A04-4194-9249-D459460DE328}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{92F35A76-1A04-4194-9249-D459460DE328}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3F911D8A-55E4-4293-8FCF-DE37B3D79E72}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
- https://github.com/BHoM/BHoM/pull/1122
- https://github.com/BHoM/Test_Toolkit/pull/307
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2221

This provides the Verification of the `Serialiser_Engine` in a format that can be executed by the BHoMBot.


### Test files

Just run the TestRunner in `ProgramData/BHoM/Assemblies` by providing `Serialiser` as first argument.
If the BHoMBot is already capable of running this, you can also test it that way.

![image](https://user-images.githubusercontent.com/16853390/101606278-28185a00-3a3e-11eb-9be4-204be8bd465c.png)


### Additional comments
@FraserGreenroyd , I suppose the key thing here is to make sure that you are happy with the general framework on this PR and the two it depends on. From our discussion yesterday, I feel this should be quite close but happy to modify as needed.