### PR TITLE
Humans_Engine: Add previous version attribute to CvalueAnalysis

### DIFF
--- a/Humans_Engine/Query/CvalueAnalysis.cs
+++ b/Humans_Engine/Query/CvalueAnalysis.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Humans.ViewQuality
         /***************************************************/
 
         [PreviousVersion("4.1", "BH.Engine.Humans.ViewQuality.Query.CvalueAnalysis(BH.oM.Humans.ViewQuality.Audience, BH.oM.Humans.ViewQuality.CvalueSettings, BH.oM.Geometry.Polyline)")]
-        [Description("Evaluate Cvalues for a single Audience")]
+        [Description("Evaluate Cvalues for a single Audience. See the wiki page to understand how Cvalue is calculated. https://github.com/BHoM/documentation/wiki/BHoM-View-quality-conventions")]
         [Input("audience", "Audience to evaluate")]
         [Input("settings", "CvalueSettings to configure the evaluation")]
         [Input("playingArea", "Polyline to be used for defining edge of performance or playing area")]
@@ -53,7 +53,7 @@ namespace BH.Engine.Humans.ViewQuality
         /***************************************************/
 
         [PreviousVersion("4.1", "BH.Engine.Humans.ViewQuality.Query.CvalueAnalysis(System.Collections.Generic.List<BH.oM.Humans.ViewQuality.Audience>, BH.oM.Humans.ViewQuality.CvalueSettings, BH.oM.Geometry.Polyline)")]
-        [Description("Evaluate Cvalues for a List of Audience.")]
+        [Description("Evaluate Cvalues for a List of Audience. See the wiki page to understand how Cvalue is calculated. https://github.com/BHoM/documentation/wiki/BHoM-View-quality-conventions")]
         [Input("audience", "Audience to evaluate.")]
         [Input("settings", "CvalueSettings to configure the evaluation.")]
         [Input("playingArea", "Polyline to be used for defining edge of performance or playing area.")]

--- a/Humans_Engine/Query/CvalueAnalysis.cs
+++ b/Humans_Engine/Query/CvalueAnalysis.cs
@@ -38,6 +38,7 @@ namespace BH.Engine.Humans.ViewQuality
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.Humans.ViewQuality.Query.CvalueAnalysis(BH.oM.Humans.ViewQuality.Audience, BH.oM.Humans.ViewQuality.CvalueSettings, BH.oM.Geometry.Polyline)")]
         [Description("Evaluate Cvalues for a single Audience")]
         [Input("audience", "Audience to evaluate")]
         [Input("settings", "CvalueSettings to configure the evaluation")]
@@ -51,6 +52,7 @@ namespace BH.Engine.Humans.ViewQuality
 
         /***************************************************/
 
+        [PreviousVersion("4.1", "BH.Engine.Humans.ViewQuality.Query.CvalueAnalysis(List<BH.oM.Humans.ViewQuality.Audience>, BH.oM.Humans.ViewQuality.CvalueSettings, BH.oM.Geometry.Polyline)")]
         [Description("Evaluate Cvalues for a List of Audience.")]
         [Input("audience", "Audience to evaluate.")]
         [Input("settings", "CvalueSettings to configure the evaluation.")]

--- a/Humans_Engine/Query/CvalueAnalysis.cs
+++ b/Humans_Engine/Query/CvalueAnalysis.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Humans.ViewQuality
         [Input("settings", "CvalueSettings to configure the evaluation")]
         [Input("playingArea", "Polyline to be used for defining edge of performance or playing area")]
         [Input("focalPoint", "Point defining a single focal point used by all spectators. Used only when CvalueFocalMethodEnum is SinglePoint.")]
-        public static List<Cvalue> CvalueAnalysis(Audience audience, CvalueSettings settings, Polyline playingArea, Point focalPoint = null)
+        public static List<Cvalue> CvalueAnalysis(this Audience audience, CvalueSettings settings, Polyline playingArea, Point focalPoint = null)
         {
             List<Cvalue> results = EvaluateCvalue(audience, settings, playingArea, focalPoint);
             return results;
@@ -58,7 +58,7 @@ namespace BH.Engine.Humans.ViewQuality
         [Input("settings", "CvalueSettings to configure the evaluation.")]
         [Input("playingArea", "Polyline to be used for defining edge of performance or playing area.")]
         [Input("focalPoint", "Point defining a single focal point used by all spectators. Used only when CvalueFocalMethodEnum is SinglePoint.")]
-        public static List<List<Cvalue>> CvalueAnalysis(List<Audience> audience, CvalueSettings settings, Polyline playingArea, Point focalPoint = null)
+        public static List<List<Cvalue>> CvalueAnalysis(this List<Audience> audience, CvalueSettings settings, Polyline playingArea, Point focalPoint = null)
         {
             List<List<Cvalue>> results = new List<List<Cvalue>>();
             foreach (Audience a in audience)

--- a/Humans_Engine/Query/CvalueAnalysis.cs
+++ b/Humans_Engine/Query/CvalueAnalysis.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.Humans.ViewQuality
 
         /***************************************************/
 
-        [PreviousVersion("4.1", "BH.Engine.Humans.ViewQuality.Query.CvalueAnalysis(Sytstem.Collections.Generic.List<BH.oM.Humans.ViewQuality.Audience>, BH.oM.Humans.ViewQuality.CvalueSettings, BH.oM.Geometry.Polyline)")]
+        [PreviousVersion("4.1", "BH.Engine.Humans.ViewQuality.Query.CvalueAnalysis(System.Collections.Generic.List<BH.oM.Humans.ViewQuality.Audience>, BH.oM.Humans.ViewQuality.CvalueSettings, BH.oM.Geometry.Polyline)")]
         [Description("Evaluate Cvalues for a List of Audience.")]
         [Input("audience", "Audience to evaluate.")]
         [Input("settings", "CvalueSettings to configure the evaluation.")]

--- a/Humans_Engine/Query/CvalueAnalysis.cs
+++ b/Humans_Engine/Query/CvalueAnalysis.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.Humans.ViewQuality
 
         /***************************************************/
 
-        [PreviousVersion("4.1", "BH.Engine.Humans.ViewQuality.Query.CvalueAnalysis(List<BH.oM.Humans.ViewQuality.Audience>, BH.oM.Humans.ViewQuality.CvalueSettings, BH.oM.Geometry.Polyline)")]
+        [PreviousVersion("4.1", "BH.Engine.Humans.ViewQuality.Query.CvalueAnalysis(Sytstem.Collections.Generic.List<BH.oM.Humans.ViewQuality.Audience>, BH.oM.Humans.ViewQuality.CvalueSettings, BH.oM.Geometry.Polyline)")]
         [Description("Evaluate Cvalues for a List of Audience.")]
         [Input("audience", "Audience to evaluate.")]
         [Input("settings", "CvalueSettings to configure the evaluation.")]
@@ -282,4 +282,3 @@ namespace BH.Engine.Humans.ViewQuality
         private static CvalueSettings m_CvalueSettings;
     }
 }
-


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM/issues/1221
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->
Property name change versioned for CValueSettings
Previous version attribute for the CValueAnalysis method

Closes #2391 and https://github.com/BHoM/BHoM/issues/1221

<!-- Add short description of what has been fixed -->


### Test files
Old components and old json strings in this [file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Humans_oM/%231221-CvalueVersioning/%231221_cvalueversioning.gh?csf=1&web=1&e=D0d4O0)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->