### PR TITLE
Spatial_Engine, Structure_Engine: OrientationAngleBar migrated to Spatial_Engine and renamed to OrientationAngleLinear

### DIFF
--- a/Spatial_Engine/Compute/OrientationAngleLinear.cs
+++ b/Spatial_Engine/Compute/OrientationAngleLinear.cs
@@ -1,0 +1,87 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Geometry;
+using BH.oM.Base;
+using BH.Engine.Geometry;
+
+namespace BH.Engine.Spatial
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [PreviousVersion("4.1", "BH.Engine.Structure.Compute.OrientationAngleBar(BH.oM.Geometry.Vector, BH.oM.Geometry.Line)")]
+        [Description("Calculates the orientation angle of a linear element based on a normal vector and a centreline.")]
+        [Input("normal", "Vector to be used as normal of the linear element. This vector should generally be orthogonal to the element, if it is not, it will be made orthogonal by projecting it to the section plane of the element (a plane that has that element tangent as its normal). This means that the Normal cannot be paralell to the Tangent of the element. \n" +
+                         "Vector will be used to determine the orientation angle of the element. This is done by measuring the counter clockwise angle in the section plane of the element between a reference Vector and the provided Vector. For a non-vertical element, the reference vector will be the global Z-axis. For a vertical element the reference vector will be a vector that is orthogonal to the tangent vector of the element and the global Y-axis.")]
+        [Input("centreline", "Geometrical Line, centreline of the linear element.")]
+        [Output("orientationAngle", "The calculated orientation angle of the linear element based on the provided geometry and normal. Will return NaN if the orientation can not be calculated.")]
+        public static double OrientationAngleLinear(this Vector normal, Line centreline)
+        {
+            double orientationAngle;
+
+            if (normal == null)
+                orientationAngle = 0;
+            else
+            {
+                normal = normal.Normalise();
+                Vector tan = (centreline.End - centreline.Start).Normalise();
+
+                double dot = normal.DotProduct(tan);
+
+                if (Math.Abs(1 - dot) < Tolerance.Angle)
+                {
+                    Reflection.Compute.RecordError("The normal is parallel to the centreline of the element. OrientationAngle could not be calcualted.");
+                    return double.NaN;
+                }
+                else if (Math.Abs(dot) > Tolerance.Angle)
+                {
+                    Reflection.Compute.RecordWarning("Normal is not othogonal to the centreline and will get projected.");
+                }
+
+                Vector reference;
+
+                if (!centreline.IsVertical())
+                    reference = Vector.ZAxis;
+                else
+                {
+                    reference = tan.CrossProduct(Vector.YAxis);
+                }
+
+                orientationAngle = reference.Angle(normal, new Plane { Normal = tan });
+            }
+
+            return orientationAngle;
+        }
+
+        /***************************************************/
+    }
+}
+

--- a/Spatial_Engine/Spatial_Engine.csproj
+++ b/Spatial_Engine/Spatial_Engine.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Compute\DistributeOutlines.cs" />
     <Compile Include="Compute\InterpolateProfile.cs" />
     <Compile Include="Compute\MapDomain.cs" />
+    <Compile Include="Compute\OrientationAngleLinear.cs" />
     <Compile Include="Create\DomainTree.cs" />
     <Compile Include="Create\ExplicitCurveLayout.cs" />
     <Compile Include="Create\OffsetCurveLayout.cs" />

