### PR TITLE
Structure_Engine: Transform methods added for structural elements

### DIFF
--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -1,0 +1,196 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Structure.Elements;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Engine.Structure
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Interface Methods - IElements             ****/
+        /***************************************************/
+
+        [Description("Transforms the Node's position and orientation by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("node", "Node to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Output("transformed", "Modified Node with unchanged properties, but transformed position and orientation.")]
+        public static Node Transform(this Node node, TransformMatrix transform)
+        {
+            if (!transform.IsRigidTransformation())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            Node result = node.GetShallowClone() as Node;
+            result.Position = result.Position.Transform(transform);
+            result.Orientation = result.Orientation.Transform(transform);
+            return result;
+        }
+
+        /***************************************************/
+        
+        [Description("Transforms the Bar's nodes and rotation by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("bar", "Bar to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Output("transformed", "Modified Bar with unchanged properties, but transformed nodes and rotation.")]
+        public static Bar Transform(this Bar bar, TransformMatrix transform)
+        {
+            if (!transform.IsRigidTransformation())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            Bar result = bar.GetShallowClone() as Bar;
+            result.StartNode = result.StartNode.Transform(transform);
+            result.EndNode = result.EndNode.Transform(transform);
+            
+            Vector normalBefore = new Line { Start = bar.StartNode.Position, End = bar.EndNode.Position }.ElementNormal(bar.OrientationAngle);
+            Vector normalAfter = normalBefore.Transform(transform);
+            result.OrientationAngle = normalAfter.OrientationAngleLinear(new Line { Start = result.StartNode.Position, End = result.EndNode.Position });
+
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the RigidLink's primary and secondary nodes by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("link", "RigidLink to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Output("transformed", "Modified RigidLink with unchanged properties, but transformed primary and secondary nodes.")]
+        public static RigidLink Transform(this RigidLink link, TransformMatrix transform)
+        {
+            if (!transform.IsRigidTransformation())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            RigidLink result = link.GetShallowClone() as RigidLink;
+            result.PrimaryNode = result.PrimaryNode.Transform(transform);
+            result.SecondaryNodes = result.SecondaryNodes.Select(x => x.Transform(transform)).ToList();
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the Edge's location by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("edge", "Edge to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Output("transformed", "Modified Edge with unchanged properties, but transformed location.")]
+        public static Edge Transform(this Edge edge, TransformMatrix transform)
+        {
+            if (!transform.IsRigidTransformation())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            Edge result = edge.GetShallowClone() as Edge;
+            result.Curve = result.Curve.ITransform(transform);
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the Opening's edges by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("opening", "Opening to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Output("transformed", "Modified Opening with unchanged properties, but transformed edges.")]
+        public static Opening Transform(this Opening opening, TransformMatrix transform)
+        {
+            if (!transform.IsRigidTransformation())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            Opening result = opening.GetShallowClone() as Opening;
+            result.Edges = result.Edges.Select(x => x.Transform(transform)).ToList();
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the Panel's edges, openings and orientation angle by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("panel", "Panel to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Output("transformed", "Modified Panel with unchanged properties, but transformed edges, openings and orientation angle.")]
+        public static Panel Transform(this Panel panel, TransformMatrix transform)
+        {
+            if (!transform.IsRigidTransformation())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            Panel result = panel.GetShallowClone() as Panel;
+            result.ExternalEdges = result.ExternalEdges.Select(x => x.Transform(transform)).ToList();
+            result.Openings = result.Openings.Select(x => x.Transform(transform)).ToList();
+
+            Basis orientation = panel.LocalOrientation().Transform(transform);
+            result.OrientationAngle = orientation.Z.OrientationAngleAreaElement(orientation.X);
+
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the FEMesh's nodes by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("mesh", "FEMesh to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Output("transformed", "Modified FEMesh with unchanged properties, but transformed nodes.")]
+        public static FEMesh Transform(this FEMesh mesh, TransformMatrix transform)
+        {
+            if (!transform.IsRigidTransformation())
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            FEMesh result = mesh.GetShallowClone() as FEMesh;
+            result.Nodes = result.Nodes.Select(x => x.Transform(transform)).ToList();
+
+            List<Basis> orientationsBefore = mesh.LocalOrientations();
+            result.Faces = new List<FEMeshFace>(mesh.Faces);
+            for (int i = 0; i < orientationsBefore.Count; i++)
+            {
+                result.Faces[i] = result.Faces[i].SetLocalOrientation(result, orientationsBefore[i].Transform(transform).X);
+            }
+
+            return result;
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -40,10 +40,11 @@ namespace BH.Engine.Structure
         [Description("Transforms the Node's position and orientation by the transform matrix. Only rigid body transformations are supported.")]
         [Input("node", "Node to transform.")]
         [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
         [Output("transformed", "Modified Node with unchanged properties, but transformed position and orientation.")]
-        public static Node Transform(this Node node, TransformMatrix transform)
+        public static Node Transform(this Node node, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
-            if (!transform.IsRigidTransformation())
+            if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
                 return null;
@@ -60,10 +61,11 @@ namespace BH.Engine.Structure
         [Description("Transforms the Bar's nodes and rotation by the transform matrix. Only rigid body transformations are supported.")]
         [Input("bar", "Bar to transform.")]
         [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
         [Output("transformed", "Modified Bar with unchanged properties, but transformed nodes and rotation.")]
-        public static Bar Transform(this Bar bar, TransformMatrix transform)
+        public static Bar Transform(this Bar bar, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
-            if (!transform.IsRigidTransformation())
+            if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
                 return null;
@@ -85,10 +87,11 @@ namespace BH.Engine.Structure
         [Description("Transforms the RigidLink's primary and secondary nodes by the transform matrix. Only rigid body transformations are supported.")]
         [Input("link", "RigidLink to transform.")]
         [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
         [Output("transformed", "Modified RigidLink with unchanged properties, but transformed primary and secondary nodes.")]
-        public static RigidLink Transform(this RigidLink link, TransformMatrix transform)
+        public static RigidLink Transform(this RigidLink link, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
-            if (!transform.IsRigidTransformation())
+            if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
                 return null;
@@ -105,10 +108,11 @@ namespace BH.Engine.Structure
         [Description("Transforms the Edge's location by the transform matrix. Only rigid body transformations are supported.")]
         [Input("edge", "Edge to transform.")]
         [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
         [Output("transformed", "Modified Edge with unchanged properties, but transformed location.")]
-        public static Edge Transform(this Edge edge, TransformMatrix transform)
+        public static Edge Transform(this Edge edge, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
-            if (!transform.IsRigidTransformation())
+            if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
                 return null;
@@ -124,10 +128,11 @@ namespace BH.Engine.Structure
         [Description("Transforms the Opening's edges by the transform matrix. Only rigid body transformations are supported.")]
         [Input("opening", "Opening to transform.")]
         [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
         [Output("transformed", "Modified Opening with unchanged properties, but transformed edges.")]
-        public static Opening Transform(this Opening opening, TransformMatrix transform)
+        public static Opening Transform(this Opening opening, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
-            if (!transform.IsRigidTransformation())
+            if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
                 return null;
@@ -143,10 +148,11 @@ namespace BH.Engine.Structure
         [Description("Transforms the Panel's edges, openings and orientation angle by the transform matrix. Only rigid body transformations are supported.")]
         [Input("panel", "Panel to transform.")]
         [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
         [Output("transformed", "Modified Panel with unchanged properties, but transformed edges, openings and orientation angle.")]
-        public static Panel Transform(this Panel panel, TransformMatrix transform)
+        public static Panel Transform(this Panel panel, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
-            if (!transform.IsRigidTransformation())
+            if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
                 return null;
@@ -167,10 +173,11 @@ namespace BH.Engine.Structure
         [Description("Transforms the FEMesh's nodes by the transform matrix. Only rigid body transformations are supported.")]
         [Input("mesh", "FEMesh to transform.")]
         [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
         [Output("transformed", "Modified FEMesh with unchanged properties, but transformed nodes.")]
-        public static FEMesh Transform(this FEMesh mesh, TransformMatrix transform)
+        public static FEMesh Transform(this FEMesh mesh, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
-            if (!transform.IsRigidTransformation())
+            if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
                 return null;

--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -58,11 +58,11 @@ namespace BH.Engine.Structure
 
         /***************************************************/
         
-        [Description("Transforms the Bar's nodes and rotation by the transform matrix. Only rigid body transformations are supported.")]
+        [Description("Transforms the Bar's nodes and orientation by the transform matrix. Only rigid body transformations are supported.")]
         [Input("bar", "Bar to transform.")]
         [Input("transform", "Transform matrix.")]
         [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
-        [Output("transformed", "Modified Bar with unchanged properties, but transformed nodes and rotation.")]
+        [Output("transformed", "Modified Bar with unchanged properties, but transformed nodes and orientation.")]
         public static Bar Transform(this Bar bar, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
             if (!transform.IsRigidTransformation(tolerance))

--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.Structure
 
             Node result = node.GetShallowClone() as Node;
             result.Position = result.Position.Transform(transform);
-            result.Orientation = result.Orientation.Transform(transform);
+            result.Orientation = result.Orientation?.Transform(transform);
             return result;
         }
 

--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -72,8 +72,8 @@ namespace BH.Engine.Structure
             }
 
             Bar result = bar.GetShallowClone() as Bar;
-            result.StartNode = result.StartNode.Transform(transform);
-            result.EndNode = result.EndNode.Transform(transform);
+            result.StartNode = result.StartNode.Transform(transform, tolerance);
+            result.EndNode = result.EndNode.Transform(transform, tolerance);
             
             Vector normalBefore = new Line { Start = bar.StartNode.Position, End = bar.EndNode.Position }.ElementNormal(bar.OrientationAngle);
             Vector normalAfter = normalBefore.Transform(transform);
@@ -98,8 +98,8 @@ namespace BH.Engine.Structure
             }
 
             RigidLink result = link.GetShallowClone() as RigidLink;
-            result.PrimaryNode = result.PrimaryNode.Transform(transform);
-            result.SecondaryNodes = result.SecondaryNodes.Select(x => x.Transform(transform)).ToList();
+            result.PrimaryNode = result.PrimaryNode.Transform(transform, tolerance);
+            result.SecondaryNodes = result.SecondaryNodes.Select(x => x.Transform(transform, tolerance)).ToList();
             return result;
         }
 
@@ -139,7 +139,7 @@ namespace BH.Engine.Structure
             }
 
             Opening result = opening.GetShallowClone() as Opening;
-            result.Edges = result.Edges.Select(x => x.Transform(transform)).ToList();
+            result.Edges = result.Edges.Select(x => x.Transform(transform, tolerance)).ToList();
             return result;
         }
 
@@ -159,8 +159,8 @@ namespace BH.Engine.Structure
             }
 
             Panel result = panel.GetShallowClone() as Panel;
-            result.ExternalEdges = result.ExternalEdges.Select(x => x.Transform(transform)).ToList();
-            result.Openings = result.Openings.Select(x => x.Transform(transform)).ToList();
+            result.ExternalEdges = result.ExternalEdges.Select(x => x.Transform(transform, tolerance)).ToList();
+            result.Openings = result.Openings.Select(x => x.Transform(transform, tolerance)).ToList();
 
             Basis orientation = panel.LocalOrientation().Transform(transform);
             result.OrientationAngle = orientation.Z.OrientationAngleAreaElement(orientation.X);
@@ -184,7 +184,7 @@ namespace BH.Engine.Structure
             }
 
             FEMesh result = mesh.GetShallowClone() as FEMesh;
-            result.Nodes = result.Nodes.Select(x => x.Transform(transform)).ToList();
+            result.Nodes = result.Nodes.Select(x => x.Transform(transform, tolerance)).ToList();
 
             List<Basis> orientationsBefore = mesh.LocalOrientations();
             result.Faces = new List<FEMeshFace>(mesh.Faces);
@@ -199,5 +199,4 @@ namespace BH.Engine.Structure
         /***************************************************/
     }
 }
-
 

--- a/Structure_Engine/Structure_Engine.csproj
+++ b/Structure_Engine/Structure_Engine.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Modify\SetMaterial.cs" />
     <Compile Include="Modify\SetNormal.cs" />
     <Compile Include="Modify\SetStructuralFragment.cs" />
+    <Compile Include="Modify\Transform.cs" />
     <Compile Include="Objects\EqualityComparers\CaseNumberComaprer.cs" />
     <Compile Include="Objects\EqualityComparers\Constraint4DOFComparer.cs" />
     <Compile Include="Objects\EqualityComparers\Constraint6DOFComparer.cs" />


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Contributes to resolving #2322

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FStructure%5FEngine%2F%232322%2DTransform%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FStructure%5FEngine). I have disabled the test of FEMeshes because for some weird reason they slow GH down badly even if a completely unrelated part of the script gets modified - I could not come up with an explanation for that, maybe the reviewer will have an idea 😃 However, this is outside of the scope of this PR, because the above issue does not affect the correctness of the results, so please do not be afraid of enabling the disabled part.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Transform` methods added for `Node`, `Bar`, `RigidLink`, `Edge`, `Opening`, `Panel` and `FEMesh`


### Additional comments
<!-- As required -->
I believe this is the most problematic/sensitive of all transform-related PRs so far, so probably worth @IsakNaslundBh's time for a proper review. I hope the provided test files will make the process a bit less painful.