### PR TITLE
BHoM_Engine: Adding null checks on geometry methods

### DIFF
--- a/Analytical_Engine/Query/Geometry.cs
+++ b/Analytical_Engine/Query/Geometry.cs
@@ -155,7 +155,7 @@ namespace BH.Engine.Analytical
         [Output("face", "The geometry of the IFace as geometrical Mesh Face.")]
         public static Face Geometry(this IFace face)
         {
-            if (face == null || face.NodeListIndices == null)
+            if (face?.NodeListIndices == null)
                 return null;
 
             if (face.NodeListIndices.Count < 3)
@@ -232,4 +232,3 @@ namespace BH.Engine.Analytical
         
     }
 }
-

--- a/Analytical_Engine/Query/Geometry.cs
+++ b/Analytical_Engine/Query/Geometry.cs
@@ -155,7 +155,7 @@ namespace BH.Engine.Analytical
         [Output("face", "The geometry of the IFace as geometrical Mesh Face.")]
         public static Face Geometry(this IFace face)
         {
-            if (face == null)
+            if (face == null || face.NodeListIndices == null)
                 return null;
 
             if (face.NodeListIndices.Count < 3)

--- a/Architecture_Engine/Query/Geometry.cs
+++ b/Architecture_Engine/Query/Geometry.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Architecture
 
         public static ICurve Geometry(this Grid grid)
         {
-            return grid.Curve;
+            return grid?.Curve;
         }
 
         /***************************************************/

--- a/Environment_Engine/Query/Geometry.cs
+++ b/Environment_Engine/Query/Geometry.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Environment
         [Output("point", "The geometry of the Node")]
         public static Point Geometry(this Node node)
         {
-            return node.Position;
+            return node?.Position;
         }
 
         /***************************************************/
@@ -51,7 +51,7 @@ namespace BH.Engine.Environment
         [Output("curve", "The geometry of the curve")]
         public static ICurve Geometry(this Edge edge)
         {
-            return edge.Curve;
+            return edge?.Curve;
         }
     }
 }

--- a/Geometry_Engine/Query/Geometry.cs
+++ b/Geometry_Engine/Query/Geometry.cs
@@ -89,7 +89,7 @@ namespace BH.Engine.Geometry
 
         public static ICurve Geometry(this Grid grid)
         {
-            return grid.Curve;
+            return grid?.Curve;
         }
 
 

--- a/MEP_Engine/Query/Geometry.cs
+++ b/MEP_Engine/Query/Geometry.cs
@@ -39,7 +39,10 @@ namespace BH.Engine.MEP
         
         public static IGeometry Geometry(this IFlow flowObj)
         {
-            return new Line { Start = flowObj?.StartPoint, End = flowObj?.EndPoint};
+            if (flowObj?.StartPoint == null || flowObj?.EndPoint == null)
+                return null;
+            else
+                return new Line { Start = flowObj.StartPoint, End = flowObj.EndPoint};
         }
 
         /***************************************************/

--- a/MEP_Engine/Query/Geometry.cs
+++ b/MEP_Engine/Query/Geometry.cs
@@ -39,7 +39,7 @@ namespace BH.Engine.MEP
         
         public static IGeometry Geometry(this IFlow flowObj)
         {
-            return new Line { Start = flowObj.StartPoint, End = flowObj.EndPoint};
+            return new Line { Start = flowObj?.StartPoint, End = flowObj?.EndPoint};
         }
 
         /***************************************************/

--- a/Physical_Engine/Query/Geometry.cs
+++ b/Physical_Engine/Query/Geometry.cs
@@ -49,12 +49,11 @@ namespace BH.Engine.Physical
         [Output("surface", "The defining location surface geometry of the ISurface with its openings represented")]
         public static oM.Geometry.ISurface Geometry(this oM.Physical.Elements.ISurface surface)
         {
-            PlanarSurface planarSurface = surface?.Location as PlanarSurface;
-            if (planarSurface == null)
+            ICurve exBound = (surface?.Location as PlanarSurface)?.ExternalBoundary;
+            if (exBound == null)
                 return null;
 
-            ICurve exBound = planarSurface.ExternalBoundary;
-            List<ICurve> inBound = surface?.Openings?.Select(o => (o?.Location as PlanarSurface)?.ExternalBoundary).ToList();
+            List<ICurve> inBound = surface?.Openings?.Select(o => (o?.Location as PlanarSurface)?.ExternalBoundary).Where(x => x != null).ToList();
             return Engine.Geometry.Create.PlanarSurface(exBound, inBound);
         }
 
@@ -63,5 +62,4 @@ namespace BH.Engine.Physical
 
     }
 }
-
 

