### PR TITLE
Reflection_Engine: Fix recursive ToText on types

### DIFF
--- a/Reflection_Engine/Convert/ToText.cs
+++ b/Reflection_Engine/Convert/ToText.cs
@@ -141,12 +141,12 @@ namespace BH.Engine.Reflection
                 Type[] types = type.GetGenericArguments();
 
                 if (replaceGeneric && types.Count() == 1 && type.Namespace != null && !type.Namespace.StartsWith("BH"))
-                    return types[0].ToText(includePath, replaceGeneric);
+                    return types[0].ToText(includePath, replaceGeneric, genericStart, genericSeparator, genericEnd);
                 else
                 {
                     string text = type.Name.Substring(0, type.Name.IndexOf('`'))
                         + genericStart
-                        + types.Select(x => x.ToText(includePath)).Aggregate((x, y) => x + genericSeparator + y)
+                        + types.Select(x => x.ToText(includePath, replaceGeneric, genericStart, genericSeparator, genericEnd)).Aggregate((x, y) => x + genericSeparator + y)
                         + genericEnd;
 
                     if (includePath)


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2505

See issue


### Test files
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Reflection_Engine/%232505-TypeToTextBug.gh?csf=1&web=1&e=JI7rMJ

Note that `[,]` is used to represent a matrix and is considered as a single type. So the separator is not applied there (Excel deals with that separately). 
