### PR TITLE
Reflection_Engine: InheritedTypes stopped from passing nulls to output

### DIFF
--- a/Reflection_Engine/Query/InheritedTypes.cs
+++ b/Reflection_Engine/Query/InheritedTypes.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Reflection
         {
             List<Type> types = type.GetInterfaces().ToList();
 
-            if (type.BaseType != typeof(object))
+            if (type.BaseType != null && type != typeof(object))
                 types.Add(type.BaseType);
 
             if (onlyBHoM)

--- a/Reflection_Engine/Query/InheritedTypes.cs
+++ b/Reflection_Engine/Query/InheritedTypes.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.Reflection
         {
             List<Type> types = type.GetInterfaces().ToList();
 
-            if (type.BaseType != null && type != typeof(object))
+            if (type.BaseType != null && type.BaseType != typeof(object))
                 types.Add(type.BaseType);
 
             if (onlyBHoM)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2330

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine%2F%232402%2DNullInInheritedTypes%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- InheritedTypes stopped from passing nulls to output

### Additional comments
<!-- As required -->