### PR TITLE
BHoM_Engine: adding Geometry3D methods

### DIFF
--- a/BHoM_Engine/BHoM_Engine.csproj
+++ b/BHoM_Engine/BHoM_Engine.csproj
@@ -61,6 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Query\Geometry3D.cs" />
     <Compile Include="Query\UniquenessRestrictions.cs" />
     <Compile Include="Query\CanTarget.cs" />
     <Compile Include="Query\Hash.cs" />
@@ -69,8 +70,8 @@
     <Compile Include="Create\CustomObject.cs" />
     <Compile Include="Modify\RemoveFragment.cs" />
     <Compile Include="Modify\AddFragment.cs" />
-	<Compile Include="Modify\SetHashFragment.cs" />
-	<Compile Include="Objects\EqualityComparers\HashComparer.cs" />
+    <Compile Include="Modify\SetHashFragment.cs" />
+    <Compile Include="Objects\EqualityComparers\HashComparer.cs" />
     <Compile Include="Objects\EqualityComparers\TypeComparer.cs" />
     <Compile Include="Objects\EqualityComparers\BHoMGuidComparer.cs" />
     <Compile Include="Objects\EqualityComparers\BHoMObjectNameComparer.cs" />

--- a/BHoM_Engine/Query/Geometry.cs
+++ b/BHoM_Engine/Query/Geometry.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Base
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static IGeometry IGeometry(this IBHoMObject obj)
+        public static IGeometry IGeometry(this IObject obj)
         {
             if (obj == null)
                 return null;

--- a/BHoM_Engine/Query/Geometry.cs
+++ b/BHoM_Engine/Query/Geometry.cs
@@ -52,6 +52,9 @@ namespace BH.Engine.Base
                     geometries.Add(geometry);
             }
 
+            if (geometries.Count == 1)
+                return geometries.FirstOrDefault();
+
             return new CompositeGeometry { Elements = geometries.ToList() };
         }
 

--- a/BHoM_Engine/Query/Geometry.cs
+++ b/BHoM_Engine/Query/Geometry.cs
@@ -34,7 +34,7 @@ namespace BH.Engine.Base
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static IGeometry IGeometry(this IObject obj)
+        public static IGeometry IGeometry(this IBHoMObject obj)
         {
             if (obj == null)
                 return null;

--- a/BHoM_Engine/Query/Geometry.cs
+++ b/BHoM_Engine/Query/Geometry.cs
@@ -56,9 +56,9 @@ namespace BH.Engine.Base
             }
 
             if (geometries.Count == 1)
-                return geometries.FirstOrDefault();
+                return geometries[0];
 
-            return new CompositeGeometry { Elements = geometries.ToList() };
+            return new CompositeGeometry { Elements = geometries };
         }
 
 
@@ -82,7 +82,7 @@ namespace BH.Engine.Base
                         geometries.Add(geometry);
                 }
                 if (geometries.Count() > 0)
-                    return new CompositeGeometry { Elements = geometries.ToList() };
+                    return new CompositeGeometry { Elements = geometries };
                 else
                     return null;
             }

--- a/BHoM_Engine/Query/Geometry.cs
+++ b/BHoM_Engine/Query/Geometry.cs
@@ -36,6 +36,9 @@ namespace BH.Engine.Base
 
         public static IGeometry IGeometry(this IBHoMObject obj)
         {
+            if (obj == null)
+                return null;
+
             return Geometry(obj as dynamic);
         }
 

--- a/BHoM_Engine/Query/Geometry3D.cs
+++ b/BHoM_Engine/Query/Geometry3D.cs
@@ -34,8 +34,11 @@ namespace BH.Engine.Base
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static IGeometry IGeometry3D(this IBHoMObject obj)
+        public static IGeometry IGeometry3D(this IObject obj)
         {
+            if (obj == null)
+                return null;
+
             return Geometry3D(obj as dynamic);
         }
 
@@ -51,6 +54,9 @@ namespace BH.Engine.Base
                 if (geometry != null)
                     geometries.Add(geometry);
             }
+
+            if (geometries.Count == 1)
+                return geometries.FirstOrDefault();
 
             return new CompositeGeometry { Elements = geometries.ToList() };
         }

--- a/BHoM_Engine/Query/Geometry3D.cs
+++ b/BHoM_Engine/Query/Geometry3D.cs
@@ -99,7 +99,7 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
-        private static IGeometry Geometry3D(this IBHoMObject obj)
+        private static IGeometry Geometry3D(this IObject obj)
         {
             return Reflection.Compute.RunExtensionMethod(obj, "Geometry3D") as IGeometry;
         }

