### PR TITLE
Facade_Engine: Adjacency check bugfix for matching edges

### DIFF
--- a/Facade_Engine/Compute/EdgeAdjacencies.cs
+++ b/Facade_Engine/Compute/EdgeAdjacencies.cs
@@ -46,10 +46,10 @@ namespace BH.Engine.Facade
         [Description("Returns adjacent edges and elements at a provided frame edge for a collection of panels.")]
         [Input("edge", "Edge to find adjacencies at.")]
         [Input("elems", "2D elements to use to find edge adjacencies (These should be panels and/or openings).")]
-        [Input("tolerance", "Tolerance is the minimum overlap amount required to consider adjacent. If 0, edges overlapping at endpoints only will be included.")]
+        [Input("tolerance", "Tolerance is the minimum overlap amount required to consider adjacent.")]
         [MultiOutput(0, "adjEdges", "Adjacent edges")]
         [MultiOutput(1, "adjElems", "Adjacent Elements per adjacent edge")]
-        public static Output<List<IElement1D>, List<IElement2D>> EdgeAdjacencies(this IElement1D edge, List<IElement2D> elems, double tolerance = 0)
+        public static Output<List<IElement1D>, List<IElement2D>> EdgeAdjacencies(this IElement1D edge, List<IElement2D> elems, double tolerance = Tolerance.Distance)
         {
             List<IElement1D> adjEdges = new List<IElement1D>();
             List<IElement2D> adjElems = new List<IElement2D>();

--- a/Facade_Engine/Query/IsAdjacent.cs
+++ b/Facade_Engine/Query/IsAdjacent.cs
@@ -55,8 +55,8 @@ namespace BH.Engine.Facade
                 Point e2 = curve2.End;
 
                 // Check if lines have matching end points
-                if ((s1.Distance(s2) <= tolerance && e1.Distance(e2) == tolerance) ||
-                    (s1.Distance(e2) == tolerance && e1.Distance(s2) == tolerance))
+                if ((s1.Distance(s2) <= tolerance && e1.Distance(e2) <= tolerance) ||
+                    (s1.Distance(e2) <= tolerance && e1.Distance(s2) <= tolerance))
                 {
                     return true;
                 }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2238 

Fixes bug for checking adjacency of matching edges.


### Test files
[201204-TestFacadeEngineAdjacencyAndAreaMethods.zip](https://github.com/BHoM/BHoM_Engine/files/5646190/201204-TestFacadeEngineAdjacencyAndAreaMethods.zip)