### PR TITLE
Serialiser_Engine: Roll back counter from Deprecated serialiser

### DIFF
--- a/Serialiser_Engine/Objects/BsonSerializers/DeprecatedSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/DeprecatedSerializer.cs
@@ -57,33 +57,7 @@ namespace BH.Engine.Serialiser.BsonSerializers
             BsonDocument doc = bSerializer.Deserialize(context, args) as BsonDocument;
             BsonDocument newDoc = Versioning.Convert.ToNewVersion(doc);
 
-            bool overflow = false;
-            if (doc.Contains("BHoM_Guid"))
-            {
-                string objectId = "";
-                BsonValue value = doc.GetElement("BHoM_Guid").Value;
-                
-                if (value.BsonType == BsonType.String)
-                    objectId = value.AsString;
-                else
-                {
-                    try
-                    {
-                        objectId = value.AsGuid.ToString();
-                    }
-                    catch { }
-                }
-                if (!string.IsNullOrWhiteSpace(objectId))
-                {
-                    if (m_StackCounter.ContainsKey(objectId))
-                        m_StackCounter[objectId] += 1;
-                    else
-                        m_StackCounter[objectId] = 1;
-                    overflow = m_StackCounter[objectId] > 10;
-                }
-            }
-
-            if (newDoc == null || doc == newDoc || overflow)
+            if (newDoc == null || doc == newDoc)
             {
                 Engine.Reflection.Compute.RecordWarning("The type " + doc["_t"] + " is unknown -> data returned as custom objects.");
                 context.Reader.ReturnToBookmark(bookmark);
@@ -94,16 +68,8 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 return BH.Engine.Serialiser.Convert.FromBson(newDoc);
         }
 
-
-        /***************************************************/
-        /**** Private Fields                            ****/
         /***************************************************/
 
-        private static Dictionary<string, int> m_StackCounter = new Dictionary<string, int>();
-
-        /*******************************************/
     }
-
-
 }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2240 

<!-- Add short description of what has been fixed -->

Rolling back https://github.com/BHoM/BHoM_Engine/pull/2217 changes as it caused issues with de-serialising the same type of object multiple types. Stack counter was never reset, which meant 10 items of a specific type was versioned correctly, then all the rest, for the entire session of rhino/GH, never could upgrade an object of that type any longer.

Especially issue when you have multiple objects referring to the same object (with same id) needing upgrading.

Testing shows that this code was not needed, giving the same result on the verification scripts with or without this. Removing this code however, get some scripts with significant amounts of serialised obejct working, that where previously failing (see Create Walls script in test files folder).

Also, Spaces are deserialising and versioning fine without this code.

Rolling back for now as it seem to fix the general issues.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/El6K9VWTp7hNlr0_QOsYI6cBVKa4ztleFiHzWocHPbkhGQ?e=aNDAjn

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->