--- a/BHoM_Engine/Query/Geometry3D.cs
+++ b/BHoM_Engine/Query/Geometry3D.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Base
             CompositeGeometry comp = geom as CompositeGeometry;
 
             if (comp != null && comp.Elements.Count == 1)
-                geom = comp.Elements.FirstOrDefault();
+                geom = comp.Elements[0];
 
             return geom;
         }
@@ -63,9 +63,9 @@ namespace BH.Engine.Base
             }
 
             if (geometries.Count == 1)
-                return geometries.FirstOrDefault();
+                return geometries[0];
 
-            return new CompositeGeometry { Elements = geometries.ToList() };
+            return new CompositeGeometry { Elements = geometries };
         }
 
 
@@ -89,7 +89,7 @@ namespace BH.Engine.Base
                         geometries.Add(geometry);
                 }
                 if (geometries.Count() > 0)
-                    return new CompositeGeometry { Elements = geometries.ToList() };
+                    return new CompositeGeometry { Elements = geometries };
                 else
                     return null;
             }

--- a/BHoM_Engine/Query/Geometry3D.cs
+++ b/BHoM_Engine/Query/Geometry3D.cs
@@ -1,0 +1,98 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Geometry;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Engine.Base
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static IGeometry IGeometry3D(this IBHoMObject obj)
+        {
+            return Geometry3D(obj as dynamic);
+        }
+
+        /***************************************************/
+
+        public static IGeometry Geometry3D(this CustomObject obj)
+        {
+            List<IGeometry> geometries = new List<IGeometry>();
+
+            foreach (object item in obj.CustomData.Values)
+            {
+                IGeometry geometry = item.Geometry3D();
+                if (geometry != null)
+                    geometries.Add(geometry);
+            }
+
+            return new CompositeGeometry { Elements = geometries.ToList() };
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static IGeometry Geometry3D(this object obj)
+        {
+            if (obj is IGeometry)
+                return obj as IGeometry;
+            else if (obj is IBHoMObject)
+                return ((IBHoMObject)obj).IGeometry3D();
+            else if (obj is IEnumerable)
+            {
+                List<IGeometry> geometries = new List<IGeometry>();
+                foreach (object item in (IEnumerable)obj)
+                {
+                    IGeometry geometry = item.Geometry3D();
+                    if (geometry != null)
+                        geometries.Add(geometry);
+                }
+                if (geometries.Count() > 0)
+                    return new CompositeGeometry { Elements = geometries.ToList() };
+                else
+                    return null;
+            }
+            else
+                return null;   
+        }
+
+        /***************************************************/
+
+        private static IGeometry Geometry3D(this IBHoMObject obj)
+        {
+            return Reflection.Compute.RunExtensionMethod(obj, "Geometry3D") as IGeometry;
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/BHoM_Engine/Query/Geometry3D.cs
+++ b/BHoM_Engine/Query/Geometry3D.cs
@@ -39,7 +39,14 @@ namespace BH.Engine.Base
             if (obj == null)
                 return null;
 
-            return Geometry3D(obj as dynamic);
+            IGeometry geom = Geometry3D(obj as dynamic);
+
+            CompositeGeometry comp = geom as CompositeGeometry;
+
+            if (comp != null && comp.Elements.Count == 1)
+                geom = comp.Elements.FirstOrDefault();
+
+            return geom;
         }
 
         /***************************************************/

--- a/Physical_Engine/Physical_Engine.csproj
+++ b/Physical_Engine/Physical_Engine.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Query\ConstructionByName.cs" />
     <Compile Include="Query\BottomCentreline.cs" />
     <Compile Include="Query\BoundingBoxCentreline.cs" />
+    <Compile Include="Query\Geometry3D.cs" />
     <Compile Include="Query\Mass.cs" />
     <Compile Include="Query\TopCentreline.cs" />
     <Compile Include="Query\ExternalPolyline.cs" />

--- a/Physical_Engine/Query/Geometry3D.cs
+++ b/Physical_Engine/Query/Geometry3D.cs
@@ -53,7 +53,7 @@ namespace BH.Engine.Physical
                     line = new Line() { Start = pl.ControlPoints.First(), End = pl.ControlPoints.Last() };
                 }
 
