### PR TITLE
Reflection_Engine: ExtensionMethodToCall isolated from RunExtensionMethod

### DIFF
--- a/Reflection_Engine/Compute/RunExtensionMethod.cs
+++ b/Reflection_Engine/Compute/RunExtensionMethod.cs
@@ -20,15 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using System.Linq;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
-using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
+using System;
+using System.ComponentModel;
+using System.Linq;
 
 namespace BH.Engine.Reflection
 {
@@ -38,14 +33,15 @@ namespace BH.Engine.Reflection
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Runs an extension method accepting a single argument based on a provided object and method name.\n" + 
+        [Description("Runs an extension method accepting a single argument based on a provided object and method name.\n" +
                      "Finds the method via reflection the first time it is run, thean compiles it to a function and stores it for subsequent calls.")]
         [Input("target", "The object to find and run the extension method for.")]
         [Input("methodName", "The name of the method to be run.")]
         [Output("result", "The result of the method execution. If no method was found, null is returned.")]
         public static object RunExtensionMethod(object target, string methodName)
         {
-            return RunExtensionMethod(methodName, new object[] { target });
+            Func<object[], object> method = Query.ExtensionMethodToCall(target, methodName);
+            return RunExtensionMethod(target, method);
         }
 
         /***************************************************/
@@ -58,117 +54,59 @@ namespace BH.Engine.Reflection
         [Output("result", "The result of the method execution. If no method was found, null is returned.")]
         public static object RunExtensionMethod(object target, string methodName, object[] parameters)
         {
-            return RunExtensionMethod(methodName, new object[] { target }.Concat(parameters).ToArray());
+            Func<object[], object> method = Query.ExtensionMethodToCall(target, methodName, parameters);
+            return RunExtensionMethod(target, method, parameters);
         }
+
+        /***************************************************/
+
+        [Description("Runs given extension method (in a form of compiled function) accepting a single argument.")]
+        [Input("target", "The object to run the extension method on.")]
+        [Input("method", "The method to be run, provided in a form of compiled function.")]
+        [Output("result", "The result of the method execution. If no or invalid method was provided, null is returned.")]
+        public static object RunExtensionMethod(object target, Func<object[], object> method)
+        {
+            return RunExtensionMethod(method, new object[] { target });
+        }
+
+        /***************************************************/
+        
+        [Description("Runs given extension method (in a form of compiled function) accepting multiple arguments.")]
+        [Input("target", "The object to run the extension method on.")]
+        [Input("method", "The method to be run, provided in a form of compiled function.")]
+        [Input("parameters", "The additional arguments of the call to the method, skipping the first argument provided by 'target'.")]
+        [Output("result", "The result of the method execution. If no or invalid method was provided, null is returned.")]
+        public static object RunExtensionMethod(object target, Func<object[], object> method, object[] parameters)
+        {
+            return RunExtensionMethod(method, new object[] { target }.Concat(parameters).ToArray());
+        }
+
 
         /***************************************************/
         /**** Private Methods                           ****/
         /***************************************************/
 
-        [Description("Helper method doing the heavy lifting of RunExtensionMethod. Finds the matching method via reflection, compiles it to a function, stores if for subsequent calls and finally runs it and returns the result.")]
-        [Input("methodName", "The name of the method to be run.")]
-        [Input("parameters", "All parameters of the method.")]
-        [Output("result", "The result of the method execution. If no method was found, null is returned.")]
-        private static object RunExtensionMethod(string methodName, object[] parameters)
+        [Description("Runs the requested function and returns the result.")]
+        private static object RunExtensionMethod(Func<object[], object> method, object[] parameters)
         {
-            if (parameters == null || parameters.Length == 0 || parameters.Any(x => x == null) || string.IsNullOrWhiteSpace(methodName))
+            // Throw an error and return null if method is null
+            if (method == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Failed to run the extension method because it was null.");
                 return null;
-
-            //Get type of first argument, to be used for first method extraction filtering
-            Type type = parameters[0].GetType();
-
-            //Construct key used to store/extract method
-            string name = methodName + parameters.Select(x => x.GetType().ToString()).Aggregate((a, b) => a + b);
-            Tuple<Type, string> key = new Tuple<Type, string>(type, name);
-
-            // If the method has been called before, just use that
-            if (MethodPreviouslyExtracted(key))
-                return GetStoredExtensionMethod(key)?.Invoke(parameters);
-
-            //Loop through all methods with matching name, first argument and number of parameters, sorted by best match to the first argument
-            foreach (MethodInfo method in type.ExtensionMethods(methodName).Where(x => x.GetParameters().Length == parameters.Length).SortExtensionMethods(type))
-            {
-                ParameterInfo[] paramInfo = method.GetParameters();
-
-                // Make sure the type of parameters is matching, skipping first as already used to extract parameters
-                bool matchingTypes = true;
-                for (int i = 1; i < parameters.Length; i++)
-                {
-                    if(!paramInfo[i].ParameterType.IsAssignableFromIncludeGenerics(parameters[i].GetType()))
-                    {
-                        //Parameter does not match, abort for this method
-                        matchingTypes = false;
-                        break;
-                    }
-                }
-
-                if (!matchingTypes)
-                    continue;
-
-                //If method is generic, make sure the appropriate generic arguments are set
-                MethodInfo finalMethod = method.MakeGenericFromInputs(parameters.Select(x => x.GetType()).ToList());
-
-                //Turn the MethodInfo to a compiled function, store it and finally call it
-                try
-                {
-                    Func<object[], object> func = finalMethod.ToFunc();
-                    object result = func(parameters);
-                    StoreExtensionMethod(key, func);
-                    return result;
-                }
-                catch (Exception e)
-                {
-                    BH.Engine.Reflection.Compute.RecordError($"Failed to run extension method {methodName}.\nError: {e.Message}");
-                    return null;
-                }
             }
 
-            //If nothing found, store null, to avoid having to search again in vain
-            StoreExtensionMethod(key, null);
-
-            // Return null if nothing found
-            return null;
-        }
-
-        /***************************************************/
-
-        [Description("Checkes if an entry with the provided key has already been extracted. Put in its own method to simplify the use of locks to provide thread safety.")]
-        private static bool MethodPreviouslyExtracted(Tuple<Type, string> key)
-        {
-            lock (m_RunExtensionMethodLock)
+            // Try calling the method
+            try
             {
-                return m_PreviousInvokedMethods.ContainsKey(key);
+                return method(parameters);
+            }
+            catch (Exception e)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Failed to run the extension method.\nError: {e.Message}");
+                return null;
             }
         }
-
-        /***************************************************/
-
-        [Description("Gets a previously extracted method from the stored methods. Put in its own method to simplify the use of locks to provide thread safety.")]
-        private static Func<object[], object> GetStoredExtensionMethod(Tuple<Type, string> key)
-        {
-            lock (m_RunExtensionMethodLock)
-            {
-                return m_PreviousInvokedMethods[key];
-            }
-        }
-
-        /***************************************************/
-
-        [Description("Stores an extracted method. Put in its own method to simplify the use of locks to provide thread safety.")]
-        private static void StoreExtensionMethod(Tuple<Type, string> key, Func<object[], object> method)
-        {
-            lock (m_RunExtensionMethodLock)
-            {
-                m_PreviousInvokedMethods[key] = method;
-            }
-        }
-
-        /***************************************************/
-        /**** Private fields                            ****/
-        /***************************************************/
-
-        private static ConcurrentDictionary<Tuple<Type, string>, Func<object[], object>> m_PreviousInvokedMethods = new ConcurrentDictionary<Tuple<Type, string>, Func<object[], object>>();
-        private static readonly object m_RunExtensionMethodLock = new object();
 
         /***************************************************/
     }

