### PR TITLE
Reflection_Engine: Fixes necessary for the RunCode component

### DIFF
--- a/Reflection_Engine/Convert/ToText.cs
+++ b/Reflection_Engine/Convert/ToText.cs
@@ -98,7 +98,7 @@ namespace BH.Engine.Reflection
                             break;
                         }
 
-                        paramText += ", " + singleParamText;
+                        paramText += paramSeparator + singleParamText;
                     }
                 }
 

--- a/Reflection_Engine/Query/AssemblyList.cs
+++ b/Reflection_Engine/Query/AssemblyList.cs
@@ -64,9 +64,9 @@ namespace BH.Engine.Reflection
 
         private static void ExtractAllAssemblies()
         {
-            IEnumerable<Assembly> assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            IEnumerable<Assembly> assemblies = AppDomain.CurrentDomain.GetAssemblies().GroupBy(x => x.FullName).Select(g => g.First());
             m_BHoMAssemblies = assemblies.Where(x => x.IsBHoM()).ToDictionary(x => x.FullName);
-            m_AllAssemblies = assemblies.GroupBy(x => x.FullName).Select(g => g.First()).ToDictionary(x => x.FullName);
+            m_AllAssemblies = assemblies.ToDictionary(x => x.FullName);
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
Provide support for this UI PR: 

   
### Issues addressed by this PR

A few small fixes needed for the new RunCode component to work properly (see changelog).


### Changelog
- Fix hard-coded separator instead of using the one provided as input in the ToText method
- Make sure assemblies are collected only once even for BHoM dlls
- Allow to collect indirect references in UsedAssemblies