-                if (pl == null  || (pl!= null && pl.ControlPoints.Count() > 2))
+                if (pl == null  || (pl != null && pl.ControlPoints.Count() > 2))
                     BH.Engine.Reflection.Compute.RecordWarning($"Geometry3D for {nameof(IFramingElement)} currently works only if it has its {nameof(IFramingElement.Location)} defined as a {nameof(Line)}. Proceeding by taking Start/End point of the provided {framingElement.Location.GetType().Name}.");
             }
 
@@ -169,4 +169,3 @@ namespace BH.Engine.Physical
         }
     }
 }
-

--- a/Physical_Engine/Query/Geometry3D.cs
+++ b/Physical_Engine/Query/Geometry3D.cs
@@ -39,7 +39,8 @@ namespace BH.Engine.Physical
         /***************************************************/
 
         [Description("Gets the centreline geometry from the framing element")]
-        [Output("CL", "The centre line curve of the framing element")]
+        [Description("Gets the 3d geometry from the framing element")]
+        [Output("3d", "The composite geometry representing the framing element")]
         public static IGeometry Geometry3D(this Beam beam)
         {
             Line line = beam.Location as Line;
@@ -162,5 +163,4 @@ namespace BH.Engine.Physical
         }
     }
 }
-
 

--- a/Physical_Engine/Query/Geometry3D.cs
+++ b/Physical_Engine/Query/Geometry3D.cs
@@ -1,0 +1,200 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Physical.Elements;
+using BH.oM.Geometry;
+using BH.oM.Physical.FramingProperties;
+using BH.oM.Spatial.ShapeProfiles;
+using BH.Engine.Geometry;
+
+namespace BH.Engine.Physical
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Gets the centreline geometry from the framing element")]
+        [Output("CL", "The centre line curve of the framing element")]
+        public static IGeometry Geometry3D(this Beam beam)
+        {
+            Line line = beam.Location as Line;
+
+            if (line == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Geometry3D for {nameof(Beam)} currently works only if it has its {nameof(Beam.Location)} defined as a {nameof(Line)}.");
+                return null;
+            }
+
+            Vector extrusionVec = BH.Engine.Geometry.Create.Vector(line.Start, line.End);
+            ICurve profileToExtrude = null;
+
+            IFramingElementProperty prop = beam.Property;
+
+            BoxProfile bp = prop as BoxProfile;
+            if (bp != null)
+            {
+                bp.Edges
+            }
+
+            if (profileToExtrude == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Geometry3D error: could not gather the profile curve to be extruded for this {nameof(Beam)}.");
+                return null;
+            }
+
+            Extrusion extr = BH.Engine.Geometry.Create.Extrusion(, extrusionVec);
+
+            return extr;
+        }
+
+       
+        public static List<IGeometry> Extrude(this Bar bar)
+        {
+            if (bar.SectionProperty == null || !(bar.SectionProperty is IGeometricalSection))
+                return new List<IGeometry>();
+
+            IProfile profile = (bar.SectionProperty as IGeometricalSection).SectionProfile;
+
+            List<ICurve> secCurves = profile.Edges.ToList();
+
+            Vector tan = bar.Tangent();
+
+            TransformMatrix totalTransform = bar.BarSectionTranformation();
+            if (simple)
+                return ExtrudeSimple(secCurves, totalTransform, tan);
+            else
+                return ExtrudeFullCurves(secCurves, totalTransform, tan);
+
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static List<IGeometry> ExtrudeFullCurves(List<ICurve> sectionCurves, TransformMatrix matrix, Vector tangent)
+        {
+            List<IGeometry> extrusions = new List<IGeometry>();
+
+            List<PolyCurve> joined = BH.Engine.Geometry.Compute.IJoin(sectionCurves);
+
+            for (int i = 0; i < joined.Count; i++)
+            {
+                ICurve curve = joined[i];
+                curve = BH.Engine.Geometry.Modify.ITransform(curve, matrix);
+                extrusions.Add(new Extrusion() { Curve = curve, Direction = tangent });
+            }
+
+            return extrusions;
+        }
+
+
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Constructs the transformation matrix needed to move the profile of an element from the default drawing position (around the global origin) to the start of the Element, aligned with its tangent.")]
+        public static TransformMatrix SectionTranformation(Point startPoint, Vector tangent, Vector normal)
+        {
+            Vector trans = startPoint - Point.Origin;
+
+            Vector gX = Vector.XAxis;
+            Vector gY = Vector.YAxis;
+            Vector gZ = Vector.ZAxis;
+
+            Vector lX = tangent;
+            Vector lZ = normal;
+            Vector lY = lZ.CrossProduct(lX);
+
+            TransformMatrix localToGlobal = new TransformMatrix();
+
+            localToGlobal.Matrix[0, 0] = gX.DotProduct(lX);
+            localToGlobal.Matrix[0, 1] = gX.DotProduct(lY);
+            localToGlobal.Matrix[0, 2] = gX.DotProduct(lZ);
+
+            localToGlobal.Matrix[1, 0] = gY.DotProduct(lX);
+            localToGlobal.Matrix[1, 1] = gY.DotProduct(lY);
+            localToGlobal.Matrix[1, 2] = gY.DotProduct(lZ);
+
+            localToGlobal.Matrix[2, 0] = gZ.DotProduct(lX);
+            localToGlobal.Matrix[2, 1] = gZ.DotProduct(lY);
+            localToGlobal.Matrix[2, 2] = gZ.DotProduct(lZ);
+            localToGlobal.Matrix[3, 3] = 1;
+
+            return Engine.Geometry.Create.TranslationMatrix(trans) * localToGlobal * GlobalToSectionAxes;
+
+
+        }
+
+        /***************************************************/
+        /**** Private Property                          ****/
+        /***************************************************/
+
+
+        private static TransformMatrix GlobalToSectionAxes
+        {
+            get
+            {
+                Vector gX = Vector.XAxis;
+                Vector gY = Vector.YAxis;
+                Vector gZ = Vector.ZAxis;
+
+                //Global system vectors, Sections are drawn in global XY plane with y relating to the normal
+                Vector lX = Vector.ZAxis;
+                Vector lY = Vector.XAxis;
+                Vector lZ = Vector.YAxis;
+
+                TransformMatrix transform = new TransformMatrix();
+
+
+
+                transform.Matrix[0, 0] = lX.DotProduct(gX);
+                transform.Matrix[0, 1] = lX.DotProduct(gY);
+                transform.Matrix[0, 2] = lX.DotProduct(gZ);
+
+                transform.Matrix[1, 0] = lY.DotProduct(gX);
+                transform.Matrix[1, 1] = lY.DotProduct(gY);
+                transform.Matrix[1, 2] = lY.DotProduct(gZ);
+
+                transform.Matrix[2, 0] = lZ.DotProduct(gX);
+                transform.Matrix[2, 1] = lZ.DotProduct(gY);
+                transform.Matrix[2, 2] = lZ.DotProduct(gZ);
+
+                transform.Matrix[3, 3] = 1;
+
+                return transform;
+            }
+        }
+
+        /***************************************************/
+
+    }
+}
+
+

