### PR TITLE
Geometry_Engine: Removing Centre(Polyline)

### DIFF
--- a/Environment_Engine/Query/BottomLeft.cs
+++ b/Environment_Engine/Query/BottomLeft.cs
@@ -60,13 +60,12 @@ namespace BH.Engine.Environment
             Vector normal = polyline.Normal();
             if (!polyline.NormalAwayFromSpace(panelsAsSpace))
                 normal = polyline.Flip().Normal();
+            if (normal == null)
+                return null;
 
             Point centre = polyline.Centroid();
             if (centre == null)
                 centre = polyline.ControlPoints.CullDuplicates().Average();
-
-            if (normal == null)
-                return null;
 
             Line line = new Line
             {

--- a/Environment_Engine/Query/BottomLeft.cs
+++ b/Environment_Engine/Query/BottomLeft.cs
@@ -63,9 +63,9 @@ namespace BH.Engine.Environment
 
             Point centre = polyline.Centroid();
             if (centre == null)
-                centre = polyline.Centre();
+                centre = polyline.ControlPoints.CullDuplicates().Average();
 
-            if(normal == null)
+            if (normal == null)
                 return null;
 
             Line line = new Line

--- a/Environment_Engine/Query/BottomRight.cs
+++ b/Environment_Engine/Query/BottomRight.cs
@@ -60,13 +60,12 @@ namespace BH.Engine.Environment
             Vector normal = polyline.Normal();
             if (!polyline.NormalAwayFromSpace(panelsAsSpace))
                 normal = polyline.Flip().Normal();
+            if (normal == null)
+                return null;
 
             Point centre = polyline.Centroid();
             if (centre == null)
                 centre = polyline.ControlPoints.CullDuplicates().Average();
-
-            if (normal == null)
-                return null;
 
             Line line = new Line
             {

--- a/Environment_Engine/Query/BottomRight.cs
+++ b/Environment_Engine/Query/BottomRight.cs
@@ -63,9 +63,9 @@ namespace BH.Engine.Environment
 
             Point centre = polyline.Centroid();
             if (centre == null)
-                centre = polyline.Centre();
+                centre = polyline.ControlPoints.CullDuplicates().Average();
 
-            if(normal == null)
+            if (normal == null)
                 return null;
 
             Line line = new Line

--- a/Environment_Engine/Query/NormalAwayFromSpace.cs
+++ b/Environment_Engine/Query/NormalAwayFromSpace.cs
@@ -66,7 +66,7 @@ namespace BH.Engine.Environment
             if (centrePt == null)
                 centrePt = polyline.Centroid();
             if (centrePt == null)
-                centrePt = polyline.Centre();
+                centrePt = polyline.ControlPoints.CullDuplicates().Average();
             if (centrePt == null)
                 return false; //Problems
 

--- a/Environment_Engine/Query/TopRight.cs
+++ b/Environment_Engine/Query/TopRight.cs
@@ -60,13 +60,12 @@ namespace BH.Engine.Environment
             Vector normal = polyline.Normal();
             if (!polyline.NormalAwayFromSpace(panelsAsSpace))
                 normal = polyline.Flip().Normal();
+            if (normal == null)
+                return null;
 
             Point centre = polyline.Centroid();
             if (centre == null)
                 centre = polyline.ControlPoints.CullDuplicates().Average();
-
-            if(normal == null)
-                return null;
 
             Line line = new Line
             {

--- a/Environment_Engine/Query/TopRight.cs
+++ b/Environment_Engine/Query/TopRight.cs
@@ -63,7 +63,7 @@ namespace BH.Engine.Environment
 
             Point centre = polyline.Centroid();
             if (centre == null)
-                centre = polyline.Centre();
+                centre = polyline.ControlPoints.CullDuplicates().Average();
 
             if(normal == null)
                 return null;

--- a/Geometry_Engine/Query/Centre.cs
+++ b/Geometry_Engine/Query/Centre.cs
@@ -21,9 +21,8 @@
  */
 
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
-using System.Linq;
-using System;
 
 namespace BH.Engine.Geometry
 {
@@ -40,6 +39,7 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [ToBeRemoved("4.1", "To be removed as it is generally incorrect. Advising using Centroid instead.")]
         public static Point Centre(this Polyline polyline, double tolerance = Tolerance.Distance)
         {
             //TODO: this is an average point, not centroid - should be distinguished


### PR DESCRIPTION
 <!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
Pull requests removing references to `Centre()`:
- [XML_Toolkit](https://github.com/BHoM/XML_Toolkit/pull/519)
- [IES_Toolkit](https://github.com/BHoM/IES_Toolkit/pull/168)
 
  
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #944 

<!-- Add short description of what has been fixed -->
Deprecating `Query.Centre(Polyline)` as it is generally incorrect. All references are being changed to `Centroid()`.

### Test files
<!-- Link to test files to validate the proposed changes -->
Not needed as it doesn't affect a logic of any method, however [here](https://burohappold.sharepoint.com/:u:/s/BHoM/ETgDDrmqBoZNvApme34KNDcBOT7zjI5DWfZlWrTE3oOcAA?e=Jr2EtM) is the script I used to check if any reference has been missed.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Deprecating `Query.Centre(Polyline)` method in the `Geometry_Engine`.
- Updating methods in `Environment_Engine` to call for an average non-duplicated control point.