--- a/Reflection_Engine/Query/ExtensionMethodToCall.cs
+++ b/Reflection_Engine/Query/ExtensionMethodToCall.cs
@@ -1,0 +1,163 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+        
+        [Description("Finds an extension method accepting a multiple argument based on a provided main object and method name.\n" +
+                     "The method is found via reflection at the first time it is queried, then it gets compiled into a function and stored for subsequent calls.")]
+        [Input("target", "First argument of the method to find.")]
+        [Input("methodName", "The name of the method to be sought.")]
+        [Output("method", "Most suitable extension method with requested target, name and parameters. If no method was found, null is returned.")]
+        public static Func<object[], object> ExtensionMethodToCall(object target, string methodName)
+        {
+            return ExtensionMethodToCall(methodName, new object[] { target });
+        }
+
+        /***************************************************/
+
+        [Description("Finds an extension method accepting a multiple argument based on a provided main object and method name and additional arguments.\n" +
+                     "The method is found via reflection at the first time it is queried, then it gets compiled into a function and stored for subsequent calls.")]
+        [Input("target", "First argument of the method to find.")]
+        [Input("methodName", "The name of the method to be sought.")]
+        [Input("parameters", "The additional arguments of the call to the method, skipping the first argument provided by 'target'.")]
+        [Output("method", "Most suitable extension method with requested target, name and parameters. If no method was found, null is returned.")]
+        public static Func<object[], object> ExtensionMethodToCall(object target, string methodName, object[] parameters)
+        {
+            return ExtensionMethodToCall(methodName, new object[] { target }.Concat(parameters).ToArray());
+        }
+
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        [Description("Helper method doing the heavy lifting of ExtensionMethodToCall. Finds the matching method via reflection, compiles it to a function, caches if for subsequent calls.")]
+        private static Func<object[],object> ExtensionMethodToCall(string methodName, object[] parameters)
+        {
+            if (parameters == null || parameters.Length == 0 || parameters.Any(x => x == null) || string.IsNullOrWhiteSpace(methodName))
+                return null;
+            
+            //Get type of first argument, to be used for first method extraction filtering
+            Type type = parameters[0].GetType();
+
+            //Construct key used to store/extract method
+            string name = methodName + parameters.Select(x => x.GetType().ToString()).Aggregate((a, b) => a + b);
+            Tuple<Type, string> key = new Tuple<Type, string>(type, name);
+
+            // If the method has been called before, just use that
+            if (MethodPreviouslyExtracted(key))
+                return GetStoredExtensionMethod(key);
+
+            //Loop through all methods with matching name, first argument and number of parameters, sorted by best match to the first argument
+            foreach (MethodInfo method in type.ExtensionMethods(methodName).Where(x => x.GetParameters().Length == parameters.Length).SortExtensionMethods(type))
+            {
+                ParameterInfo[] paramInfo = method.GetParameters();
+
+                // Make sure the type of parameters is matching, skipping first as already used to extract parameters
+                bool matchingTypes = true;
+                for (int i = 1; i < parameters.Length; i++)
+                {
+                    if (!paramInfo[i].ParameterType.IsAssignableFromIncludeGenerics(parameters[i].GetType()))
+                    {
+                        //Parameter does not match, abort for this method
+                        matchingTypes = false;
+                        break;
+                    }
+                }
+
+                if (!matchingTypes)
+                    continue;
+
+                // If method is generic, make sure the appropriate generic arguments are set
+                MethodInfo finalMethod = method.MakeGenericFromInputs(parameters.Select(x => x.GetType()).ToList());
+                Func<object[], object> func = finalMethod.ToFunc();
+                StoreExtensionMethod(key, func);
+                return func;
+            }
+
+            // If nothing found, store null, to avoid having to search again in vain
+            StoreExtensionMethod(key, null);
+
+            // Return null if nothing found
+            return null;
+        }
+
+        /***************************************************/
+
+        [Description("Checks if an entry with the provided key has already been extracted. Put in its own method to simplify the use of locks to provide thread safety.")]
+        private static bool MethodPreviouslyExtracted(Tuple<Type, string> key)
+        {
+            lock (m_RunExtensionMethodLock)
+            {
+                return m_PreviousInvokedMethods.ContainsKey(key);
+            }
+        }
+
+        /***************************************************/
+
+        [Description("Gets a previously extracted method from the stored methods. Put in its own method to simplify the use of locks to provide thread safety.")]
+        private static Func<object[], object> GetStoredExtensionMethod(Tuple<Type, string> key)
+        {
+            lock (m_RunExtensionMethodLock)
+            {
+                return m_PreviousInvokedMethods[key];
+            }
+        }
+
+        /***************************************************/
+
+        [Description("Stores an extracted method. Put in its own method to simplify the use of locks to provide thread safety.")]
+        private static void StoreExtensionMethod(Tuple<Type, string> key, Func<object[], object> method)
+        {
+            lock (m_RunExtensionMethodLock)
+            {
+                m_PreviousInvokedMethods[key] = method;
+            }
+        }
+
+
+        /***************************************************/
+        /**** Private fields                            ****/
+        /***************************************************/
+
+        private static ConcurrentDictionary<Tuple<Type, string>, Func<object[], object>> m_PreviousInvokedMethods = new ConcurrentDictionary<Tuple<Type, string>, Func<object[], object>>();
+        private static readonly object m_RunExtensionMethodLock = new object();
+
+        /***************************************************/
+    }
+}
+
+