--- a/Physical_Engine/Query/Geometry3D.cs
+++ b/Physical_Engine/Query/Geometry3D.cs
@@ -38,8 +38,8 @@ namespace BH.Engine.Physical
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Gets the centreline geometry from the framing element")]
         [Description("Gets the 3d geometry from the framing element")]
+        [Input("Beam", "The input beam to get the Geometry3D out of, i.e. its extrusion with its cross section along its centreline.")]
         [Output("3d", "The composite geometry representing the framing element")]
         public static IGeometry Geometry3D(this Beam beam)
         {

--- a/Physical_Engine/Query/Geometry3D.cs
+++ b/Physical_Engine/Query/Geometry3D.cs
@@ -71,14 +71,14 @@ namespace BH.Engine.Physical
 
             TransformMatrix totalTransform = SectionTranformation(line.Start, extrusionVec.Normalise(), normal);
 
-            return ExtrudeFullCurves(profileToExtrude, totalTransform, extrusionVec);
+            return Extrude(profileToExtrude, totalTransform, extrusionVec);
         }
 
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static CompositeGeometry ExtrudeFullCurves(List<ICurve> sectionCurves, TransformMatrix matrix, Vector tangent)
+        private static CompositeGeometry Extrude(List<ICurve> sectionCurves, TransformMatrix matrix, Vector tangent)
         {
             List<IGeometry> extrusions = new List<IGeometry>();
 
@@ -125,46 +125,40 @@ namespace BH.Engine.Physical
             localToGlobal.Matrix[2, 2] = gZ.DotProduct(lZ);
             localToGlobal.Matrix[3, 3] = 1;
 
-            return Engine.Geometry.Create.TranslationMatrix(trans) * localToGlobal * GlobalToSectionAxes;
+            return Engine.Geometry.Create.TranslationMatrix(trans) * localToGlobal * GetGlobalToSectionAxes();
         }
 
         /***************************************************/
