### PR TITLE
Facade_Engine: Added null FrameEdgeProperty handling and improved warnings and errors

### DIFF
--- a/Facade_Engine/Query/FrameGeometry2D.cs
+++ b/Facade_Engine/Query/FrameGeometry2D.cs
@@ -51,13 +51,12 @@ namespace BH.Engine.Facade
 
         public static IGeometry FrameGeometry2D(this Opening opening)
         {
-            List<ICurve> extCrvs = new List<ICurve>();
             PolyCurve extCrv = opening.Geometry();
             List<double> widths = new List<double>();
 
             if (!extCrv.IsPlanar(Tolerance.Distance))
             {
-                BH.Engine.Reflection.Compute.RecordWarning("This method only works on planar curves. Openings with non-planar curves will be ignored.");
+                BH.Engine.Reflection.Compute.RecordWarning("This method only works on planar curves. Opening " + opening.BHoM_Guid + " has non-planar curves and will be ignored.");
                 return null;
             }
 
@@ -68,10 +67,10 @@ namespace BH.Engine.Facade
                 widths.Add(width*-1);
             }
 
-            if (widths.Max() == 0)
+            if (widths.Min() == 0)
             {
-                BH.Engine.Reflection.Compute.RecordWarning("All frame edges have widths of zero. Returning opening outline.");
-                return extCrv;
+                BH.Engine.Reflection.Compute.RecordWarning("Opening " + opening.BHoM_Guid + " has no 2D frame geometry because frame edges all have widths of zero.");
+                return null;
             }
 
             PolyCurve intCrv = Modify.OffsetVariable(extCrv, widths);

--- a/Facade_Engine/Query/SolidVolume.cs
+++ b/Facade_Engine/Query/SolidVolume.cs
@@ -80,7 +80,7 @@ namespace BH.Engine.Facade
                     
                     foreach (FrameEdge edge in opening.Edges)
                     {
-                        frameVolume = frameVolume + edge.SolidVolume();
+                        frameVolume += edge.SolidVolume();
                     }
                 }
                 else
@@ -108,7 +108,7 @@ namespace BH.Engine.Facade
                 foreach (ConstantFramingProperty prop in props)
                 {
                     double profArea = prop.AverageProfileArea();
-                    totalArea = totalArea + profArea;
+                    totalArea += profArea;
                 }
 
                 frameVolume = frameLength * totalArea;

--- a/Facade_Engine/Query/WidthIntoOpening.cs
+++ b/Facade_Engine/Query/WidthIntoOpening.cs
@@ -48,6 +48,8 @@ namespace BH.Engine.Facade
 
         public static double WidthIntoOpening(this FrameEdgeProperty frameEdgeProp)
         {
+            if (frameEdgeProp == null)
+                return 0;
             Polyline rectGeo = frameEdgeProp.SimpleGeometry();
             BoundingBox bounds = rectGeo.Bounds();
             if (bounds == null)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2403 

Resolved issues with how some engine methods were handling null frame edge properties so that handling is improved and warnings are clearer where applicable.


### Test files
[Test Script and Rhino File](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_Engine/Facade_Engine?csf=1&web=1&e=bu66s8)
(Test by changing one or more of the FrameEdgeProperties assigned to the openings to null / empty)
