### PR TITLE
CI/CD: Serialisation verification for methods and types

### DIFF
--- a/.ci/code/Serialiser_Test/Helpers/ObjectTypesToTest.cs
+++ b/.ci/code/Serialiser_Test/Helpers/ObjectTypesToTest.cs
@@ -38,7 +38,7 @@ namespace BH.Test.Serialiser
         /**** Public Methods              ****/
         /*************************************/
 
-        public static List<Type> TypesToTest()
+        public static List<Type> ObjectTypesToTest()
         {
             Engine.Reflection.Compute.LoadAllAssemblies();
 
@@ -46,7 +46,8 @@ namespace BH.Test.Serialiser
             return Engine.Reflection.Query.BHoMTypeList().Where(x => {
                 return typeof(IObject).IsAssignableFrom(x)
                   && !x.IsAbstract
-                  && !x.IsDeprecated();
+                  && !x.IsDeprecated()
+                  && !x.GetProperties().Select(p => p.PropertyType.Namespace).Any(n => !n.StartsWith("BH.") && !n.StartsWith("System"));
             }).ToList();
         }
 

--- a/.ci/code/Serialiser_Test/Serialiser_Test.csproj
+++ b/.ci/code/Serialiser_Test/Serialiser_Test.csproj
@@ -66,8 +66,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Helpers\TestObjects.cs" />
-    <Compile Include="Helpers\TypesToTest.cs" />
-    <Compile Include="Verify\ToFromJson.cs" />
+    <Compile Include="Helpers\ObjectTypesToTest.cs" />
+    <Compile Include="Verify\MethodsToFromJson.cs" />
+    <Compile Include="Verify\TypesToFromJson.cs" />
+    <Compile Include="Verify\ObjectsToFromJson.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/.ci/code/Serialiser_Test/Verify/MethodsToFromJson.cs
+++ b/.ci/code/Serialiser_Test/Verify/MethodsToFromJson.cs
@@ -1,0 +1,120 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Reflection;
+using BH.Engine.Serialiser;
+using BH.Engine.Test;
+using BH.oM.Reflection.Debugging;
+using BH.oM.Test;
+using BH.oM.Test.Results;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Serialiser
+{
+    public static partial class Verify
+    {
+        /*************************************/
+        /**** Test Methods                ****/
+        /*************************************/
+
+        public static TestResult MethodsToFromJson()
+        {
+            // Test all the BHoM types available
+            List<MethodInfo> methods = Engine.Reflection.Query.BHoMMethodList().Where(x => !x.IsDeprecated()).ToList();
+            List<TestResult> results = methods.Select(x => MethodToFromJson(x)).ToList();
+
+            // Generate the result message
+            int errorCount = results.Where(x => x.Status == TestStatus.Error).Count();
+            int warningCount = results.Where(x => x.Status == TestStatus.Warning).Count();
+
+            // Returns a summary result 
+            return new TestResult()
+            {
+                ID = "MethodSerialiserToFromJson",
+                Description = $"Serialisation of Methods via json: {results.Count} methods available.",
+                Message = $"{errorCount} errors and {warningCount} warnings reported.",
+                Status = results.MostSevereStatus(),
+                Information = results.Where(x => x.Status != TestStatus.Pass).ToList<ITestInformation>(),
+                UTCTime = DateTime.UtcNow,
+            };
+        }
+
+        /*************************************/
+
+        public static TestResult MethodToFromJson(MethodBase method)
+        {
+            string methodDescription = method.IToText(true);
+
+            // To Json
+            string json = "";
+            try
+            {
+                Engine.Reflection.Compute.ClearCurrentEvents();
+                json = method.ToJson();
+            }
+            catch (Exception e)
+            {
+                Engine.Reflection.Compute.RecordError(e.Message);
+            }
+
+            if (string.IsNullOrWhiteSpace(json))
+                return new TestResult
+                {
+                    Description = methodDescription,
+                    Status = TestStatus.Error,
+                    Message = $"Error: Failed to convert method {methodDescription} to json.",
+                    Information = Engine.Reflection.Query.CurrentEvents().Select(x => x.ToEventMessage()).ToList<ITestInformation>()
+                };
+
+            // From Json
+            MethodInfo copy = null;
+            try
+            {
+                Engine.Reflection.Compute.ClearCurrentEvents();
+                copy = Engine.Serialiser.Convert.FromJson(json) as MethodInfo;
+            }
+            catch (Exception e)
+            {
+                Engine.Reflection.Compute.RecordError(e.Message);
+            }
+
+            if (!method.IsEqual(copy))
+                return new TestResult
+                {
+                    Description = methodDescription,
+                    Status = TestStatus.Error,
+                    Message = $"Error: Method {methodDescription} is not equal to the original after serialisation.",
+                    Information = Engine.Reflection.Query.CurrentEvents().Select(x => x.ToEventMessage()).ToList<ITestInformation>()
+                };
+
+            // All test objects passed the test
+            return Engine.Test.Create.PassResult(methodDescription);
+        }
+
+        /*************************************/
+    }
+}