-        /**** Private Properties                        ****/
-        /***************************************************/
 
-        private static TransformMatrix GlobalToSectionAxes
+        [Description("Returns the transformation matrix that transforms from Global to the Section Axes (around the global origin).")]
+        private static TransformMatrix GetGlobalToSectionAxes()
         {
-            get
-            {
-                Vector gX = Vector.XAxis;
-                Vector gY = Vector.YAxis;
-                Vector gZ = Vector.ZAxis;
+            Vector gX = Vector.XAxis;
+            Vector gY = Vector.YAxis;
+            Vector gZ = Vector.ZAxis;
 
-                //Global system vectors, Sections are drawn in global XY plane with y relating to the normal
-                Vector lX = Vector.ZAxis;
-                Vector lY = Vector.XAxis;
-                Vector lZ = Vector.YAxis;
+            //Global system vectors, Sections are drawn in global XY plane with y relating to the normal
+            Vector lX = Vector.ZAxis;
+            Vector lY = Vector.XAxis;
+            Vector lZ = Vector.YAxis;
 
-                TransformMatrix transform = new TransformMatrix();
+            TransformMatrix transform = new TransformMatrix();
 
+            transform.Matrix[0, 0] = lX.DotProduct(gX);
+            transform.Matrix[0, 1] = lX.DotProduct(gY);
+            transform.Matrix[0, 2] = lX.DotProduct(gZ);
 
+            transform.Matrix[1, 0] = lY.DotProduct(gX);
+            transform.Matrix[1, 1] = lY.DotProduct(gY);
+            transform.Matrix[1, 2] = lY.DotProduct(gZ);
 
-                transform.Matrix[0, 0] = lX.DotProduct(gX);
-                transform.Matrix[0, 1] = lX.DotProduct(gY);
-                transform.Matrix[0, 2] = lX.DotProduct(gZ);
+            transform.Matrix[2, 0] = lZ.DotProduct(gX);
+            transform.Matrix[2, 1] = lZ.DotProduct(gY);
+            transform.Matrix[2, 2] = lZ.DotProduct(gZ);
 
-                transform.Matrix[1, 0] = lY.DotProduct(gX);
-                transform.Matrix[1, 1] = lY.DotProduct(gY);
-                transform.Matrix[1, 2] = lY.DotProduct(gZ);
+            transform.Matrix[3, 3] = 1;
 
-                transform.Matrix[2, 0] = lZ.DotProduct(gX);
-                transform.Matrix[2, 1] = lZ.DotProduct(gY);
-                transform.Matrix[2, 2] = lZ.DotProduct(gZ);
-
-                transform.Matrix[3, 3] = 1;
-
-                return transform;
-            }
+            return transform;
         }
     }
 }

--- a/Physical_Engine/Query/Geometry3D.cs
+++ b/Physical_Engine/Query/Geometry3D.cs
@@ -47,8 +47,14 @@ namespace BH.Engine.Physical
 
             if (line == null)
             {
-                BH.Engine.Reflection.Compute.RecordError($"Geometry3D for {nameof(IFramingElement)} currently works only if it has its {nameof(IFramingElement.Location)} defined as a {nameof(Line)}.");
-                return null;
+                Polyline pl = framingElement.Location as Polyline;
+                if (pl != null)
+                {
+                    line = new Line() { Start = pl.ControlPoints.First(), End = pl.ControlPoints.Last() };
+                }
+
+                if (pl == null  || (pl!= null && pl.ControlPoints.Count() > 2))
+                    BH.Engine.Reflection.Compute.RecordWarning($"Geometry3D for {nameof(IFramingElement)} currently works only if it has its {nameof(IFramingElement.Location)} defined as a {nameof(Line)}. Proceeding by taking Start/End point of the provided {framingElement.Location.GetType().Name}.");
             }
 
             Vector extrusionVec = BH.Engine.Geometry.Create.Vector(line.Start, line.End);

--- a/Physical_Engine/Query/Geometry3D.cs
+++ b/Physical_Engine/Query/Geometry3D.cs
@@ -39,26 +39,26 @@ namespace BH.Engine.Physical
         /***************************************************/
 
         [Description("Gets the 3d geometry from the framing element")]