--- a/Reflection_Engine/Query/ExtensionMethodToCall.cs
+++ b/Reflection_Engine/Query/ExtensionMethodToCall.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Reflection
         [Input("target", "First argument of the method to find.")]
         [Input("methodName", "The name of the method to be sought.")]
         [Output("method", "Most suitable extension method with requested target, name and parameters. If no method was found, null is returned.")]
-        public static MethodInfo ExtensionMethodToCall(object target, string methodName)
+        public static MethodInfo ExtensionMethodToCall(this object target, string methodName)
         {
             return ExtensionMethodToCall(methodName, new object[] { target });
         }
@@ -54,7 +54,7 @@ namespace BH.Engine.Reflection
         [Input("methodName", "The name of the method to be sought.")]
         [Input("parameters", "The additional arguments of the call to the method, skipping the first argument provided by 'target'.")]
         [Output("method", "Most suitable extension method with requested target, name and parameters. If no method was found, null is returned.")]
-        public static MethodInfo ExtensionMethodToCall(object target, string methodName, object[] parameters)
+        public static MethodInfo ExtensionMethodToCall(this object target, string methodName, object[] parameters)
         {
             return ExtensionMethodToCall(methodName, new object[] { target }.Concat(parameters).ToArray());
         }
@@ -160,5 +160,4 @@ namespace BH.Engine.Reflection
         /***************************************************/
     }
 }
