### PR TITLE
Geometry_Engine: comment added explaining why IsPlanar returns true if the tolerance is set to it's default value

### DIFF
--- a/Geometry_Engine/Query/IsPlanar.cs
+++ b/Geometry_Engine/Query/IsPlanar.cs
@@ -112,6 +112,7 @@ namespace BH.Engine.Geometry
 
         public static bool IsPlanar(this PlanarSurface surface, double tolerance = Tolerance.Distance)
         {
+            // This is not a bug: PlanarSurface is IImmutable, therefore it is assumed that it is planar within the default tolerance.
             if (tolerance == Tolerance.Distance)
                 return true;
             else


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2356

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
It is a simple comment addition, no test files needed.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->