### PR TITLE
Reflection_Engine: SortExtensionMethods fixed to work on generics

### DIFF
--- a/Reflection_Engine/Modify/SortExtensionMethods.cs
+++ b/Reflection_Engine/Modify/SortExtensionMethods.cs
@@ -103,7 +103,12 @@ namespace BH.Engine.Reflection
         {
             for (int i = 0; i < hierarchy.Count; i++)
             {
-                if (hierarchy[i].Contains(type))
+                if (!type.IsGenericType)
+                {
+                    if (hierarchy[i].Contains(type))
+                        return i;
+                }
+                else if (hierarchy[i].Any(x => x.IsAssignableFromIncludeGenerics(type)))
                     return i;
             }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2344

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine%2F%232345%2DSortExtensionMethodsOnGenerics%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine) - the results do not matter, the methods should just trigger.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `SortExtensionMethods` fixed to work on generics


### Additional comments
<!-- As required -->
@adecler it would be great if you could prioritise this PR as it breaks quite a few things across the entire engine 😭 

An alternative fix could also be move the -1 level methods to the end of the returned list instead of ruling them out:
https://github.com/BHoM/BHoM_Engine/blob/37622745daa5ae55412d470ace7e14f669564996/Reflection_Engine/Modify/SortExtensionMethods.cs#L47