### PR TITLE
BHoM_Engine: Query.Hash() to return a Hash also when an object with all empty or null properties is input

### DIFF
--- a/BHoM_Engine/Query/Hash.cs
+++ b/BHoM_Engine/Query/Hash.cs
@@ -108,7 +108,13 @@ namespace BH.Engine.Base
             string hashString = DefiningString(iObj_copy, cc, fractionalDigits, 0);
 
             if (string.IsNullOrWhiteSpace(hashString))
-                throw new Exception("Error computing the defining string of the object.");
+            {
+                // This means that:
+                // - all properties of the input object were disregarded due to the settings specified in the ComparisonConfig, or
+                // - all properties of the input object that were not disregarded were null or empty,
+                // Since a hash has to be always returned, for this scenario we are forced to build a defining string out of the type full name.
+                hashString = iObj_copy.GetType().FullName;
+            }
 
             // Return the SHA256 hash of the defining string.
             return SHA256Hash(hashString);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2223 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->