### PR TITLE
Reflection_Engine: Remove the condition that BHoMTypeList can only contain IObjects

### DIFF
--- a/Reflection_Engine/Query/TypeList.cs
+++ b/Reflection_Engine/Query/TypeList.cs
@@ -137,7 +137,7 @@ namespace BH.Engine.Reflection
                     {
                         foreach (Type type in asm.GetTypes())
                         {
-                            if (type.Namespace != null && type.Namespace.StartsWith("BH.oM") && typeof(IObject).IsAssignableFrom(type))
+                            if (type.Namespace != null && type.Namespace.StartsWith("BH.oM"))
                             {
                                 AddBHoMTypeToDictionary(type.FullName, type);
                                 if (!type.IsInterface && !(type.IsAbstract && type.IsSealed)) // Avoid interfaces and static classes


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2258

See issue for details


### Test files
Make sure that the `CreateEnum` component doesn't have an empty menu anymore and that `CreateType` is able to create enum types

