### PR TITLE
Reflection_Engine: Add support for setting an enum property from a string

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -90,9 +90,16 @@ namespace BH.Engine.Reflection
                 if (propType.IsEnum && value is string)
                 {
                     string enumName = (value as string).Split('.').Last();
-                    object enumValue = Enum.Parse(propType, enumName);
-                    if (enumValue != null)
-                        value = enumValue;
+                    try
+                    {
+                        object enumValue = Enum.Parse(propType, enumName);
+                        if (enumValue != null)
+                            value = enumValue;
+                    }
+                    catch
+                    {
+                        Engine.Reflection.Compute.RecordError($"An enum of type {propType.ToText(true)} does not have a value of {enumName}");
+                    }   
                 }
 
                 if (propType == typeof(Type) && value is string)

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -102,6 +102,9 @@ namespace BH.Engine.Reflection
                     }
                 }
 
+                if (propType == typeof(Type) && value is string)
+                    value = Create.Type(value as string);
+
                 if (value != null)
                 {
                     if (value.GetType() != propType && value.GetType().GenericTypeArguments.Length > 0 && propType.GenericTypeArguments.Length > 0)

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -26,6 +26,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Reflection;
 
 namespace BH.Engine.Reflection
@@ -88,7 +89,7 @@ namespace BH.Engine.Reflection
 
                 if (propType.IsEnum && value is string)
                 {
-                    string enumName= (value as string).Split('.').Last();
+                    string enumName = (value as string).Split('.').Last();
                     object enumValue = Enum.Parse(propType, enumName);
                     if (enumValue != null)
                         value = enumValue;

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -86,6 +86,22 @@ namespace BH.Engine.Reflection
                         value = Activator.CreateInstance(propType);
                 }
 
+                if (propType.IsEnum && value is string)
+                {
+                    string fullName = value as string;
+                    int index = fullName.LastIndexOf('.');
+                    if (index > 0)
+                    {
+                        Type enumType = Create.Type(fullName.Substring(0, index));
+                        if (enumType != null)
+                        {
+                            object enumValue = Enum.Parse(enumType, fullName.Substring(index + 1));
+                            if (enumValue != null)
+                                value = enumValue;
+                        }
+                    }
+                }
+
                 if (value != null)
                 {
                     if (value.GetType() != propType && value.GetType().GenericTypeArguments.Length > 0 && propType.GenericTypeArguments.Length > 0)

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -88,18 +88,10 @@ namespace BH.Engine.Reflection
 
                 if (propType.IsEnum && value is string)
                 {
-                    string fullName = value as string;
-                    int index = fullName.LastIndexOf('.');
-                    if (index > 0)
-                    {
-                        Type enumType = Create.Type(fullName.Substring(0, index));
-                        if (enumType != null)
-                        {
-                            object enumValue = Enum.Parse(enumType, fullName.Substring(index + 1));
-                            if (enumValue != null)
-                                value = enumValue;
-                        }
-                    }
+                    string enumName= (value as string).Split('.').Last();
+                    object enumValue = Enum.Parse(propType, enumName);
+                    if (enumValue != null)
+                        value = enumValue;
                 }
 
                 if (propType == typeof(Type) && value is string)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Supports
https://github.com/BHoM/Excel_Toolkit/pull/283

   
### Issues addressed by this PR
Provides support for https://github.com/BHoM/Excel_Toolkit/pull/283 although this can be merged separately.
Otherwise as the title said, this enables setting an enum property by providing a string directly instead of an enum of the correct type.


### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Reflection_Engine/ExcelToolkit%23158-SetEnumPropertyWithString.gh?csf=1&web=1&e=lFCcQN

![image](https://user-images.githubusercontent.com/16853390/114808867-b2e9d680-9ddb-11eb-8d41-261540247dda.png)

Although I find testing in Grasshopper easier, you can obviously test this in Excel VBA using something like this:

```vba
Dim bhom As New Excel_UI.Server

Dim obj As New Excel_UI.Object
Call obj.SetType("BH.oM.Acoustic.Rasti")
Call obj.SetProperty("Frequency", "BH.oM.Acoustic.Frequency.Hz125")

Dim objJson As String
objJson = ToJson(obj)
```

