### PR TITLE
Reflection_Engine: Make the RecordEvent(Event) method public

### DIFF
--- a/Reflection_Engine/Compute/RecordEvent.cs
+++ b/Reflection_Engine/Compute/RecordEvent.cs
@@ -45,10 +45,8 @@ namespace BH.Engine.Reflection
         }
 
         /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
 
-        private static bool RecordEvent(Event newEvent)
+        public static bool RecordEvent(Event newEvent)
         {
             string trace = System.Environment.StackTrace;
             newEvent.StackTrace = string.Join("\n", trace.Split('\n').Skip(4).ToArray());

--- a/Reflection_Engine/Query/Events.cs
+++ b/Reflection_Engine/Query/Events.cs
@@ -23,6 +23,7 @@
 using BH.oM.Reflection.Debugging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace BH.Engine.Reflection
@@ -36,7 +37,7 @@ namespace BH.Engine.Reflection
         public static List<Event> AllEvents()
         {
             Log log = Query.DebugLog();
-            return log.AllEvents;
+            return log.AllEvents.ToList();
         }
 
 
@@ -45,7 +46,7 @@ namespace BH.Engine.Reflection
         public static List<Event> CurrentEvents()
         {
             Log log = Query.DebugLog();
-            return log.CurrentEvents;       
+            return log.CurrentEvents.ToList();       
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Provides support to
https://github.com/BHoM/Grasshopper_Toolkit/pull/604
https://github.com/BHoM/BHoM_UI/pull/370
   
### Issues addressed by this PR

Provide changes required for fileName and project code to be saved by analytics. Two things were required here:
- `RecordEvent(Event)` needed to be public to save other types of events (ses code in the BHoM_UI PR for where it is needed)
- Fix a by where the private list of events was passed by the `CurrentEvents` method instead of a copy (see code in the Grashopper PR for where it is needed).


### Test files
Will be tested alongside the [BHoMAnalytics PR](https://github.com/BHoM/BHoMAnalytics_Toolkit/pull/16)