--- a/Physical_Engine/Query/Geometry.cs
+++ b/Physical_Engine/Query/Geometry.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.Physical
         [Output("CL", "The centre line curve of the framing element")]
         public static ICurve Geometry(this IFramingElement framingElement)
         {
-            return framingElement.Location;
+            return framingElement?.Location;
         }
 
         /***************************************************/
@@ -49,8 +49,12 @@ namespace BH.Engine.Physical
         [Output("surface", "The defining location surface geometry of the ISurface with its openings represented")]
         public static oM.Geometry.ISurface Geometry(this oM.Physical.Elements.ISurface surface)
         {
-            ICurve exBound = (surface.Location as PlanarSurface).ExternalBoundary;
-            List<ICurve> inBound = surface.Openings.Select(o => (o.Location as PlanarSurface).ExternalBoundary).ToList();
+            PlanarSurface planarSurface = surface?.Location as PlanarSurface;
+            if (planarSurface == null)
+                return null;
+
+            ICurve exBound = planarSurface.ExternalBoundary;
+            List<ICurve> inBound = surface?.Openings?.Select(o => (o?.Location as PlanarSurface)?.ExternalBoundary).ToList();
             return Engine.Geometry.Create.PlanarSurface(exBound, inBound);
         }
 

--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -78,7 +78,7 @@ namespace BH.Engine.Structure
         {
             List<IGeometry> lines = new List<IGeometry>();
 
-            if (link?.SecondaryNodes != null && link?.PrimaryNode != null)
+            if (link?.SecondaryNodes != null && link?.PrimaryNode?.Position != null)
             {
                 foreach (Node sn in link.SecondaryNodes)
                 {
@@ -130,5 +130,4 @@ namespace BH.Engine.Structure
     }
 
 }
-
 

--- a/Structure_Engine/Query/Geometry.cs
+++ b/Structure_Engine/Query/Geometry.cs
@@ -43,6 +43,9 @@ namespace BH.Engine.Structure
         [Output("outlines", "The geometry of the ConcreteSection as its outline and reinforment curves in the global XY.")]
         public static CompositeGeometry Geometry(this ConcreteSection section)
         {
+            if (section?.SectionProfile?.Edges == null)
+                return null;
+
             if (section.SectionProfile.Edges.Count == 0)
                 return null;
 
@@ -60,7 +63,10 @@ namespace BH.Engine.Structure
         [Output("outlines", "The geometry of the GeometricalSection as its outline in the global XY plane.")]
         public static IGeometry Geometry(this IGeometricalSection section)
         {
-            return new CompositeGeometry { Elements = section.SectionProfile.Edges.ToList<IGeometry>() };
+            if (section?.SectionProfile?.Edges == null)
+                return new CompositeGeometry();
+            else
+                return new CompositeGeometry { Elements = section.SectionProfile.Edges.ToList<IGeometry>() };
         }
 
         /***************************************************/
@@ -72,10 +78,15 @@ namespace BH.Engine.Structure
         {
             List<IGeometry> lines = new List<IGeometry>();
 
-            foreach (Node sn in link.SecondaryNodes)
+            if (link?.SecondaryNodes != null && link?.PrimaryNode != null)
             {
-                lines.Add(new Line() { Start = link.PrimaryNode.Position, End = sn.Position });
+                foreach (Node sn in link.SecondaryNodes)
+                {
+                    if (sn?.Position != null)
+                        lines.Add(new Line() { Start = link.PrimaryNode.Position, End = sn.Position });
+                }   
             }
+            
             return new CompositeGeometry() { Elements = lines };
         }
 
@@ -108,7 +119,10 @@ namespace BH.Engine.Structure
         [Deprecated("3.1", "Replaced with method for base interface IGeometricalSection.", typeof(Query), "Geometry(this IGeometricalSection section).")]
         public static IGeometry Geometry(this SteelSection section)
         {
-            return new CompositeGeometry { Elements = section.SectionProfile.Edges.ToList<IGeometry>() };
+            if (section?.SectionProfile?.Edges == null)
+                return new CompositeGeometry();
+            else
+                return new CompositeGeometry { Elements = section.SectionProfile.Edges.ToList<IGeometry>() };
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2417 

Adding the necessary null checks on `Query.Geometry` methods.

the `Query.Geometry(IFace)` method actually records errors on its own. Not sure if we should keep them or not. They make sense for that very specific case so I'm happy either way.


### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Geometry_Engine/%232417-NullChecksForGeometryMethods/GeometryNullChecks.gh?csf=1&web=1&e=ZXKtpw


### Additional comments
@FraserGreenroyd , those changes are purely adding null checks so I assume this is safe to merge (after thorough review of course). But happy to wait if you disagree.