### PR TITLE
Geometry_Engine: Removing Radius(Arc) and adding warnings to Area() methods

### DIFF
--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Geometry
 
         public static double Area(this Arc curve)
         {
-            return curve.IsClosed() ? curve.Angle() * Math.Pow(curve.Radius(), 2) : 0;
+            return curve.IsClosed() ? curve.Angle() * Math.Pow(curve.Radius, 2) : 0;
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -22,7 +22,6 @@
 
 using BH.Engine.Base;
 using BH.oM.Geometry;
-using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -47,20 +46,27 @@ namespace BH.Engine.Geometry
 
         public static double Area(this Arc curve)
         {
-            return curve.IsClosed() ? curve.Angle() * Math.Pow(curve.Radius, 2) : 0;
+            if (curve.IsClosed())
+                return Math.PI * curve.Radius * curve.Radius;
+            else
+            {
+                Reflection.Compute.RecordWarning("Cannot calculate area for an open curve.");
+                return 0;
+            }
         }
 
         /***************************************************/
 
         public static double Area(this Circle curve)
         {
-            return Math.PI * Math.Pow(curve.Radius, 2);
+            return Math.PI * curve.Radius * curve.Radius;
         }
 
         /***************************************************/
 
         public static double Area(this Line curve)
         {
+            Reflection.Compute.RecordWarning("Cannot calculate area for an open curve.");
             return 0;
         }
 
@@ -72,7 +78,10 @@ namespace BH.Engine.Geometry
                 return (curve.Curves[0] as Circle).Area();
 
             if (!curve.IsClosed())
+            {
+                Reflection.Compute.RecordWarning("Cannot calculate area for an open curve.");
                 return 0;
+            }
 
             Plane p = curve.FitPlane();
             if (p == null)
@@ -116,7 +125,10 @@ namespace BH.Engine.Geometry
         public static double Area(this Polyline curve)
         {
             if (!curve.IsClosed())
+            {
+                Reflection.Compute.RecordWarning("Cannot calculate area for an open curve.");
                 return 0;
+            }
 
             List<Point> pts = curve.ControlPoints;
             int ptsCount = pts.Count;

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -108,7 +108,7 @@ namespace BH.Engine.Geometry
         public static bool IsContaining(this Arc curve, List<Point> points, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
         {
             if (!curve.IsClosed(tolerance)) return false;
-            Circle circle = new Circle { Centre = curve.Centre(), Radius = curve.Radius(), Normal = curve.FitPlane().Normal };
+            Circle circle = new Circle { Centre = curve.Centre(), Radius = curve.Radius, Normal = curve.FitPlane().Normal };
             return circle.IsContaining(points, acceptOnEdge, tolerance);
         }
 
@@ -360,7 +360,7 @@ namespace BH.Engine.Geometry
         public static bool IsContaining(this Arc curve1, ICurve curve2, bool acceptOnEdge = true, double tolerance = Tolerance.Distance)
         {
             if (!curve1.IsClosed(tolerance)) return false;
-            Circle circle = new Circle { Centre = curve1.Centre(), Radius = curve1.Radius(), Normal = curve1.FitPlane().Normal };
+            Circle circle = new Circle { Centre = curve1.Centre(), Radius = curve1.Radius, Normal = curve1.FitPlane().Normal };
             return circle.IsContaining(curve2);
         }
 

--- a/Geometry_Engine/Query/Length.cs
+++ b/Geometry_Engine/Query/Length.cs
@@ -53,7 +53,7 @@ namespace BH.Engine.Geometry
 
         public static double Length(this Arc curve)
         {
-            return curve.Angle() * curve.Radius();
+            return curve.Angle() * curve.Radius;
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/Radius.cs
+++ b/Geometry_Engine/Query/Radius.cs
@@ -31,7 +31,7 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Deprecated("4.1", "To be removed as radius is a public property of the Arc class.")]
+        [ToBeRemoved("4.1", "To be removed as radius is a public property of the Arc class.")]
         public static double Radius(this Arc arc)
         {
             //TODO: remove this method?

--- a/Geometry_Engine/Query/Radius.cs
+++ b/Geometry_Engine/Query/Radius.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 
 namespace BH.Engine.Geometry
 {
@@ -30,6 +31,7 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Deprecated("4.1", "To be removed as radius is a public property of the Arc class.")]
         public static double Radius(this Arc arc)
         {
             //TODO: remove this method?

--- a/Graphics_Engine/Convert/ToSVGString.cs
+++ b/Graphics_Engine/Convert/ToSVGString.cs
@@ -206,7 +206,7 @@ namespace BH.Engine.Graphics
             Point end = arc.EndPoint();
             string arcString = "<path d=\"M" + start.X.ToString()
                                 + "," + start.Y.ToString()
-                                + " A" + arc.Radius() + "," + arc.Radius()
+                                + " A" + arc.Radius + "," + arc.Radius
                                 + " 0"
                                 + " " + largeArcFlag
                                 + "," + sweepFlag


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #945
Closes #946

<!-- Add short description of what has been fixed -->
Deprecating `Query.Radius(Arc)` as `Radius` is a public property of the `Arc` class.
**EDIT**
Decided to merge this one with #946 as they both update `Area.cs` and I didn't want to wait until this one get merged 😉 
**/EDIT**
### Test files
<!-- Link to test files to validate the proposed changes -->
**945**
Not needed as it doesn't affect a logic of any method, however [here](https://burohappold.sharepoint.com/:u:/s/BHoM/EW9cmLWzc7ROrZw_5Sb7UHMBU36t3W9nmSuP3ElJ3YvY0A?e=xCspMY) is the script I used to check if any reference has been missed.
**946**
Not needed - only added warnings.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Deprecating `Query.Radius(Arc)` method in the `Geometry_Engine`.
- Updating methods in `Geometry_Engine` to call for `Radius` _property_ instead of `Radius()` _method_.
- Adding warnings to `Query.Area` methods in the `Geometry_Engine` in cases of open curves. 