### PR TITLE
Physical_Engine: ISurface stopped from failing to transform when their Location is not PlanarSurface

### DIFF
--- a/Physical_Engine/Modify/Transform.cs
+++ b/Physical_Engine/Modify/Transform.cs
@@ -76,6 +76,47 @@ namespace BH.Engine.Physical
         }
 
         /***************************************************/
+
+        [Description("Transforms the IOpening's location by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("opening", "IOpening to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
+        [Output("transformed", "Modified IOpening with unchanged properties, but transformed location.")]
+        public static IOpening Transform(this IOpening opening, TransformMatrix transform, double tolerance = Tolerance.Distance)
+        {
+            if (!transform.IsRigidTransformation(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            IOpening result = opening.GetShallowClone() as IOpening;
+            result.Location = result.Location?.ITransform(transform);
+            return result;
+        }
+
+        /***************************************************/
+
+        [Description("Transforms the ISurface's location and openings by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("panel", "ISurface to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
+        [Output("transformed", "Modified ISurface with unchanged properties, but transformed location and openings.")]
+        public static oM.Physical.Elements.ISurface Transform(this oM.Physical.Elements.ISurface panel, TransformMatrix transform, double tolerance = Tolerance.Distance)
+        {
+            if (!transform.IsRigidTransformation(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            oM.Physical.Elements.ISurface result = panel.GetShallowClone() as oM.Physical.Elements.ISurface;
+            result.Location = result.Location?.ITransform(transform);
+            result.Openings = result.Openings?.Select(x => x?.Transform(transform, tolerance)).ToList();
+            return result;
+        }
+
+        /***************************************************/
     }
 }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2415

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FPhysical%5FEngine%2F%232415%2DTransformPolySurface%2Egh&parent=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FPhysical%5FEngine)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `BH.oM.Physical.Elements.ISurface` stopped from failing to transform when their Location is not `PlanarSurface`

### Additional comments
<!-- As required -->
Hopefully it will be an easy one to review since there were a few similar PRs in the near past. Please note that a wider discussion about the possibility of applying a non-planar surface to an `IElement2D` has been started in https://github.com/BHoM/BHoM/issues/1223 - this PR is a (hopefully) temp fix.