### PR TITLE
Facade_Engine: ConvertOffsetDefinition

### DIFF
--- a/Facade_Engine/Facade_Engine.csproj
+++ b/Facade_Engine/Facade_Engine.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Compute\ComponentAreas.cs" />
     <Compile Include="Compute\EdgeAdjacencies.cs" />
     <Compile Include="Compute\AdjacentElements.cs" />
+    <Compile Include="Modify\DefineOffset.cs" />
     <Compile Include="Modify\OffsetVariable.cs" />
     <Compile Include="Query\AdjacencyId.cs" />
     <Compile Include="Compute\UniqueAdjacencies.cs" />

--- a/Facade_Engine/Facade_Engine.csproj
+++ b/Facade_Engine/Facade_Engine.csproj
@@ -60,6 +60,11 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="Physical_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_Engine.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="Physical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
       <Private>False</Private>

--- a/Facade_Engine/Facade_Engine.csproj
+++ b/Facade_Engine/Facade_Engine.csproj
@@ -102,7 +102,7 @@
     <Compile Include="Compute\ComponentAreas.cs" />
     <Compile Include="Compute\EdgeAdjacencies.cs" />
     <Compile Include="Compute\AdjacentElements.cs" />
-    <Compile Include="Modify\DefineOffset.cs" />
+    <Compile Include="Modify\SetOffsetFromFacetoFaceDist.cs" />
     <Compile Include="Modify\OffsetVariable.cs" />
     <Compile Include="Query\AdjacencyId.cs" />
     <Compile Include="Compute\UniqueAdjacencies.cs" />

--- a/Facade_Engine/Modify/DefineOffset.cs
+++ b/Facade_Engine/Modify/DefineOffset.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Base;
+using BH.oM.Geometry;
+using BH.Engine.Geometry;
+using BH.Engine.Reflection;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Reflection.Debugging;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using BH.oM.Facade.Elements;
+using BH.oM.Facade.Fragments;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Copies a Panel into a new object")]
+        [Input("panel", "A panel to calculate offset for")]
+        [Input("opening", "An opening to calculate offset for")]
+        [Input("useroffset", "A user defined offset (face of panel to face of glazing)")]
+        [Output("offset", "The copied Environment Panel")]
+        public static ConstructionOffset DefineOffset(this Panel panel, Opening opening, double useroffset)
+        {
+            //TODO:
+            //Check for null case
+            if (panel == null || opening == null)
+                return null;
+
+            //Retrieve panel width and opening glazing width
+            double panelwidth = panel.Construction;
+            double glzwidth = opening.OpeningConstruction.PropertyValue("Layers");
+
+            //Calculate and return offset defined panel centerline to glazing (opening) centerline
+            double offset = 0.5 * panelwidth - 0.5 * glzwidth - useroffset;
+            return offset;
+        }
+    }
+}

--- a/Facade_Engine/Modify/DefineOffset.cs
+++ b/Facade_Engine/Modify/DefineOffset.cs
@@ -75,7 +75,7 @@ namespace BH.Engine.Facade
             if (offsetFragment == null)
             {
                 ConstructionOffset newOffsetFragment = new ConstructionOffset() { OffsetDistance = offset };
-                opening.AddFragment(newOffsetFragment);
+                opening.Fragments.Add(newOffsetFragment);
             }
             else
             {

--- a/Facade_Engine/Modify/SetOffsetFromFacetoFaceDist.cs
+++ b/Facade_Engine/Modify/SetOffsetFromFacetoFaceDist.cs
@@ -43,16 +43,16 @@ namespace BH.Engine.Facade
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Sets an openings offset based on a specified value defining the desired distance between the panel's exterior face and the openings exterior face.")]
-        [Input("panel", "A panel to base opening offset on.")]
-        [Input("opening", "An opening to set the offset on based on the specified value and provided panel.")]
+        [Description("Sets an opening offset based on a specified value defining the desired distance between the panel's exterior face and the openings exterior face.")]
+        [Input("panel", "A panel to base opening offset on. The panel must have a construction thickness.")]
+        [Input("opening", "An opening to set the offset on based on the specified value and provided panel. The opening must have a glazing thickness.")]
         [Input("useroffset", "A user defined offset (exterior face of panel to exterior face of glazing).")]
-        [Output("opening", "The opening with the specified offset applied.")]
-        public static Opening SetOffsetPerExteriorOffset(this Opening opening, Panel panel, double useroffset)
+        [Output("opening", "The opening with the specified offset applied as a fragment.")]
+        public static Opening SetOffsetFromFacetoFaceDist(this Opening opening, Panel panel, double useroffset)
         {
             //TODO:
             //Check for null case
-            if (panel == null || opening == null)
+            if (panel == null || opening == null || useroffset == null)
                 return null;
 
             //Retrieve panel width and opening glazing width


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2266 

<!-- Add short description of what has been fixed -->

Added method SetOffsetFromFacetoFaceDefinition to Facade_Engine Methods. This method takes a user input offset (defined from face of glazing to face of panel) and applies it as a ConstructionOffsetFragment to an opening.