### PR TITLE
Serialiser_Engine: check if FullName is empty before returning Error in TypeSerializer

### DIFF
--- a/Serialiser_Engine/Objects/BsonSerializers/TypeSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/TypeSerializer.cs
@@ -153,7 +153,8 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 }
 
                 if (type == null)
-                    Reflection.Compute.RecordError("Type " + fullName + " failed to deserialise.");
+                    if (!string.IsNullOrWhiteSpace(fullName))
+                        Reflection.Compute.RecordError("Type " + fullName + " failed to deserialise.");
                 else if (type.IsGenericType && type.GetGenericArguments().Length == genericTypes.Where(x => x != null).Count())
                     type = type.MakeGenericType(genericTypes.ToArray()); 
 
@@ -161,7 +162,8 @@ namespace BH.Engine.Serialiser.BsonSerializers
             }
             catch
             {
-                Reflection.Compute.RecordError("Type " + fullName + " failed to deserialise.");
+                if (!string.IsNullOrWhiteSpace(fullName))
+                    Reflection.Compute.RecordError("Type " + fullName + " failed to deserialise.");
                 return null;
             }
         }

--- a/Serialiser_Engine/Objects/BsonSerializers/TypeSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/TypeSerializer.cs
@@ -153,16 +153,16 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 }
 
                 if (type == null)
-                    if (!string.IsNullOrWhiteSpace(fullName))
+                    if (!string.IsNullOrWhiteSpace(fullName))  // To mirror the structure of the code above (line 59), we need to check if the fullName is empty.
                         Reflection.Compute.RecordError("Type " + fullName + " failed to deserialise.");
-                else if (type.IsGenericType && type.GetGenericArguments().Length == genericTypes.Where(x => x != null).Count())
+                    else if (type.IsGenericType && type.GetGenericArguments().Length == genericTypes.Where(x => x != null).Count())
                     type = type.MakeGenericType(genericTypes.ToArray()); 
 
                 return type;
             }
             catch
             {
-                if (!string.IsNullOrWhiteSpace(fullName))
+                if (!string.IsNullOrWhiteSpace(fullName)) // To mirror the structure of the code above (line 59), we need to check if the fullName is empty.
                     Reflection.Compute.RecordError("Type " + fullName + " failed to deserialise.");
                 return null;
             }

--- a/Serialiser_Engine/Objects/BsonSerializers/TypeSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/TypeSerializer.cs
@@ -153,9 +153,11 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 }
 
                 if (type == null)
+                {
                     if (!string.IsNullOrWhiteSpace(fullName))  // To mirror the structure of the code above (line 59), we need to check if the fullName is empty.
                         Reflection.Compute.RecordError("Type " + fullName + " failed to deserialise.");
-                    else if (type.IsGenericType && type.GetGenericArguments().Length == genericTypes.Where(x => x != null).Count())
+                }
+                else if (type.IsGenericType && type.GetGenericArguments().Length == genericTypes.Where(x => x != null).Count())
                     type = type.MakeGenericType(genericTypes.ToArray()); 
 
                 return type;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2242 

<!-- Add short description of what has been fixed -->

This solves the problem described in https://github.com/BHoM/BHoM_Adapter/issues/271#issuecomment-747968997 for me.

Why is the Error thrown even if FullName is empty? Why is deserialization attempted with FullName emtpy?

It seems it comes from a limitation in Mongo, that we are dealing with when serializing on line 59:
https://github.com/BHoM/BHoM_Engine/pull/2243/files#diff-97ac4289062918885fd1d3f995c876f456d9be4b96b3c21b0b5818bdda4c9881L59-L66

in order to make the structure symmetric, this PR "mirrors" this in the deserialization.


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->