### PR TITLE
BHoM_Engine: Fix FilterByType

### DIFF
--- a/BHoM_Engine/Query/FilterByType.cs
+++ b/BHoM_Engine/Query/FilterByType.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Base
         [Output("List", "Filtered list containing only objects assignable from the provided type.")]
         public static List<object> FilterByType(this IEnumerable<object> list, Type type)
         {
-            return list.Where(x => x.GetType().IsAssignableFrom(type)).ToList();
+            return list.Where(x => type.IsAssignableFrom(x.GetType())).ToList();
         }
     }
 }


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2237

The `IsAssignableFrom` was used backwards. This PR fixes that.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/BHoM_Engine/%232237-FixFilterByType?csf=1&web=1&e=mFMbIK