-
 

--- a/Reflection_Engine/Query/ExtensionMethodToCall.cs
+++ b/Reflection_Engine/Query/ExtensionMethodToCall.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Reflection
         /***************************************************/
         
         [Description("Finds an extension method accepting a multiple argument based on a provided main object and method name.\n" +
-                     "The method is found via reflection at the first time it is queried, then it gets compiled into a function and stored for subsequent calls.")]
+                     "The method is found via reflection at the first time it is queried, then it is stored for subsequent calls.")]
         [Input("target", "First argument of the method to find.")]
         [Input("methodName", "The name of the method to be sought.")]
         [Output("method", "Most suitable extension method with requested target, name and parameters. If no method was found, null is returned.")]
@@ -49,7 +49,7 @@ namespace BH.Engine.Reflection
         /***************************************************/
 
         [Description("Finds an extension method accepting a multiple argument based on a provided main object and method name and additional arguments.\n" +
-                     "The method is found via reflection at the first time it is queried, then it gets compiled into a function and stored for subsequent calls.")]
+                     "The method is found via reflection at the first time it is queried, then it is stored for subsequent calls.")]
         [Input("target", "First argument of the method to find.")]
         [Input("methodName", "The name of the method to be sought.")]
         [Input("parameters", "The additional arguments of the call to the method, skipping the first argument provided by 'target'.")]
@@ -64,7 +64,7 @@ namespace BH.Engine.Reflection
         /**** Private Methods                           ****/
         /***************************************************/
 
-        [Description("Helper method doing the heavy lifting of ExtensionMethodToCall. Finds the matching method via reflection, compiles it to a function, caches if for subsequent calls.")]
+        [Description("Helper method doing the heavy lifting of ExtensionMethodToCall. Finds the matching method via reflection and caches if for subsequent calls.")]
         private static MethodInfo ExtensionMethodToCall(string methodName, object[] parameters)
         {
             if (parameters == null || parameters.Length == 0 || parameters.Any(x => x == null) || string.IsNullOrWhiteSpace(methodName))
@@ -103,6 +103,8 @@ namespace BH.Engine.Reflection
 
                 // If method is generic, make sure the appropriate generic arguments are set
                 MethodInfo finalMethod = method.MakeGenericFromInputs(parameters.Select(x => x.GetType()).ToList());
+
+                // Cache and return the method
                 StoreExtensionMethod(key, finalMethod);
                 return finalMethod;
             }

--- a/Reflection_Engine/Reflection_Engine.csproj
+++ b/Reflection_Engine/Reflection_Engine.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Query\CurrentAssemblyFolder.cs" />
     <Compile Include="Query\BHoMFolder.cs" />
     <Compile Include="Query\EnumValues.cs" />
+    <Compile Include="Query\ExtensionMethodToCall.cs" />
     <Compile Include="Query\GenericTypeConstraint.cs" />
     <Compile Include="Query\ImplementingTypes.cs" />
     <Compile Include="Query\Count.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2328

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine%2F%232331%2DExtensionMethodToCall%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine) - it only proves that the mechanism used up to date still works - the benefits coming from this PR will be tested more explicitly in #2321.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `ExtensionMethodToCall` method isolated from `RunExtensionMethod`

### Additional comments
<!-- As required -->
What I do not like about the solution proposed in this PR is the fact that in case of execution failure the error message is missing the information about the method name. However, `Func<object[], object>` does not carry it any more, and StackOverflow says it would need to be wrapped into `Expression<T>`. Not sure if that is worth the extra complexity added to the code - happy to hear others' opinion on that.