### PR TITLE
Versioning_Engine: Add BHoM version in serialisation

### DIFF
--- a/Serialiser_Engine/Compute/RegisterClassMap.cs
+++ b/Serialiser_Engine/Compute/RegisterClassMap.cs
@@ -54,7 +54,7 @@ namespace BH.Engine.Serialiser
                         cm.AutoMap();
                         cm.SetDiscriminator(type.FullName);
                         cm.SetDiscriminatorIsRequired(true);
-                        cm.SetIgnoreExtraElements(false);   // It would have been nice to use cm.MapExtraElementsProperty("CustomData") but it doesn't work for inherited properties
+                        cm.SetIgnoreExtraElements(true);   // It would have been nice to use cm.MapExtraElementsProperty("CustomData") but it doesn't work for inherited properties
                         cm.SetIdMember(null);
 
                         BsonClassMap.RegisterClassMap(cm);

--- a/Serialiser_Engine/Convert/Bson.cs
+++ b/Serialiser_Engine/Convert/Bson.cs
@@ -81,7 +81,6 @@ namespace BH.Engine.Serialiser
                 return bson["_v"].AsString;
 
             bson.Remove("_id");
-            bson.RemoveVersion();
 
             object obj = BsonSerializer.Deserialize(bson, typeof(object));
             if (obj is ExpandoObject)

--- a/Serialiser_Engine/Objects/BsonSerializers/ColourSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/ColourSerializer.cs
@@ -72,6 +72,10 @@ namespace BH.Engine.Serialiser.BsonSerializers
             int g = context.Reader.ReadInt32();
             int b = context.Reader.ReadInt32();
 
+            string version = "";
+            if (context.Reader.FindElement("_bhomVersion"))
+                version = context.Reader.ReadString();
+
             context.Reader.ReadEndDocument();
 
             return Color.FromArgb(a, r, g, b);

--- a/Serialiser_Engine/Objects/BsonSerializers/CustomObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/CustomObjectSerializer.cs
@@ -123,6 +123,8 @@ namespace BH.Engine.Serialiser.BsonSerializers
                                         dic["CustomData"] = value;
                                 }
                                 break;
+                            case "_bhomVersion":
+                                break;
                             default:
                                 dic[name] = value;
                                 break;

--- a/Serialiser_Engine/Objects/BsonSerializers/DictionarySerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/DictionarySerializer.cs
@@ -108,6 +108,11 @@ namespace BH.Engine.Serialiser.BsonSerializers
                 dic.Add(key, value);
             }
             bsonReader.ReadEndArray();
+
+            string version = "";
+            if (bsonReader.FindElement("_bhomVersion"))
+                version = bsonReader.ReadString();
+
             bsonReader.ReadEndDocument();
 
             return dic;

--- a/Serialiser_Engine/Objects/BsonSerializers/EnumSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/EnumSerializer.cs
@@ -81,6 +81,10 @@ namespace BH.Engine.Serialiser.BsonSerializers
             bsonReader.ReadName();
             string valueName = bsonReader.ReadString();
 
+            string version = "";
+            if (bsonReader.FindElement("_bhomVersion"))
+                version = bsonReader.ReadString();
+
             context.Reader.ReadEndDocument();
 
             try

--- a/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/ObjectSerializer.cs
@@ -291,6 +291,9 @@ namespace BH.Engine.Serialiser.BsonSerializers
             // Handle the general case of finding the correct deserialiser and calling it
             try
             {
+                if (!BsonClassMap.IsClassMapRegistered(actualType))
+                    Compute.RegisterClassMap(actualType); // LookupSerializer creates the classMap if it doesn't exist so important to do it through our own method
+
                 IBsonSerializer bsonSerializer = BsonSerializer.LookupSerializer(actualType);
 
                 if (bsonSerializer.GetType().Name == "EnumerableInterfaceImplementerSerializer`2" && context.Reader.CurrentBsonType == BsonType.Document)

--- a/Versioning_Engine/Modify/AddVersion.cs
+++ b/Versioning_Engine/Modify/AddVersion.cs
@@ -37,8 +37,8 @@ namespace BH.Engine.Versioning
         public static void AddVersion(this BsonDocument document)
         {
             // TODO: Uncomment this code after producing the 4.1 beta
-            /*if (document != null)
-                document["_bhomVersion"] = Reflection.Query.BHoMVersion();*/
+            if (document != null)
+                document["_bhomVersion"] = Reflection.Query.BHoMVersion();
         }
 
         /***************************************************/
@@ -46,11 +46,11 @@ namespace BH.Engine.Versioning
         public static void AddVersion(this IBsonWriter writer)
         {
             // TODO: Uncomment this code after producing the 4.1 beta
-            /*if (writer != null)
+            if (writer != null)
             {
                 writer.WriteName("_bhomVersion");
                 writer.WriteString(Reflection.Query.BHoMVersion());
-            }*/
+            }
         }
 
         /***************************************************/

--- a/Versioning_Engine/Modify/AddVersion.cs
+++ b/Versioning_Engine/Modify/AddVersion.cs
@@ -36,7 +36,6 @@ namespace BH.Engine.Versioning
 
         public static void AddVersion(this BsonDocument document)
         {
-            // TODO: Uncomment this code after producing the 4.1 beta
             if (document != null)
                 document["_bhomVersion"] = Reflection.Query.BHoMVersion();
         }
@@ -45,7 +44,6 @@ namespace BH.Engine.Versioning
 
         public static void AddVersion(this IBsonWriter writer)
         {
-            // TODO: Uncomment this code after producing the 4.1 beta
             if (writer != null)
             {
                 writer.WriteName("_bhomVersion");


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2346

This add the versioning info to each object during serialisation. 

It is important to note that only version 4.1 will be able to open files from version 4.2. We've never had a good support for backward compatibility. So it was already not recommended to open a file from a version more recent than what is installed on your machine since modified objects/methods would likely break. This, however would break every single component for version 4.0 and older trying to open a file from version 4.2. Looking at BHoM analytics, we currently have around 45% of the people using version 4.0 or older.   

Again, this only affects versions 4.0 and older opening files from 4.2 BUT I would not merge this PR until:
- We've properly communicated this change to our user base
- Everyone on this PR approved the change.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Serialiser_Engine/%232346-AddVersionToJson?csf=1&web=1&e=5OxN0P

This file should open and run without problem in version 4.2 and beta 4.1. Beta 4.0 and older would fail on all components

