### PR TITLE
Structure_Engine: Transform stopped from crashing for panels with nurbs edges

### DIFF
--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -158,7 +158,7 @@ namespace BH.Engine.Geometry
         public static Vector Normal(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
             List<ICurve> crvs = new List<ICurve>(curve.ISubParts());
-            if (crvs.Any(x => !(x is Line || x is Arc)))
+            if (crvs.Any(x => !(x is Line || x is Arc || x is Circle)))
             {
                 Reflection.Compute.RecordError("Normal is implemented only for PolyCurves consisting of Lines or Arcs.");
                 return null;
@@ -317,4 +317,3 @@ namespace BH.Engine.Geometry
         /***************************************************/
     }
 }
-

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -157,6 +157,13 @@ namespace BH.Engine.Geometry
         [Output("normal", "Vector normal to the plane of a curve.")]
         public static Vector Normal(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
+            List<ICurve> crvs = new List<ICurve>(curve.ISubParts());
+            if (crvs.Any(x => !(x is Line || x is Arc)))
+            {
+                Reflection.Compute.RecordError("Normal is implemented only for PolyCurves consisting of Lines or Arcs.");
+                return null;
+            }
+
             if (!curve.IsPlanar(tolerance))
             {
                 Reflection.Compute.RecordError("A single normal vector is not unambiguously definable for non-planar curves.");
@@ -169,9 +176,7 @@ namespace BH.Engine.Geometry
             }
             else if (curve.IsSelfIntersecting(tolerance))
                 Reflection.Compute.RecordWarning("Input curve is self-intersecting. Resulting normal vector might be flipped.");
-
-            List<ICurve> crvs = new List<ICurve>(curve.ISubParts());
-
+            
             if (crvs.Count() == 0)
                 return null;
             else if (crvs.Count() == 1)
@@ -190,11 +195,6 @@ namespace BH.Engine.Geometry
                         {
                             points.Add((crv as Arc).PointAtParameter(j * 0.25));
                         }
-                    }
-                    else
-                    {
-                        Reflection.Compute.RecordError("Normal is implemented only for PolyCurves consisting of Lines or Arcs.");
-                        return null;
                     }
                 }
 

--- a/Geometry_Engine/Query/Normal.cs
+++ b/Geometry_Engine/Query/Normal.cs
@@ -158,9 +158,9 @@ namespace BH.Engine.Geometry
         public static Vector Normal(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
             List<ICurve> crvs = new List<ICurve>(curve.ISubParts());
-            if (crvs.Any(x => !(x is Line || x is Arc || x is Circle)))
+            if (crvs.Any(x => x is NurbsCurve))
             {
-                Reflection.Compute.RecordError("Normal is implemented only for PolyCurves consisting of Lines or Arcs.");
+                Reflection.Compute.RecordError("Querying normal from PolyCurves with segments of type NurbsCurve is not supported.");
                 return null;
             }
 

--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -162,8 +162,11 @@ namespace BH.Engine.Structure
             result.ExternalEdges = result.ExternalEdges.Select(x => x.Transform(transform, tolerance)).ToList();
             result.Openings = result.Openings.Select(x => x.Transform(transform, tolerance)).ToList();
 
-            Basis orientation = panel.LocalOrientation().Transform(transform);
-            result.OrientationAngle = orientation.Z.OrientationAngleAreaElement(orientation.X);
+            Basis orientation = panel.LocalOrientation()?.Transform(transform);
+            if (orientation != null)
+                result.OrientationAngle = orientation.Z.OrientationAngleAreaElement(orientation.X);
+            else
+                BH.Engine.Reflection.Compute.RecordWarning("Local orientation of the panel could not be transformed. Please note that the orientation of the resultant panel may be incorrect.");
 
             return result;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2397

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FStructure%5FEngine%2F%232398%2DPanelTransformBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Transform` stopped from crashing for panels with nurbs edges


### Additional comments
<!-- As required -->
Component going red due to the underlaying error looks a bit weird, but at least the method works...