-        [Input("Beam", "The input beam to get the Geometry3D out of, i.e. its extrusion with its cross section along its centreline.")]
+        [Input("framingElement", "The input framingElement to get the Geometry3D out of, i.e. its extrusion with its cross section along its centreline.")]
         [Output("3d", "The composite geometry representing the framing element")]
-        public static IGeometry Geometry3D(this Beam beam)
+        public static IGeometry Geometry3D(this IFramingElement framingElement)
         {
-            Line line = beam.Location as Line;
+            Line line = framingElement.Location as Line;
 
             if (line == null)
             {
-                BH.Engine.Reflection.Compute.RecordError($"Geometry3D for {nameof(Beam)} currently works only if it has its {nameof(Beam.Location)} defined as a {nameof(Line)}.");
+                BH.Engine.Reflection.Compute.RecordError($"Geometry3D for {nameof(IFramingElement)} currently works only if it has its {nameof(IFramingElement.Location)} defined as a {nameof(Line)}.");
                 return null;
             }
 
             Vector extrusionVec = BH.Engine.Geometry.Create.Vector(line.Start, line.End);
             Vector normal = line.ElementNormal(0);
-            IFramingElementProperty prop = beam.Property;
+            IFramingElementProperty prop = framingElement.Property;
 
             ConstantFramingProperty constantFramingProperty = prop as ConstantFramingProperty;
             if (constantFramingProperty == null)
             {
-                BH.Engine.Reflection.Compute.RecordError($"Geometry3D for {nameof(Beam)} currently works only if its {nameof(Beam.Property)} is of type {nameof(ConstantFramingProperty)}.");
+                BH.Engine.Reflection.Compute.RecordError($"Geometry3D for {nameof(IFramingElement)} currently works only if its {nameof(IFramingElement.Property)} is of type {nameof(ConstantFramingProperty)}.");
                 return null;
             }
 
@@ -66,7 +66,7 @@ namespace BH.Engine.Physical
 
             if (profileToExtrude == null || !profileToExtrude.Any())
             {
-                BH.Engine.Reflection.Compute.RecordError($"Geometry3D error: could not gather the profile curve to be extruded for this {nameof(Beam)}.");
+                BH.Engine.Reflection.Compute.RecordError($"Geometry3D error: could not gather the profile curve to be extruded for this {framingElement.GetType().Name}.");
                 return null;
             }
 

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -40,13 +40,15 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Gets the BH.oM.Geometry.Extrusion out of the Bar as its Geometry3D.")]
-        public static IGeometry Geometry3D(this Bar bar, bool onlyOutermostExtrusion = true)
+        [Input("bar", "The input Bar to get the Geometry3D out of, i.e.its extrusion with its cross section along its centreline.")]
+        [Input("onlyOuterExtrusion", "If true, and if the cross-section of the Bar is composed by multiple edges (e.g. a Circular Hollow Section), only return the extrusion of the outermost edge.")]
+        public static IGeometry Geometry3D(this Bar bar, bool onlyOuterExtrusion = true)
         {
             // . If the profile is made of two curves (e.g. I section), selects only the outermost.
             IEnumerable<IGeometry> extrusions = bar.Extrude(false);
             Extrusion barOutermostExtrusion = extrusions.OfType<Extrusion>().OrderBy(extr => Engine.Geometry.Query.IArea(extr.Curve)).First();
 
-            if (onlyOutermostExtrusion)
+            if (onlyOuterExtrusion)
                 return barOutermostExtrusion;
             else
                 return new CompositeGeometry() { Elements = extrusions.ToList() };

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Geometry;
+using BH.oM.Structure.Elements;
+using BH.Engine.Structure;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+
+namespace BH.Engine.Structure
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Gets the BH.oM.Geometry.Extrusion out of the Bar as its Geometry3D.")]
+        public static IGeometry Geometry3D(this Bar bar, bool onlyOutermostExtrusion = true)
+        {
+            // . If the profile is made of two curves (e.g. I section), selects only the outermost.
+            IEnumerable<IGeometry> extrusions = bar.Extrude(false);
+            Extrusion barOutermostExtrusion = extrusions.OfType<Extrusion>().OrderBy(extr => Engine.Geometry.Query.IArea(extr.Curve)).First();
+
+            if (onlyOutermostExtrusion)
+                return barOutermostExtrusion;
+            else
+                return new CompositeGeometry() { Elements = extrusions.ToList() };
+        }
+
+        public static IGeometry Geometry3D(this Panel panel, bool onlyCentralSurface = false)
+        {
+            PlanarSurface centralPlanarSurface = Engine.Geometry.Create.PlanarSurface(
+                    Engine.Geometry.Compute.IJoin(panel.ExternalEdges.Select(x => x.Curve).ToList()).FirstOrDefault(),
+                    panel.Openings.SelectMany(x => Engine.Geometry.Compute.IJoin(x.Edges.Select(y => y.Curve).ToList())).Cast<ICurve>().ToList());
+
+            if (onlyCentralSurface)
+                return centralPlanarSurface;
+            else
+            {
+                CompositeGeometry compositeGeometry = new CompositeGeometry();
+
+                double thickness = panel.Property.IAverageThickness();
+                Vector translateVect = new Vector() { Z = -thickness / 2 };
+                Vector extrudeVect = new Vector() { Z = thickness };
+
+                Vector upHalf = new Vector() { X = 0, Y = 0, Z = thickness / 2 };
+                Vector downHalf = new Vector() { X = 0, Y = 0, Z = -thickness / 2 };
+
+                PlanarSurface topSrf = centralPlanarSurface.ITranslate(upHalf) as PlanarSurface;
+                PlanarSurface botSrf = centralPlanarSurface.ITranslate(downHalf) as PlanarSurface;
+
+                IEnumerable<ICurve> internalEdgesBot = panel.InternalElementCurves().Select(c => c.ITranslate(translateVect));
+                IEnumerable<Extrusion> internalEdgesExtrusions = internalEdgesBot.Select(c => BH.Engine.Geometry.Create.Extrusion(c, extrudeVect));
+
+                IEnumerable<ICurve> externalEdgesBot = panel.ExternalEdges.Select(c => c.Curve.ITranslate(translateVect));
+                IEnumerable<Extrusion> externalEdgesExtrusions = externalEdgesBot.Select(c => BH.Engine.Geometry.Create.Extrusion(c, extrudeVect));
+
+                compositeGeometry.Elements.Add(topSrf);
+                compositeGeometry.Elements.Add(botSrf);
+                compositeGeometry.Elements.AddRange(internalEdgesExtrusions);
+                compositeGeometry.Elements.AddRange(externalEdgesExtrusions);
+
+                return compositeGeometry;
+            }
+        }
+    }
+}
+
+

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -54,6 +54,11 @@ namespace BH.Engine.Structure
                 return new CompositeGeometry() { Elements = extrusions.ToList() };
         }
 