--- a/Structure_Engine/Compute/OrientationAngle.cs
+++ b/Structure_Engine/Compute/OrientationAngle.cs
@@ -37,51 +37,6 @@ namespace BH.Engine.Structure
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Calculates the orientation angle of a Bar based on a normal vector and a centreline.")]
-        [Input("normal", "Vector to be used as normal of the Bar. This vector should generally be orthogonal to the Bar, if it is not, it will be made orthogonal by projecting it to the section plane of the Bar (a plane that has that Bar tangent as its normal). This means that the Normal cannot be paralell to the Tangent of the Bar. \n" +
-                         "Vector will be used to determine the orientation angle of the Bar. This is done by measuring the counter clockwise angle in the section plane of the Bar between a reference Vector and the provided Vector. For a non-vertical Bar, the reference vector will be the global Z-axis. For a vertical bar the reference vector will be a vector that is orthogonal to the tangent vector of the Bar and the global Y-axis.")]
-        [Input("centreline", "Geometrical Line, centreline of the Bar.")]
-        [Output("orientationAngle", "The calculated orientation angle of the bar based on the provided geometry and normal. Will return NaN if the orientation can not be calculated.")]
-        public static double OrientationAngleBar(this Vector normal, Line centreline)
-        {
-            double orientationAngle;
-
-            if (normal == null)
-                orientationAngle = 0;
-            else
-            {
-                normal = normal.Normalise();
-                Vector tan = (centreline.End - centreline.Start).Normalise();
-
-                double dot = normal.DotProduct(tan);
-
-                if (Math.Abs(1 - dot) < Tolerance.Angle)
-                {
-                    Reflection.Compute.RecordError("The normal is parallel to the centreline of the Bar. OrientationAngle could not be calcualted.");
-                    return double.NaN;
-                }
-                else if (Math.Abs(dot) > Tolerance.Angle)
-                {
-                    Reflection.Compute.RecordWarning("Normal is not othogonal to the centreline and will get projected.");
-                }
-
-                Vector reference;
-
-                if (!centreline.IsVertical())
-                    reference = Vector.ZAxis;
-                else
-                {
-                    reference = tan.CrossProduct(Vector.YAxis);
-                }
-
-                orientationAngle = reference.Angle(normal, new Plane { Normal = tan });
-            }
-
-            return orientationAngle;
-        }
-
-        /***************************************************/
-
         [Description("Calculates the orientation angle of an area element based on the normal of the element and a provided local X direction.\n" +
                      "The orientation angle is calculated as the angle between local x and a reference vector in the plane of the element, defined by the normal.\n" +
                      "This reference vector is the global X-vector projected to the plane of the element, except for the case were the normal is parallel to the global X-axis." +

--- a/Structure_Engine/Create/Elements/Bar.cs
+++ b/Structure_Engine/Create/Elements/Bar.cs
@@ -28,6 +28,7 @@ using BH.oM.Structure.SectionProperties;
 using BH.oM.Structure.Constraints;
 using BH.Engine.Geometry;
 using BH.Engine.Reflection;
+using BH.Engine.Spatial;
 
 using BH.oM.Reflection.Attributes;
 using BH.oM.Quantities.Attributes;
@@ -77,7 +78,7 @@ namespace BH.Engine.Structure
         [Output("bar", "The created Bar with a centreline matching the provided geometrical Line.")]
         public static Bar Bar(Line line, ISectionProperty sectionProperty = null, Vector normal = null, BarRelease release = null, BarFEAType feaType = BarFEAType.Flexural, string name = "")
         {
-            double orientationAngle = Compute.OrientationAngleBar(normal, line);
+            double orientationAngle = normal.OrientationAngleLinear(line);
 
             if (double.IsNaN(orientationAngle))
                 return null;

--- a/Structure_Engine/Modify/SetNormal.cs
+++ b/Structure_Engine/Modify/SetNormal.cs
@@ -28,6 +28,7 @@ using BH.oM.Reflection.Attributes;
 using BH.oM.Structure.Elements;
 using BH.oM.Geometry;
 using BH.Engine.Base;
+using BH.Engine.Spatial;
 
 namespace BH.Engine.Structure
 {
@@ -44,7 +45,7 @@ namespace BH.Engine.Structure
         [Output("bar", "Bar with updated orientation angle. If the orientation angle could not be calculated, the unchanged bar is returned.")]
         public static Bar SetNormal(this Bar bar, Vector normal)
         {
-            double orientationAngle = Compute.OrientationAngleBar(normal, bar.Centreline());
+            double orientationAngle = normal.OrientationAngleLinear(bar.Centreline());
 
             //Could not calculate the orientation angle. Return the original bar
             if (double.IsNaN(orientationAngle))


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2336

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FSpatial%5FEngine%2F%232337%2DOrientationAngleLinear%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FSpatial%5FEngine) - only versioning is tested, nothing else had changed effectively. Please remember to rebuild Versioning_Toolkit before testing.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `OrientationAngleBar` migrated to Spatial_Engine and renamed to `OrientationAngleLinear`


### Additional comments
<!-- As required -->