### PR TITLE
Environment_Engine: Skip IInternalEdges when set to null

### DIFF
--- a/Environment_Engine/Create/Panel.cs
+++ b/Environment_Engine/Create/Panel.cs
@@ -94,8 +94,11 @@ namespace BH.Engine.Environment
             if (connectedSpaceName == null)
                 connectedSpaceName = Guid.NewGuid().ToString();
 
-            List<Polyline> openingLines = surface.IInternalEdges().Select(x => x.ICollapseToPolyline(angleTolerance)).ToList();
-            List<Opening> openings = new List<Opening>();
+            List<Polyline> openingLines = new List<Polyline>();
+            if (surface.IInternalEdges() != null)
+                openingLines = surface.IInternalEdges().Select(x => x.ICollapseToPolyline(angleTolerance)).ToList();
+
+            List <Opening> openings = new List<Opening>();
 
             foreach(Polyline p in openingLines)
             {

--- a/Environment_Engine/Query/OpeningsFromPhysical.cs
+++ b/Environment_Engine/Query/OpeningsFromPhysical.cs
@@ -61,7 +61,8 @@ namespace BH.Engine.Environment
                 Opening opening = new Opening();
                 opening.Name = o.Name;
                 opening.Edges = o.Location.IExternalEdges().ToEdges();
-                opening.InnerEdges = o.Location.IInternalEdges().ToEdges();
+                if (o.Location.IInternalEdges() != null)
+                    opening.InnerEdges = o.Location.IInternalEdges().ToEdges();
                 opening.Type = (o is Door ? OpeningType.Door : OpeningType.Window);
                 openings.Add(opening);
             }


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2496 

Fixes the bug where PanelsFromPhysical and Panel components are not running for panels with openings without internal edges.

### Test files
<!-- Link to test files to validate the proposed changes -->
[TestFiles.zip](https://github.com/BHoM/BHoM_Engine/files/6420173/TestFiles.zip)
