### PR TITLE
Reflection_Engine: Fix SetProperty of CustomData

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -107,18 +107,15 @@ namespace BH.Engine.Reflection
         {
             if (obj == null) return false;
 
-            if (!obj.CustomData.ContainsKey(propName))
+            if (value is IFragment)
             {
-                if (value is IFragment)
-                {
-                    obj.Fragments.Add(value as IFragment);
-                    Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as a fragment.");
-                }
-                else
-                {
-                    obj.CustomData[propName] = value;
-                    Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data.");
-                }
+                obj.Fragments.Add(value as IFragment);
+                Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as a fragment.");
+            }
+            else
+            {
+                obj.CustomData[propName] = value;
+                Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data.");
             }
 
             return true;

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -110,7 +110,7 @@ namespace BH.Engine.Reflection
             if (value is IFragment)
             {
                 obj.Fragments.Add(value as IFragment);
-                Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as a fragment.");
+                Compute.RecordWarning("The object does not contain any property with the name " + propName + ". The value is being set as a fragment.");
             }
             else
             {

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -115,7 +115,7 @@ namespace BH.Engine.Reflection
             else
             {
                 obj.CustomData[propName] = value;
-                Compute.RecordWarning("The objects does not contain any property with the name " + propName + ". The value is being set as custom data.");
+                Compute.RecordWarning("The object does not contain any property with the name " + propName + ". The value is being set as custom data.");
             }
 
             return true;


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2284

Changing a value stored in CustomData is now possible even if the corresponding key already exists


### Test files
See issue


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->