--- a/.ci/code/Serialiser_Test/Verify/TypesToFromJson.cs
+++ b/.ci/code/Serialiser_Test/Verify/TypesToFromJson.cs
@@ -1,0 +1,122 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Reflection;
+using BH.Engine.Serialiser;
+using BH.Engine.Test;
+using BH.oM.Reflection.Debugging;
+using BH.oM.Test;
+using BH.oM.Test.Results;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Serialiser
+{
+    public static partial class Verify
+    {
+        /*************************************/
+        /**** Test Methods                ****/
+        /*************************************/
+
+        public static TestResult TypesToFromJson()
+        {
+            // Test all the BHoM types available
+            List<Type> types = Engine.Reflection.Query.BHoMTypeList()
+                .Concat(Engine.Reflection.Query.BHoMInterfaceList())
+                .Concat(Engine.Reflection.Query.AdapterTypeList())
+                .ToList();
+            List<TestResult> results = types.Select(x => TypeToFromJson(x)).ToList();
+
+            // Generate the result message
+            int errorCount = results.Where(x => x.Status == TestStatus.Error).Count();
+            int warningCount = results.Where(x => x.Status == TestStatus.Warning).Count();
+
+            // Returns a summary result 
+            return new TestResult()
+            {
+                ID = "TypeSerialiserToFromJson",
+                Description = $"Serialisation of Types via json: {results.Count} types available.",
+                Message = $"{errorCount} errors and {warningCount} warnings reported.",
+                Status = results.MostSevereStatus(),
+                Information = results.Where(x => x.Status != TestStatus.Pass).ToList<ITestInformation>(),
+                UTCTime = DateTime.UtcNow,
+            };
+        }
+
+        /*************************************/
+
+        public static TestResult TypeToFromJson(Type type)
+        {
+            string typeDescription = type.IToText(true);
+
+            // To Json
+            string json = "";
+            try
+            {
+                Engine.Reflection.Compute.ClearCurrentEvents();
+                json = type.ToJson();
+            }
+            catch (Exception e)
+            {
+                Engine.Reflection.Compute.RecordError(e.Message);
+            }
+
+            if (string.IsNullOrWhiteSpace(json))
+                return new TestResult
+                {
+                    Description = typeDescription,
+                    Status = TestStatus.Error,
+                    Message = $"Error: Failed to convert type {typeDescription} to json.",
+                    Information = Engine.Reflection.Query.CurrentEvents().Select(x => x.ToEventMessage()).ToList<ITestInformation>()
+                };
+
+            // From Json
+            Type copy = null;
+            try
+            {
+                Engine.Reflection.Compute.ClearCurrentEvents();
+                copy = Engine.Serialiser.Convert.FromJson(json) as Type;
+            }
+            catch (Exception e)
+            {
+                Engine.Reflection.Compute.RecordError(e.Message);
+            }
+
+            if (!type.IsEqual(copy))
+                return new TestResult
+                {
+                    Description = typeDescription,
+                    Status = TestStatus.Error,
+                    Message = $"Error: Type {typeDescription} is not equal to the original after serialisation.",
+                    Information = Engine.Reflection.Query.CurrentEvents().Select(x => x.ToEventMessage()).ToList<ITestInformation>()
+                };
+
+            // All test objects passed the test
+            return Engine.Test.Create.PassResult(typeDescription);
+        }
+
+        /*************************************/
+    }
+}

