### PR TITLE
Reflection_Engine: SortExtensionMethods improved to return the most relevant method

### DIFF
--- a/Reflection_Engine/Modify/SortExtensionMethods.cs
+++ b/Reflection_Engine/Modify/SortExtensionMethods.cs
@@ -42,11 +42,7 @@ namespace BH.Engine.Reflection
         [Output("metods", "Sorted methods")]
         public static List<MethodInfo> SortExtensionMethods(this IEnumerable<MethodInfo> methods, Type type)
         {
-            //TODO: Sort methods based on closeness to the type, not just exact vs non exact.
-            //Example A : B and B : C
-            //Then if the type is A and list of methods contain one method with first parameter matching each type, then the list should be
-            //Sorted so that the method with A comes first followed by B and lastly C.
-            return methods.OrderBy(x => x.GetParameters().FirstOrDefault()?.ParameterType == type ? 0 : 1).ToList();
+            return methods.OrderBy(x => methods.Count(y => x.GetParameters()[0].ParameterType.IsAssignableFrom(y.GetParameters()[0].ParameterType))).ToList();
         }
 
         /***************************************************/

--- a/Reflection_Engine/Modify/SortExtensionMethods.cs
+++ b/Reflection_Engine/Modify/SortExtensionMethods.cs
@@ -42,6 +42,7 @@ namespace BH.Engine.Reflection
         [Output("metods", "Sorted methods")]
         public static List<MethodInfo> SortExtensionMethods(this IEnumerable<MethodInfo> methods, Type type)
         {
+            IEnumerable<MethodInfo> typeMethods = methods.Where(x => x.GetParameters()[0].ParameterType.IsAssignableFrom(type));
             return methods.OrderBy(x => methods.Count(y => x.GetParameters()[0].ParameterType.IsAssignableFrom(y.GetParameters()[0].ParameterType))).ToList();
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2326

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4) - the file is a bit lame, but I could not come up with a better example 🙈. I hope the code change will be self-explanatory.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `SortExtensionMethods` improved to return the most relevant method when the type-specific one does not exist

### Additional comments
<!-- As required -->
`type` parameter is now used to filter out the methods that are not relevant at all - possibly it could be removed, based on assumption that the methods are already prefiltered.

I was a bit concerned about the performance of `GetParameters` - I have tested it explicitly and there is less than 1ms difference between 1000 and 10000 calls, ergo it should not be even noticeable.