### PR TITLE
Facade_Engine: Transform methods added

### DIFF
--- a/Facade_Engine/Facade_Engine.csproj
+++ b/Facade_Engine/Facade_Engine.csproj
@@ -62,8 +62,8 @@
     </Reference>
     <Reference Include="Matter_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Matter_Engine.dll</HintPath>
-	  <Private>False</Private>
-	  <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Physical_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_Engine.dll</HintPath>
@@ -109,6 +109,7 @@
     <Compile Include="Compute\AdjacentElements.cs" />
     <Compile Include="Modify\SetOffsetFromFacetoFaceDist.cs" />
     <Compile Include="Modify\OffsetVariable.cs" />
+    <Compile Include="Modify\Transform.cs" />
     <Compile Include="Query\AdjacencyId.cs" />
     <Compile Include="Compute\UniqueAdjacencies.cs" />
     <Compile Include="Create\Elements\Opening.cs" />

--- a/Facade_Engine/Modify/Transform.cs
+++ b/Facade_Engine/Modify/Transform.cs
@@ -1,0 +1,150 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.oM.Facade.Elements;
+using BH.oM.Geometry;
+using BH.oM.Physical.FramingProperties;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Transforms the FrameEdge's location curve and profile orientations by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("edge", "FrameEdge to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
+        [Output("transformed", "Modified FrameEdge with unchanged properties, but transformed location curve and profile orientations.")]
+        public static FrameEdge Transform(this FrameEdge edge, TransformMatrix transform, double tolerance = Tolerance.Distance)
+        {
+            if (!transform.IsRigidTransformation(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            FrameEdge result = edge.GetShallowClone() as FrameEdge;
+            result.Curve = result.Curve.ITransform(transform);
+
+            if (edge.FrameEdgeProperty != null)
+            {
+                if (edge.Curve is Line)
+                {
+                    Line lineBefore = (Line)edge.Curve;
+                    Line lineAfter = (Line)result.Curve;
+
+                    List<ConstantFramingProperty> newProperties = new List<ConstantFramingProperty>();
+                    foreach (ConstantFramingProperty property in edge.FrameEdgeProperty.SectionProperties)
+                    {
+                        ConstantFramingProperty newProperty = property.GetShallowClone() as ConstantFramingProperty;
+                        Vector normalBefore = lineBefore.ElementNormal(property.OrientationAngle);
+                        Vector normalAfter = normalBefore.Transform(transform);
+                        newProperty.OrientationAngle = normalAfter.OrientationAngleLinear(lineAfter);
+                        newProperties.Add(newProperty);
+                    }
+
+                    edge.FrameEdgeProperty.SectionProperties = newProperties;
+                }
+                else if (!edge.Curve.IIsPlanar(tolerance))
+                    BH.Engine.Reflection.Compute.RecordWarning($"The element's location is a nonlinear, nonplanar curve. Correctness of orientation angle after transform could not be ensured in 100%. BHoM_Guid: {edge.BHoM_Guid}");
+            }
+
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the Opening's edges by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("opening", "Opening to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
+        [Output("transformed", "Modified Opening with unchanged properties, but transformed edges.")]
+        public static Opening Transform(this Opening opening, TransformMatrix transform, double tolerance = Tolerance.Distance)
+        {
+            if (!transform.IsRigidTransformation(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            Opening result = opening.GetShallowClone() as Opening;
+            result.Edges = result.Edges.Select(x => x.Transform(transform, tolerance)).ToList();
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the Panel's edges and openings by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("panel", "Panel to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
+        [Output("transformed", "Modified Panel with unchanged properties, but transformed edges and openings.")]
+        public static Panel Transform(this Panel panel, TransformMatrix transform, double tolerance = Tolerance.Distance)
+        {
+            if (!transform.IsRigidTransformation(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            Panel result = panel.GetShallowClone() as Panel;
+            result.ExternalEdges = result.ExternalEdges.Select(x => x.Transform(transform, tolerance)).ToList();
+            result.Openings = result.Openings.Select(x => x.Transform(transform, tolerance)).ToList();
+
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the CurtainWall's edges and openings by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("wall", "CurtainWall to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
+        [Output("transformed", "Modified CurtainWall with unchanged properties, but transformed edges and openings.")]
+        public static CurtainWall Transform(this CurtainWall wall, TransformMatrix transform, double tolerance = Tolerance.Distance)
+        {
+            if (!transform.IsRigidTransformation(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            CurtainWall result = wall.GetShallowClone() as CurtainWall;
+            result.ExternalEdges = result.ExternalEdges.Select(x => x.Transform(transform, tolerance)).ToList();
+            result.Openings = result.Openings.Select(x => x.Transform(transform, tolerance)).ToList();
+
+            return result;
+        }
+
+        /***************************************************/
+    }
+}
+


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Contributes to resolving #2383

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FFacade%5FEngine%2F%232383%2DTransform) - a trick with a cluster converting `FrameEdge` to `Bar` has been used to validate the results.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Transform` methods added for facade elements: `FrameEdge`, `Opening`, `Panel` and `CurtainWall`


### Additional comments
<!-- As required -->