### PR TITLE
Data_Engine: Requests method moved to Query class

### DIFF
--- a/Data_Engine/Query/Requests.cs
+++ b/Data_Engine/Query/Requests.cs
@@ -22,17 +22,19 @@
 
 using BH.oM.Data.Collections;
 using BH.oM.Data.Requests;
+using BH.oM.Reflection.Attributes;
 using System;
 using System.Collections.Generic;
 
 namespace BH.Engine.Data
 {
-    public static partial class Modify
+    public static partial class Query
     {
         /***************************************************/
         /****            Interface methods              ****/
         /***************************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.Data.Modify.IRequests(BH.oM.Data.Requests.ILogicalRequest)")]
         public static List<IRequest> IRequests(this ILogicalRequest request)
         {
             return Requests(request as dynamic);
@@ -43,6 +45,7 @@ namespace BH.Engine.Data
         /****              Public methods               ****/
         /***************************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.Data.Modify.Requests(BH.oM.Data.Requests.LogicalAndRequest)")]
         public static List<IRequest> Requests(this LogicalAndRequest request)
         {
             return request.Requests;
@@ -50,6 +53,7 @@ namespace BH.Engine.Data
 
         /***************************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.Data.Modify.Requests(BH.oM.Data.Requests.LogicalOrRequest)")]
         public static List<IRequest> Requests(this LogicalOrRequest request)
         {
             return request.Requests;
@@ -57,6 +61,7 @@ namespace BH.Engine.Data
 
         /***************************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.Data.Modify.Requests(BH.oM.Data.Requests.LogicalNotRequest)")]
         public static List<IRequest> Requests(this LogicalNotRequest request)
         {
             List<IRequest> result = new List<IRequest>();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2332

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Versioning tested [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FData%5FEngine%2FData%5FEngine%2D%232385%2DRequestsInWrongClass%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FData%5FEngine) - please remember about rebuilding Versioning_Toolkit.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Requests` method moved to `Query` class

### Additional comments
<!-- As required -->