+        /***************************************************/
+
+        [Description("Gets a CompositeGeometry made of the boundary surfaces of the Panel, or only its central Surface.")]
+        [Input("panel", "The input panel to get the Geometry3D out of.")]
+        [Input("onlyCentralSurface", "If true, the returned geometry is only the central (middle) surface of the panel. Otherwise, the whole external solid is returned as a CompositeGeometry of many surfaces.")]
         public static IGeometry Geometry3D(this Panel panel, bool onlyCentralSurface = false)
         {
             PlanarSurface centralPlanarSurface = Engine.Geometry.Create.PlanarSurface(

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Query\Description.cs" />
     <Compile Include="Query\EmbodiedCarbon.cs" />
     <Compile Include="Query\Fixities.cs" />
+    <Compile Include="Query\Geometry3D.cs" />
     <Compile Include="Query\HasAssignedObjectIds.cs" />
     <Compile Include="Query\HasMergeablePropertiesWith.cs" />
     <Compile Include="Query\HasModifiers.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2304 
Closes #2314 
Closes #2315 

<!-- Add short description of what has been fixed -->
Adds the methods `Geometry3D` for objects. The main method `Geometry3D()` is in the base engine and works like the `Geometry()`. The other methods are reached through `RunExtensionMethods`. I have added only one methods for `Physical.Beam` objects. More will be added in later PRs.


### Test files
<!-- Link to test files to validate the proposed changes -->
Build a `Beam` and compute its `Geometry3D`:
![image](https://user-images.githubusercontent.com/6352844/107824648-b92aea80-6d79-11eb-97e4-a9360439ad64.png)

to visualise it, because currently our BHoM Extrusions are not visualised, you need https://github.com/BHoM/TriangleNet_Toolkit/ `RenderMesh()` method.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->