### PR TITLE
MEP_Engine: Fix null handling

### DIFF
--- a/MEP_Engine/Compute/PlumbingFixtureWaterDemandPerDay.cs
+++ b/MEP_Engine/Compute/PlumbingFixtureWaterDemandPerDay.cs
@@ -42,6 +42,24 @@ namespace BH.Engine.MEP
         [Output("waterPerDay", "The amount of water in m^3 used on a daily basis by plumbing fixtures.")]
         public static double PlumbingFixtureWaterDemandPerDay(Occupancy occupancy, IFixtureFlow fixtureFlow, IFixtureUsage fixtureUsage)
         {
+            if(occupancy == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot compute the plumbing fixture water demand from a null occupancy object.");
+                return -1;
+            }
+
+            if(fixtureFlow == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot compute the plumbing fixture water demand from a null fixture flow object.");
+                return -1;
+            }
+
+            if(fixtureUsage == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot compute the plumbing fixture water demand from a null fixture usage object.");
+                return -1;
+            }
+
             double numberFemales = occupancy.OccupantCount * occupancy.FemalePercentage;
             double numberMales = occupancy.OccupantCount * occupancy.MalePercentage;
             double numberGenderNeutral = occupancy.OccupantCount * occupancy.GenderNeutralPercentage;

--- a/MEP_Engine/Create/Elements/CableTraySectionProperty.cs
+++ b/MEP_Engine/Create/Elements/CableTraySectionProperty.cs
@@ -39,8 +39,14 @@ namespace BH.Engine.MEP
         [Input("material", "A base ShapeProfile upon which to base the composite section.")]
         [Input("sectionProfile", "A base ShapeProfile upon which to base the composite section.")]
         [Output("cableTraySectionProperty", "Cable Tray Section property used to provide accurate Cable Tray assembly and capacities.")]
-        public static CableTraySectionProperty CableTraySectionProperty(Material material, SectionProfile sectionProfile = null, string name = "")
+        public static CableTraySectionProperty CableTraySectionProperty(Material material, SectionProfile sectionProfile, string name = "")
         {
+            if(sectionProfile == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create a cable tray section property with a null section profile.");
+                return null;
+            }
+
             double elementSolidArea = sectionProfile.ElementProfile.Area();
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();          
 

--- a/MEP_Engine/Create/Elements/Duct.cs
+++ b/MEP_Engine/Create/Elements/Duct.cs
@@ -41,10 +41,16 @@ namespace BH.Engine.MEP
         [Output("duct", "A duct object is a passageway which conveys material (typically air).")]
         public static Duct Duct(Line line, double flowRate = 0, DuctSectionProperty sectionProperty = null, double orientationAngle = 0)
         {
+            if(line == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create a duct from an empty line.");
+                return null;
+            }
+            
             return new Duct
             {
-                StartPoint = (Point)line.Start,
-                EndPoint = (Point)line.End,
+                StartPoint = line.Start,
+                EndPoint = line.End,
                 SectionProperty = sectionProperty,
                 OrientationAngle = orientationAngle,
             };

--- a/MEP_Engine/Create/Elements/DuctSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/DuctSectionProperty.cs
@@ -42,13 +42,14 @@ namespace BH.Engine.MEP
         [Input("insulationMaterial", "Material properties for the insulation material, or material that wraps the exterior of the Duct object.")]
         [Input("liningMaterial", "Material properties for the lining material that wraps the inside surface of the Duct object. This is the layer that is in direct contact with interior flowing material.")]
         [Output("ductSectionProperty", "Duct Section property used to provide accurate duct assembly and capacities.")]
-        public static DuctSectionProperty DuctSectionProperty(
-            SectionProfile sectionProfile,
-            Material ductMaterial = null,
-            Material insulationMaterial = null,
-            Material liningMaterial = null,
-            string name = "")
+        public static DuctSectionProperty DuctSectionProperty(SectionProfile sectionProfile, Material ductMaterial = null, Material insulationMaterial = null, Material liningMaterial = null, string name = "")
         {
+            if (sectionProfile == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create a duct section property with a null section profile.");
+                return null;
+            }
+
             double elementSolidArea = sectionProfile.ElementProfile.Area();
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
 

--- a/MEP_Engine/Create/Elements/Pipe.cs
+++ b/MEP_Engine/Create/Elements/Pipe.cs
@@ -40,10 +40,16 @@ namespace BH.Engine.MEP
 
         public static BH.oM.MEP.System.Pipe Pipe(Line line, double flowRate = 0, PipeSectionProperty sectionProperty = null)
         {
+            if (line == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create a pipe from an empty line.");
+                return null;
+            }
+
             return new BH.oM.MEP.System.Pipe
             {
-                StartPoint = (Point)line.Start,
-                EndPoint = (Point)line.End,
+                StartPoint = line.Start,
+                EndPoint = line.End,
                 SectionProperty = sectionProperty,
             };
         }

--- a/MEP_Engine/Create/Elements/PipeSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/PipeSectionProperty.cs
@@ -40,12 +40,14 @@ namespace BH.Engine.MEP
         [Input("pipeMaterial", "Material properties for the Pipe object.")]
         [Input("insulationMaterial", "Material properties for the insulation material, or material that wraps the exterior of the Pipe object.")]
         [Output("pipeSectionProperty", "Pipe Section property used to provide accurate pipe assembly and capacities.")]
-        public static PipeSectionProperty PipeSectionProperty(
-            SectionProfile sectionProfile,
-            Material pipeMaterial = null,
-            Material insulationMaterial = null,
-            string name = "")
+        public static PipeSectionProperty PipeSectionProperty(SectionProfile sectionProfile, Material pipeMaterial = null, Material insulationMaterial = null, string name = "")
         {
+            if (sectionProfile == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create a pipe section property with a null section profile.");
+                return null;
+            }
+
             double elementSolidArea = sectionProfile.ElementProfile.Area();
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
 

--- a/MEP_Engine/Create/Elements/WireSectionProperty.cs
+++ b/MEP_Engine/Create/Elements/WireSectionProperty.cs
@@ -40,12 +40,14 @@ namespace BH.Engine.MEP
         [Input("conductiveMaterial", "Material properties for the Wire object.")]
         [Input("insulationMaterial", "Material properties for the insulation material, or material that wraps the exterior of the Wire object.")]
         [Output("wireSectionProperty", "Wire Section property used to provide accurate wire assembly and capacities.")]
-        public static WireSectionProperty WireSectionProperty(
-            SectionProfile sectionProfile,
-            Material conductiveMaterial = null,
-            Material insulationMaterial = null,
-            string name = "")
+        public static WireSectionProperty WireSectionProperty(SectionProfile sectionProfile, Material conductiveMaterial = null, Material insulationMaterial = null, string name = "")
         {
+            if (sectionProfile == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create a wire section property with a null section profile.");
+                return null;
+            }
+
             double elementSolidArea = sectionProfile.ElementProfile.Area();
             double elementVoidArea = sectionProfile.ElementProfile.VoidArea();
 

--- a/MEP_Engine/Create/Elements/WireSegment.cs
+++ b/MEP_Engine/Create/Elements/WireSegment.cs
@@ -40,10 +40,16 @@ namespace BH.Engine.MEP
         [Output("wireSegment", "Wire object to work within an MEP systems.")]
         public static WireSegment WireSegment(Line line, double flowRate = 0, WireSectionProperty sectionProperty = null)
         {
+            if (line == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create a wire segment from an empty line.");
+                return null;
+            }
+
             return new WireSegment
             {
-                StartPoint = (Point)line.Start,
-                EndPoint = (Point)line.End,
+                StartPoint = line.Start,
+                EndPoint = line.End,
                 SectionProperty = sectionProperty,
             };
         }

--- a/MEP_Engine/MEP_Engine.csproj
+++ b/MEP_Engine/MEP_Engine.csproj
@@ -135,7 +135,9 @@
       <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="Versioning_42.json" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>

--- a/MEP_Engine/Query/Centreline.cs
+++ b/MEP_Engine/Query/Centreline.cs
@@ -39,6 +39,12 @@ namespace BH.Engine.MEP
         [Output("centreline", "The centreline of the IFlow object.")]
         public static Line Centreline(this IFlow flowObj)
         {
+            if(flowObj == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the centre line of a null flow object.");
+                return null;
+            }
+
             return new Line { Start = flowObj.StartPoint, End = flowObj.EndPoint };
         }
 

--- a/MEP_Engine/Query/Centreline.cs
+++ b/MEP_Engine/Query/Centreline.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.MEP
         {
             if(flowObj == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the centre line of a null flow object.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the centreline of a null flow object.");
                 return null;
             }
 

--- a/MEP_Engine/Query/CircularEquivalentDiameter.cs
+++ b/MEP_Engine/Query/CircularEquivalentDiameter.cs
@@ -37,21 +37,36 @@ namespace BH.Engine.MEP
         [Output("circularEquivalentDiameter", "Circular Equivalent Diameter for element section profiles that are non-circular, equivalent in length, fluid resistance and airflow.")]
         public static double ICircularEquivalentDiameter(this IProfile profile)
         {
+            if(profile == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the circular equivalent diameter of a null profile.");
+                return -1;
+            }
+
             return CircularEquivalentDiameter(profile as dynamic);
         }
+
         /***************************************************/
+
         [Description("Returns the Circular Equivalent Diameter for elements that are non-circular, equivalent in length, fluid resistance and airflow.")]
         [Input("box", "Box Shape profile to query the Circular Equivalent Diameter.")]
         [Output("circularEquivalentDiameter", "Circular Equivalent Diameter for element section profiles that are non-circular, equivalent in length, fluid resistance and airflow.")]
         public static double CircularEquivalentDiameter(this BoxProfile box)
         {
+            if(box == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the circular equivalent diameter of a null box profile.");
+                return - 1;
+            }
+
             double a = 1000 * (box.Height - 2 * box.Thickness);
             double b = 1000 * (box.Width - 2 * box.Thickness);
             return (1.30 * Math.Pow(a * b, 0.625) / Math.Pow(a + b, 0.250)) / 1000;
         }
+
         /***************************************************/
 
-        public static double CircularEquivalentDiameter(this object profile)
+        private static double CircularEquivalentDiameter(this object profile)
         {
             return 0; //To catch things that are not box profile.
         }

--- a/MEP_Engine/Query/FaceAreaByVelocity.cs
+++ b/MEP_Engine/Query/FaceAreaByVelocity.cs
@@ -38,6 +38,12 @@ namespace BH.Engine.MEP
         [Output("widthlength", "This is the width OR the length (they are the same value), since the method is taking the square root of the airflow divided by the velocity.")]
         public static double FaceAreaByVelocity(this AirHandlingUnit mepEquipmentObject)
         {
+            if(mepEquipmentObject == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the face area by velocity of a null air handling unit object.");
+                return -1;
+            }
+
             return Math.Sqrt(mepEquipmentObject.TotalAirFlow / mepEquipmentObject.AirVelocityAcrossCoil);
         }
     }

--- a/MEP_Engine/Query/HydraulicDiameter.cs
+++ b/MEP_Engine/Query/HydraulicDiameter.cs
@@ -41,6 +41,12 @@ namespace BH.Engine.MEP
         [Output("hydraulicDiameter", "Hydraulic Diameter allows you to calculate the round equivalent hydraulic diameter for a non-round duct (rectangular/square).")]
         public static double HydraulicDiameter(this IProfile profile, double area)
         {
+            if(profile == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the hydraulic diameter of a null profile.");
+                return -1;
+            }
+
             List<List<ICurve>> distCurves = Engine.Geometry.Compute.DistributeOutlines(Engine.Geometry.Compute.IJoin(profile.Edges.ToList()).Cast<ICurve>().ToList());
             List<ICurve> innerProfileEdges = new List<ICurve>();
 

--- a/MEP_Engine/Query/MaterialComposition.cs
+++ b/MEP_Engine/Query/MaterialComposition.cs
@@ -42,6 +42,12 @@ namespace BH.Engine.MEP
         [Output("materialComposition", "The kind of matter the Duct is composed of and in which ratios", typeof(Ratio))]
         public static MaterialComposition MaterialComposition(this Duct duct)
         {
+            if(duct == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the material composition of a null duct.");
+                return null;
+            }
+
             if (duct.SectionProperty == null)
             {
                 Engine.Reflection.Compute.RecordError("The Duct MaterialComposition could not be calculated as no SectionProperty has been assigned.");
@@ -64,6 +70,12 @@ namespace BH.Engine.MEP
         [Output("materialComposition", "The kind of matter the Duct is composed of and in which ratios", typeof(Ratio))]
         public static MaterialComposition MaterialComposition(this Pipe pipe)
         {
+            if(pipe == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the material composition of a null pipe.");
+                return null;
+            }
+
             if (pipe.SectionProperty == null)
             {
                 Engine.Reflection.Compute.RecordError("The Duct MaterialComposition could not be calculated as no SectionProperty has been assigned.");
@@ -86,6 +98,12 @@ namespace BH.Engine.MEP
         [Output("materialComposition", "The kind of matter the Duct is composed of and in which ratios", typeof(Ratio))]
         public static MaterialComposition MaterialComposition(this WireSegment wire)
         {
+            if(wire == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the material composition of a null wire segment.");
+                return null;
+            }
+
             if (wire.SectionProperty == null)
             {
                 Engine.Reflection.Compute.RecordError("The Duct MaterialComposition could not be calculated as no SectionProperty has been assigned.");
@@ -108,6 +126,12 @@ namespace BH.Engine.MEP
         [Output("materialComposition", "The kind of matter the Duct is composed of and in which ratios", typeof(Ratio))]
         public static MaterialComposition MaterialComposition(this CableTray cableTray)
         {
+            if(cableTray == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the material composition of a null cable tray.");
+                return null;
+            }
+
             if (cableTray.SectionProperty == null)
             {
                 Engine.Reflection.Compute.RecordError("The Duct MaterialComposition could not be calculated as no SectionProperty has been assigned.");

--- a/MEP_Engine/Versioning_42.json
+++ b/MEP_Engine/Versioning_42.json
@@ -1,0 +1,38 @@
+{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Method": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "Property": {
+    "ToNew": {
+
+    },
+    "ToOld": {
+
+    }
+  },
+  "MessageForDeleted": {
+    "BH.Engine.MEP.Query.CircularEquivalentDiameter(System.Object)" : "The method for calculating the Circular Equivalent Diameter of a plain System.Object has been removed from the UI to avoid confusion. Please use the appropriate method from the MEP_Engine to query the Circular Equivalent Diameter of an MEP Profile Object.",
+  },
+  "MessageForNoUpgrade": {
+
+  }
+}

--- a/Security_Engine/Query/Centreline.cs
+++ b/Security_Engine/Query/Centreline.cs
@@ -39,6 +39,12 @@ namespace BH.Engine.Security
         [Output("centreline", "The centreline of the CameraDevice object.")]
         public static Line Centreline(this CameraDevice cameraDevice)
         {
+            if(cameraDevice == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the centreline of a null camera device.");
+                return null;
+            }
+
             return new Line { Start = cameraDevice.EyePosition, End = cameraDevice.TargetPosition };
         }
 

--- a/Security_Engine/Query/Geometry.cs
+++ b/Security_Engine/Query/Geometry.cs
@@ -28,7 +28,7 @@ using BH.oM.Security.Elements;
 using BH.oM.Reflection.Attributes;
 using BH.Engine.Geometry;
 
-namespace BH.Engine.MEP
+namespace BH.Engine.Security
 {
     public static partial class Query
     {
@@ -39,8 +39,15 @@ namespace BH.Engine.MEP
         [Description("Gets the camera's geometry as a closed ICurve cone-shape. Method required for automatic display in UI packages.")]
         [Input("cameraDevice", "Camera to get the ICurve from.")]
         [Output("icurve", "The geometry of the Camera.")]
+        [PreviousVersion("4.2", "BH.Engine.MEP.Query.Geometry(BH.oM.Security.Elements.CameraDevice)")]
         public static ICurve Geometry(this CameraDevice cameraDevice)
         {
+            if(cameraDevice == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the geometry of a null camera device.");
+                return null;
+            }
+
             Vector direction = BH.Engine.Geometry.Create.Vector(
                 BH.Engine.Geometry.Create.Point(cameraDevice.EyePosition.X, cameraDevice.EyePosition.Y, 0),
                 BH.Engine.Geometry.Create.Point(cameraDevice.TargetPosition.X, cameraDevice.TargetPosition.Y, 0)).Normalise();


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #2460 

### Additional comments
@enarhi I have also fixed the methods in Security_Engine which were failing too. This includes the query method of Geometry for a `CameraDevice` which was incorrectly in the `BH.Engine.MEP` namespace instead of the `BH.Engine.Security` namespace. I have versioned this change appropriately and should be evidenced by the green ticks when the checks finish.