### PR TITLE
Reflection_Engine: Null method message introduced in RunExtensionMethod commented out temporarily

### DIFF
--- a/Reflection_Engine/Compute/RunExtensionMethod.cs
+++ b/Reflection_Engine/Compute/RunExtensionMethod.cs
@@ -96,7 +96,7 @@ namespace BH.Engine.Reflection
             // Throw an error and return null if method is null
             if (method == null)
             {
-                BH.Engine.Reflection.Compute.RecordError($"Failed to run the extension method because it was null.");
+                //BH.Engine.Reflection.Compute.RecordError($"Failed to run the extension method because it was null.");
                 return null;
             }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Temp solution for #2377 as explained in the issue

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine%2F%232378%2DRunExtensionMethodError%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- null method message introduced in RunExtensionMethod commented out temporarily


### Additional comments
<!-- As required -->