--- a/Reflection_Engine/Create/MethodBase.cs
+++ b/Reflection_Engine/Create/MethodBase.cs
@@ -46,19 +46,23 @@ namespace BH.Engine.Serialiser
 
             foreach (MethodBase method in methods)
             {
-                ParameterInfo[] parameters = method.ParametersWithConstraints();
-                if (parameters.Length == paramTypeNames.Count)
+                try
                 {
-                    bool matching = true;
-                    List<string> names = parameters.Select(x => x.ParameterType.ToText(true)).ToList();
-                    for (int i = 0; i < paramTypeNames.Count; i++)
-                        matching &= names[i] == paramTypeNames[i];
-
-                    if (matching)
+                    ParameterInfo[] parameters = method.ParametersWithConstraints();
+                    if (parameters.Length == paramTypeNames.Count)
                     {
-                        return method;
+                        bool matching = true;
+                        List<string> names = parameters.Select(x => x.ParameterType.ToText(true)).ToList();
+                        for (int i = 0; i < paramTypeNames.Count; i++)
+                            matching &= names[i] == paramTypeNames[i];
+
+                        if (matching)
+                        {
+                            return method;
+                        }
                     }
                 }
+                catch { }
             }
 
             // If failed, look for a generic method that can satisfy the constraints

--- a/Serialiser_Engine/Convert/Bson.cs
+++ b/Serialiser_Engine/Convert/Bson.cs
@@ -242,7 +242,7 @@ namespace BH.Engine.Serialiser
             }
             catch (Exception e)
             {
-                Console.WriteLine(e.ToString());
+                Debug.WriteLine(e.ToString());
             }
         }
 

--- a/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
@@ -149,6 +149,18 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 foreach (Type type in Reflection.Create.AllTypes(typeName, true))
                 {
                     method = Create.MethodBase(type, methodName, types.Select(x => x.ToText(true)).ToList()); // type overload
+                    if (method == null)
+                    {
+                        try
+                        {
+                            if (methodName == ".ctor")
+                                method = type.GetConstructor(types.ToArray());
+                            else
+                                method = type.GetMethod(methodName, types.ToArray());
+                        }
+                        catch { }
+                    }
+
                     if (method != null)
                         return method;
                 }

--- a/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
@@ -309,6 +309,9 @@ namespace BH.Engine.Serialiser.BsonSerializers
             }
             catch (Exception e)
             {
+                if (e.Message.Contains("Could not load file or assembly"))
+                    Engine.Reflection.Compute.RecordError(e.Message);
+
                 context.Reader.ReturnToBookmark(bookmark);
                 DeprecatedSerializer deprecatedSerialiser = new DeprecatedSerializer();
                 return deprecatedSerialiser.Deserialize(context, args);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2299

- Aligns the code with the recent changes to the Test_oM and Test_engine
- Adds serialisation verification for methods and types on top of the existing one for objects.

### Test files

Call the TestRunner with the `Serialiser` parameter. Here's the result that I get:

```
PS C:\ProgramData\BHoM\Assemblies> .\TestRunner.exe Serialiser

Serialisation of Methods via json: 4383 methods available.
1 errors and 0 warnings reported.
Inner results:
        BH.Engine.Adapter.Query.AdapterId(IBHoMObject bHoMObject, Type adapterIdFragmentType)
        Error: Method BH.Engine.Adapter.Query.AdapterId(IBHoMObject bHoMObject, Type adapterIdFragmentType) is not equal to the original after serialisation.

Serialisation of Types via json: 1536 types available.
0 errors and 0 warnings reported.

Serialisation of Objects via json: 1065 types of objects available in BH.oM.
0 errors and 1 warnings reported.
Inner results:
        BH.oM.Physical.Materials.MaterialComposition
        Warning: Failed to create a dummy object of type BH.oM.Physical.Materials.MaterialComposition.
```


### Additional comments
- I had to add a few try-catch in the serialiser engine due to some dlls from Rhino not being available and causing exceptions. 
- I also added a fallback to `System.Type.GetMethod()` when our own `Create.Method` fails. This is useful when trying to recover a method that is not part of the BHoM (e.g. System methods).
- The issue for `AdapterId` was already raised here: https://github.com/BHoM/BHoM_Adapter/issues/284
- `MaterialComposition` is the only type that can throw an exception within its constructor. Personally, I am not a fan and would prefer recording an error in the corresponding `Create` method instead. Just know that this is not a bug with this PR or the `CreateDummy` method.