### PR TITLE
Serialisation_Engine: Fix Serialisation of Generics

### DIFF
--- a/Serialiser_Engine/Compute/RegisterClassMap.cs
+++ b/Serialiser_Engine/Compute/RegisterClassMap.cs
@@ -41,15 +41,15 @@ namespace BH.Engine.Serialiser
         {
             if (!BsonClassMap.IsClassMapRegistered(type))
             {
-                if (type.IsEnum)
+                try
                 {
-                    MethodInfo generic = m_CreateEnumSerializer.MakeGenericMethod(type);
-                    generic.Invoke(null, null);
-                }
-                else if (!type.IsGenericType)
-                {
-                    try
+                    if (type.IsEnum)
                     {
+                        MethodInfo generic = m_CreateEnumSerializer.MakeGenericMethod(type);
+                        generic.Invoke(null, null);
+                    }
+                    else if (!type.IsGenericTypeDefinition)
+                    { 
                         BsonClassMap cm = new BsonClassMap(type);
                         cm.AutoMap();
                         cm.SetDiscriminator(type.FullName);
@@ -59,15 +59,15 @@ namespace BH.Engine.Serialiser
 
                         BsonClassMap.RegisterClassMap(cm);
 
+                        BsonSerializer.RegisterDiscriminatorConvention(type, new GenericDiscriminatorConvention()); 
+                    }
+                    else
                         BsonSerializer.RegisterDiscriminatorConvention(type, new GenericDiscriminatorConvention());
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.WriteLine(e.ToString());
-                    }
                 }
-                else
-                    BsonSerializer.RegisterDiscriminatorConvention(type, new GenericDiscriminatorConvention());
+                catch (Exception e)
+                {
+                    Debug.WriteLine(e.ToString());
+                }
             }
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2455 

The changes made in [this PR](https://github.com/BHoM/BHoM_Engine/pull/2453) broke the serialisation of components. When moving the code around, one behaviour was changed: Generic types were trying to add their discriminator conventions every time they were serialised instead of just the first time (since the code for registering types for the first time and on the fly was merged into one). Unfortunately, Mongo throws an exception when you try to do that.

So here's the changes that I have made:
- Only skip the registration of the class map if the type is a generic type definition (e.g. `List<T>`), not just a generic type (e.g. `List<string>`. This should have been done this way from the very beginning so this is an improvement on the original code too. The reason why class maps cannot be created for generic type definitions is because objects cannot be created from them.
- Bring back the try-catch inside `RegisterClassMap` to cover all cases.  After testing, this never gets hit but better safe than sorry.  The obvious way to avoid an exception altogether would have been to check if a discriminator convention is already registered before trying to register a new one. Sadly, There is no way to that. `IsTypeDiscriminated` is for checking if a discriminator (not a discriminator convention) was already registered and `LookupDiscriminatorConvention` adds an arbitrary convention when called if one doesn't exist already.

### Test files
I have run the unit tests on Serialisation and UI. I have also ran the same tests from the UI, just to make sure and all seems to be working fine. The one on serialisation can be run from the PR or the GH version can be found [here](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_Engine/Serialiser_Engine/Serialisation_Engine.gh?csf=1&web=1&e=RAAhT1). The one on the UI is not available yet but the GH can be found [here](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_UI/BHoM_UI_Test.gh?csf=1&web=1&e=6PnBiD). I have also reopened a series of older files from Grasshopper, Excel, and Dynamo to make sure all is back to normal.

It would be great if you could do the same. The most important part though is to open older files to make sure the components are deserialising correctly. Note that Any file you have save yesterday might be broken if you were on the latest installer. 


### Additional comments
I think it is critical to understand how such a critical bug managed to find its way to the master without any of us catching it. As we need to take the necessary action for this to not happen again.   
- the unit tests on serialisation didn't catch the issue because this is only affecting the serialisation of UI component ( a bit long to explain why here) and those are tested in the unit tests for UI. So I would say, two actions are needed here:
   - @FraserGreenroyd , can we have the units test for `ComponentInstantiation` and `ComponentReadWriteCycle` available through the bot ? Might be worth to have them as required tests on critical repos like the BHoM Engine.
   - Add serialisation unit tests to cover the cases that make the serialization of components unique. I'll do that straight away.
- Opening any existing file in any UI would have made the bug obvious. This mean that neither the PR creator nor any reviewer did this during the review process. I find this really hard to believe but I cannot think of any explanation. As I was one of the reviewer, here's what I did during my review process:
   - Initial check by looking at the file changes directly on GitHub to get a better idea of the scope of changes and identify any obvious problem
   - Switch to the branch on my local machine and review the code from Visual studio as the new code is always too hard to go through on GitHub.
   - Run the following tests
       - TestRunner on both Serialisation and UI
       - Equivalent of the TestRunner tests from my Grasshopper test scripts 
       - Re-opened a series of older files from different UIs

The only way that procedure could have failed to catch the bug is if I forgot to recompile the BHoM_Engine or didn't notice that a compilation failed due to a UI being opened. I am pretty OCD with my procedures so I find this very surprising but I cannot find any other explanation so :man_facepalming: me on this one.