### PR TITLE
CI/CD: Add test to make sure all methods can work with null inputs

### DIFF
--- a/.ci/code/Engine_Test/Engine_Test.csproj
+++ b/.ci/code/Engine_Test/Engine_Test.csproj
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{216E8DF8-9650-4B3B-8416-959B94BC527C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>BH.Test.Engine</RootNamespace>
+    <AssemblyName>Engine_Test</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\Build\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="BHoM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Reflection_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_Engine.dll</HintPath>
+    </Reference>
+    <Reference Include="Reflection_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Test_Engine">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Test_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Test_oM">
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Test_oM.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Verify\NullChecks.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Helpers\" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)"  "C:\ProgramData\BHoM\Assemblies" /Y</PostBuildEvent>
+  </PropertyGroup>
+</Project>

--- a/.ci/code/Engine_Test/Properties/AssemblyInfo.cs
+++ b/.ci/code/Engine_Test/Properties/AssemblyInfo.cs
@@ -33,4 +33,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.1.0.0")]
+[assembly: AssemblyFileVersion("4.2.0.0")]

--- a/.ci/code/Engine_Test/Properties/AssemblyInfo.cs
+++ b/.ci/code/Engine_Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Engine_Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Engine_Test")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("216e8df8-9650-4b3b-8416-959b94bc527c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.1.0.0")]

--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -1,0 +1,152 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Reflection;
+using BH.Engine.Serialiser;
+using BH.Engine.Test;
+using BH.oM.Reflection.Debugging;
+using BH.oM.Test;
+using BH.oM.Test.Results;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace BH.Test.Engine
+{
+    public static partial class Verify
+    {
+        /*************************************/
+        /**** Test Methods                ****/
+        /*************************************/
+
+        public static TestResult NullChecks()
+        {
+            // Ignore because of stack overflow or need to install external libraries
+            List<string> toIgnore = new List<string> { "MachineLearning", "Python", "LifeCycleAssessment.Query.GetEvaluationValue" };
+
+            // Test all the BHoM types available
+            List<MethodInfo> methods = BH.Engine.Reflection.Query.BHoMMethodList()
+                .Where(x => !x.IsDeprecated())
+                .Where(x => !toIgnore.Any(i => $"{x.DeclaringType.Namespace}.{x.DeclaringType.Name}.{x.Name}".Contains(i)))
+                .ToList();
+
+            List<TestResult> results = methods.Select(x => NullChecks(x)).ToList();
+
+            // Generate the result message
+            int errorCount = results.Where(x => x.Status == TestStatus.Error).Count();
+            int warningCount = results.Where(x => x.Status == TestStatus.Warning).Count();
+
+            // Uncomment if you want the results written in a file for convenience
+            //List<string> failingMethods = results.Where(x => x.Status == TestStatus.Error).Select(x => x.Description).ToList();
+            //File.WriteAllLines(@"C:\Temp\MethodsFaillingNullChecks.txt", failingMethods);
+
+            // Returns a summary result 
+            return new TestResult()
+            {
+                ID = "NullChecks",
+                Description = $"All methods are running the necessary null checks: {results.Count} methods available.",
+                Message = $"{errorCount} errors and {warningCount} warnings reported.",
+                Status = results.MostSevereStatus(),
+                Information = results.Where(x => x.Status != TestStatus.Pass).ToList<ITestInformation>(),
+                UTCTime = DateTime.UtcNow,
+            };
+        }
+
+        /*************************************/
+
+        public static TestResult NullChecks(MethodInfo method)
+        {
+            string methodDescription = method.IToText(true);
+
+            // Collect the inputs setting themm to null when relevant
+            object[] inputs = new object[0];
+            try
+            {
+                inputs = method.GetParameters().Select(x => x.ParameterType).Select(t =>
+                {
+                    if (t == typeof(string))
+                        return "";
+                    else if (t.GetInterfaces().Any(x => x.Name == "IEnumerable`1"))
+                    {
+                        Type listType = typeof(List<>).MakeGenericType(new Type[] { t.GetGenericArguments().First() });
+                        return Activator.CreateInstance(listType);
+                    }
+                    if (t.IsValueType) // It is acceptable to consider that lists will not be null
+                        return Activator.CreateInstance(t);
+                    else
+                        return null;
+                }).ToArray();
+            }
+            catch (Exception e)
+            {
+                return new TestResult
+                {
+                    Description = methodDescription,
+                    Status = TestStatus.Warning,
+                    Message = $"Warning: Failed to generate inputs for method {methodDescription}. It will not be tested.",
+                    Information = new List<ITestInformation> { new EventMessage { Message = e.Message, StackTrace = e.StackTrace } }
+                };
+            }
+
+            // Try invoking the method
+            try
+            {
+                method.Invoke(null, inputs);
+            }
+            catch(Exception e)
+            {
+                if (e is TargetInvocationException && e.InnerException != null)
+                    e = e.InnerException;
+
+                if (e is NullReferenceException)
+                {
+                    return new TestResult
+                    {
+                        Description = methodDescription,
+                        Status = TestStatus.Error,
+                        Message = $"Error: A NullReferenceException was received from method {methodDescription}.",
+                    };
+                }
+                else
+                {
+                    return new TestResult
+                    {
+                        Description = methodDescription,
+                        Status = TestStatus.Warning,
+                        Message = $"Warning: Failed to generate test method {methodDescription} for null checks because it thew another type of exception.",
+                        Information = new List<ITestInformation> { new EventMessage { Message = e.Message, StackTrace = e.StackTrace } }
+                    };
+                }
+            }
+
+            // All test objects passed the test
+            return BH.Engine.Test.Create.PassResult(methodDescription);
+        }
+
+        /*************************************/
+    }
+}

--- a/.ci/code/Serialiser_Test/Properties/AssemblyInfo.cs
+++ b/.ci/code/Serialiser_Test/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Serialiser_Test")]
-[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyCopyright("Copyright © https://github.com/BHoM")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/.ci/code/Verification.sln
+++ b/.ci/code/Verification.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 15.0.28307.1259
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serialiser_Test", "Serialiser_Test\Serialiser_Test.csproj", "{92F35A76-1A04-4194-9249-D459460DE328}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine_Test", "Engine_Test\Engine_Test.csproj", "{216E8DF8-9650-4B3B-8416-959B94BC527C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{92F35A76-1A04-4194-9249-D459460DE328}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{92F35A76-1A04-4194-9249-D459460DE328}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{92F35A76-1A04-4194-9249-D459460DE328}.Release|Any CPU.Build.0 = Release|Any CPU
+		{216E8DF8-9650-4B3B-8416-959B94BC527C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{216E8DF8-9650-4B3B-8416-959B94BC527C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{216E8DF8-9650-4B3B-8416-959B94BC527C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{216E8DF8-9650-4B3B-8416-959B94BC527C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2335

Note that I have considered, for now, that it is acceptable to assume that strings and Lists will be at worst empty, never null.
This is because the UI can be used as a safe-guard on those two. That doesn't obviously protect against internal calls that could provide a null for those,. But I think we can start by focussing on the null objects given how many methods are failing even that right now (1729).


### Test files
Run `./TestRunner NullChecks`. 
The full result is exceeding the content of the command window right now. So I have added a few lines to write to an temp file that you can uncomment.

### Additional comments
- There was a method in `LifeCycleAssessment` that was causing a stack overflow. Since we cannot catch those, I have just added the method to the list of exception for now until it is fixed.
- This is the kind of test where I feel CI/CD should call `NullChecks(MethodInfo method)` and not `NullChecks()` since this is purely a local impact so might then be quite fast to run on each PR since there are only going to be a few methods tested. Otherwise, the test takes a fairly long time.