### PR TITLE
Data_Engine: Handling of nested request issues fixed

### DIFF
--- a/Data_Engine/Compute/SplitRequestTreeByType.cs
+++ b/Data_Engine/Compute/SplitRequestTreeByType.cs
@@ -67,8 +67,11 @@ namespace BH.Engine.Data
                 simplified.ExtractTrees(splittingType, extracted, new List<IRequest>());
                 extracted = extracted.Select(x => x.SimplifyRequestTree()).ToList();
 
-                if (simplified.AllRequestsOfType(splittingType).Count == 0)
-                    extracted.Add(simplified.SimplifyRequestTree());
+                if (!(simplified is LogicalNotRequest) || ((LogicalNotRequest)simplified).Request != null)
+                {
+                    if (simplified.AllRequestsOfType(splittingType).Count == 0)
+                        extracted.Add(simplified.SimplifyRequestTree());
+                }
             }
             else
                 extracted.Add(simplified);

--- a/Data_Engine/Compute/SplitRequestTreeByType.cs
+++ b/Data_Engine/Compute/SplitRequestTreeByType.cs
@@ -69,7 +69,7 @@ namespace BH.Engine.Data
 
                 simplified = simplified.SimplifyRequestTree();
                 if (simplified != null)
-                    extracted.Add(simplified.SimplifyRequestTree());
+                    extracted.Add(simplified);
             }
             else
                 extracted.Add(simplified);

--- a/Data_Engine/Compute/SplitRequestTreeByType.cs
+++ b/Data_Engine/Compute/SplitRequestTreeByType.cs
@@ -67,11 +67,9 @@ namespace BH.Engine.Data
                 simplified.ExtractTrees(splittingType, extracted, new List<IRequest>());
                 extracted = extracted.Select(x => x.SimplifyRequestTree()).ToList();
 
-                if (!(simplified is LogicalNotRequest) || ((LogicalNotRequest)simplified).Request != null)
-                {
-                    if (simplified.AllRequestsOfType(splittingType).Count == 0)
-                        extracted.Add(simplified.SimplifyRequestTree());
-                }
+                simplified = simplified.SimplifyRequestTree();
+                if (simplified != null)
+                    extracted.Add(simplified.SimplifyRequestTree());
             }
             else
                 extracted.Add(simplified);

--- a/Data_Engine/Modify/SimplifyRequestTree.cs
+++ b/Data_Engine/Modify/SimplifyRequestTree.cs
@@ -93,12 +93,17 @@ namespace BH.Engine.Data
                                 subRequests.RemoveAt(i);
                             else if (subSub.Count == 1 && !(logical is LogicalNotRequest))
                             {
-                                subRequests.RemoveAt(i);
-
-                                if (subSub[0].GetType() == request.GetType())
-                                    subRequests.InsertRange(i, ((ILogicalRequest)subSub[0]).IRequests());
+                                if (request is LogicalNotRequest)
+                                    ((LogicalNotRequest)request).Request = subSub[0];
                                 else
-                                    subRequests.Insert(i, subSub[0]);
+                                {
+                                    subRequests.RemoveAt(i);
+
+                                    if (subSub[0].GetType() == request.GetType())
+                                        subRequests.InsertRange(i, ((ILogicalRequest)subSub[0]).IRequests());
+                                    else
+                                        subRequests.Insert(i, subSub[0]);
+                                }
                             }
                         }
                     }

--- a/Data_Engine/Query/AllRequestsOfType.cs
+++ b/Data_Engine/Query/AllRequestsOfType.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Data
 
         private static void RequestsOfType(this IRequest request, Type requestType, List<IRequest> instances)
         {
-            Type type = request.GetType();
+            Type type = request?.GetType();
             if (type == requestType)
                 instances.Add(request);
 

--- a/Data_Engine/Query/Requests.cs
+++ b/Data_Engine/Query/Requests.cs
@@ -59,7 +59,11 @@ namespace BH.Engine.Data
 
         public static List<IRequest> Requests(this LogicalNotRequest request)
         {
-            return new List<IRequest> { request.Request };
+            List<IRequest> result = new List<IRequest>();
+            if (request.Request != null)
+                result.Add(request.Request);
+
+            return result;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2310

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[This](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FBHoM%5FEngine%2FData%5FEngine%2F%232310%2DNestedRequestIssues%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FBHoM%5FEngine%2FData%5FEngine) is an issue-specific file. However, all other files from [this folder](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F01%5FIssue%2FBHoM%2FBHoM%5FEngine%2FData%5FEngine&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) should still work correctly.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
#### Description:
<!-- Describe your issue here -->
- issues related to handling of nested requests have been fixed:
    - running `AllRequestsOfType` on `LogicalNotRequests` with null child
    - running `SimplifyRequestTree` on `LogicalOrRequest`/`LogicalAndRequest` with a single child nested inside `LogicalNotRequest`
    - running `SplitRequestTreeByType` on `LogicalNotRequest` with a child `IRequest` of the same type as splitting type

### Additional comments
<!-- As required -->