### PR TITLE
Reflection_Engine: Make sure no warning is shown when setting property of a CustomObject

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -115,7 +115,8 @@ namespace BH.Engine.Reflection
             else
             {
                 obj.CustomData[propName] = value;
-                Compute.RecordWarning("The object does not contain any property with the name " + propName + ". The value is being set as custom data.");
+                if (!(obj is CustomObject))
+                    Compute.RecordWarning("The object does not contain any property with the name " + propName + ". The value is being set as custom data.");
             }
 
             return true;


### PR DESCRIPTION

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2418

See issue

