### PR TITLE
Geometry_Engine: Correcting logged events in Centroid methods

### DIFF
--- a/Geometry_Engine/Query/Centroid.cs
+++ b/Geometry_Engine/Query/Centroid.cs
@@ -97,17 +97,17 @@ namespace BH.Engine.Geometry
         {
             if (!curve.IsPlanar(tolerance))
             {
-                Reflection.Compute.RecordError("Input must be planar.");
+                Reflection.Compute.RecordError("Input curve is not planar. Cannot calculate centroid.");
                 return null;
             }
             else if (!curve.IsClosed(tolerance))
             {
-                Reflection.Compute.RecordError("Curve is not closed. Input must be a polygon");
+                Reflection.Compute.RecordError("Input curve is not closed. Cannot calculate centroid.");
                 return null;
             }
             else if (curve.IsSelfIntersecting(tolerance))
             {
-                Reflection.Compute.RecordWarning("Curve is self intersecting");
+                Reflection.Compute.RecordError("Input curve is self-intersecting. Cannot calculate centroid.");
                 return null;
             }
 
@@ -162,17 +162,17 @@ namespace BH.Engine.Geometry
         {
             if (!curve.IsPlanar(tolerance))
             {
-                Reflection.Compute.RecordError("Input must be planar.");
+                Reflection.Compute.RecordError("Input curve is not planar. Cannot calculate centroid.");
                 return null;
             }
             else if (!curve.IsClosed(tolerance))
             {
-                Reflection.Compute.RecordError("Curve is not closed.");
+                Reflection.Compute.RecordError("Input curve is not closed. Cannot calculate centroid.");
                 return null;
             }
             else if (curve.IsSelfIntersecting(tolerance))
             {
-                Reflection.Compute.RecordWarning("Curve is self intersecting");
+                Reflection.Compute.RecordError("Input curve is self-intersecting. Cannot calculate centroid.");
                 return null;
             }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2254 

<!-- Add short description of what has been fixed -->
Changing logged warning into an error in case of self-intersection following the rule of _returning no result -> error_.
Also unified error messages.

### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed as only descriptions and type of event is changed. [Here](https://burohappold.sharepoint.com/:f:/s/BHoM/Em--fsAco_FLhMZiO5irRVIB3aAnOxh9kJpZZhZeNolmOA?e=t996WA) is the general test file for `Centroid()`.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Updated logged events in `Centroid()` methods in the `Geometry_Engine`.

