### PR TITLE
Serialiser_Engine: Fix serialisation of Dictionary as top level object

### DIFF
--- a/Serialiser_Engine/Convert/Json.cs
+++ b/Serialiser_Engine/Convert/Json.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Serialiser
             if (obj is string)
                 return "{ \"_t\": \"System.String\", \"_v\": " + BsonExtensionMethods.ToJson<string>(obj as string) + "}";
 
-            if (obj is IEnumerable && !(obj is IObject))
+            if (obj is IEnumerable && !(obj is IObject) && !(obj is IDictionary))
                 return ToJsonArray((obj as IEnumerable).OfType<object>());
 
             var jsonWriterSettings = new JsonWriterSettings { OutputMode = JsonOutputMode.Strict };


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes https://github.com/BHoM/Excel_Toolkit/issues/279

Excel internalised its data by saving the dictionary of internalised objects as json into an hidden sheet.
Unfortunately, some code added to the ToJson method to tackle serialisation of arrays and lists (by checking for `IEnumerable`) modified the serialisation result of Dictionaries. Fortunately, this only affected the serialisation of Dictionaries as top object, not as properties. 

This PR makes sure that dictionaries are not treated as arrays when serialised. Thankfully, the change required was such that it doesn't risk to break anything else.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Serialiser_Engine/Excel%23279-FixSerialisationOfDictionaries?csf=1&web=1&e=J4KAgY

There's two test files in there:
- One Grasshopper file to make sure that top-level dictionaries are always serialising as they should.
- One Excel file to make sure that internalisation is working fine. The two explode tables should give the result below

![image](https://user-images.githubusercontent.com/16853390/112441155-14db9100-8d86-11eb-865e-b9170198eddc.png)

