### PR TITLE
Facade_Engine: Added Methods to calculate UValues on elements based on new U and Psi fragments

### DIFF
--- a/Facade_Engine/Compute/UValueOpeningCAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningCAM.cs
@@ -43,9 +43,9 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of opening calculated using Psi-tj method. Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
-        [Input("opening", "Opening to find areas for.")]
-        [Output("effectiveUValue", "Effective U-value of opening caclulated using SAM.")]
+        [Description("Returns effective U-Value of opening calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Input("opening", "Opening to find U-value for.")]
+        [Output("effectiveUValue", "Effective U-value of opening calculated using CAM.")]
         public static double UValueOpeningCAM(this Opening opening)
         {
             double glassArea = opening.ComponentAreas().Item1;
@@ -69,8 +69,8 @@ namespace BH.Engine.Facade
             List<double> psigLengths = new List<double>();
             List<double> psigValues = new List<double>();
 
-            int h = 0;
-            int j = 0;
+            int h;
+            int j;
             for (int i = 0; i < frameEdges.Count; i++)
             {
                 if (i == 0)
@@ -135,6 +135,10 @@ namespace BH.Engine.Facade
             }
 
             double totArea = opening.Area();
+            if (totArea == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} has a calculated area of 0. Ensure the opening is valid with associated edges defining its geometry and try again.");
+            }
             double effectiveUValue = (((glassArea * glassUValue) + psigProduct + FrameUValProduct) / totArea);
             return effectiveUValue;
         }

--- a/Facade_Engine/Compute/UValueOpeningCAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningCAM.cs
@@ -1,0 +1,145 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Facade.Elements;
+using BH.oM.Base;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.Engine.Base;
+using BH.oM.Facade.Fragments;
+using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****          Public Methods                   ****/
+        /***************************************************/
+
+        [Description("Returns effective U-Value of opening calculated using Psi-tj method. Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Input("opening", "Opening to find areas for.")]
+        [Output("effectiveUValue", "Effective U-value of opening caclulated using SAM.")]
+        public static double UValueOpeningCAM(this Opening opening)
+        {
+            double glassArea = opening.ComponentAreas().Item1;
+
+            List<IFragment> glassUValues = opening.GetAllFragments(typeof(UValueGlassCentre));
+            if (glassUValues.Count <= 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Glass U-value assigned.");
+                return double.NaN;
+            }
+            if (glassUValues.Count > 1)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} has more than one Glass U-value assigned.");
+                return double.NaN;
+            }
+            double glassUValue = (glassUValues[0] as UValueGlassCentre).UValue;
+
+            List<FrameEdge> frameEdges = opening.Edges;
+            List<double> frameAreas = new List<double>();
+            List<double> frameUValues = new List<double>();
+            List<double> psigLengths = new List<double>();
+            List<double> psigValues = new List<double>();
+
+            int h = 0;
+            int j = 0;
+            for (int i = 0; i < frameEdges.Count; i++)
+            {
+                if (i == 0)
+                {
+                    h = frameEdges.Count-1;
+                    j = i + 1;
+                }
+                else if (i == frameEdges.Count-1)
+                {
+                    h = i - 1;
+                    j = 0;
+                }
+                else
+                {
+                    h = i - 1;
+                    j = i + 1;
+                } 
+                double outerLength = frameEdges[i].Length();
+                double wi = frameEdges[i].FrameEdgeProperty.Width();
+                double wh = frameEdges[h].FrameEdgeProperty.Width();
+                double wj = frameEdges[j].FrameEdgeProperty.Width();
+                double innerLength = outerLength - wj - wh;
+                double area = wi * (outerLength + innerLength) / 2;
+                frameAreas.Add(area);
+                psigLengths.Add(innerLength);
+
+                List<IFragment> uValues = frameEdges[i].GetAllFragments(typeof(UValueFrame));
+                if (uValues.Count <= 0)
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Frame U-value assigned.");
+                    return double.NaN;
+                }
+                if (uValues.Count > 1)
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} has more than one Frame U-value assigned.");
+                    return double.NaN;
+                }
+                double frameUValue = (uValues[0] as UValueFrame).UValue;
+                frameUValues.Add(frameUValue);
+                
+                List<IFragment> psiGs = frameEdges[i].GetAllFragments(typeof(PsiGlassEdge));
+                if (psiGs.Count <= 0)
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} does not have PsiG value assigned.");
+                    return double.NaN;
+                }
+                if (psiGs.Count > 1)
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} has more than one PsiG value assigned. Each FrameEdge should only have one unique PsiG value assigned to it.");
+                    return double.NaN;
+                }
+                double psiG = (psiGs[0] as PsiGlassEdge).PsiValue;
+                psigValues.Add(psiG);
+            }
+
+            double psigProduct = 0;
+            double FrameUValProduct = 0;
+            for (int i = 0; i < psigLengths.Count; i++)
+            {
+                psigProduct += (psigLengths[i] * psigValues[i]);
+                FrameUValProduct += (frameUValues[i] * frameAreas[i]);
+            }
+
+            double totArea = opening.Area();
+            double effectiveUValue = (((glassArea * glassUValue) + psigProduct + FrameUValProduct) / totArea);
+            return effectiveUValue;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Facade_Engine/Compute/UValueOpeningSAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningSAM.cs
@@ -1,0 +1,103 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Facade.Elements;
+using BH.oM.Base;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.Engine.Base;
+using BH.oM.Facade.Fragments;
+using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****          Public Methods                   ****/
+        /***************************************************/
+
+        [Description("Returns effective U-Value of opening calculated using Psi-tj method. Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Input("opening", "Opening to find areas for.")]
+        [Output("effectiveUValue", "Effective U-value of opening caclulated using SAM.")]
+        public static double UValueOpeningSAM(this Opening opening)
+        {
+            double area = opening.Area();
+
+            List<IFragment> uValues = opening.GetAllFragments(typeof(UValueGlassCentre));
+            if (uValues.Count <= 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have U-value assigned.");
+                return double.NaN;
+            }
+            if (uValues.Count > 1)
+            {
+                BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} has more than one U-value assigned.");
+                return double.NaN;
+            }
+            double uValue = (uValues[0] as UValueGlassCentre).UValue;
+
+            List<FrameEdge> frameEdges = opening.Edges;
+            List<double> psiValues = new List<double>();
+            List<double> lengths = new List<double>();
+
+            foreach (FrameEdge frameEdge in frameEdges)
+            {
+                List<IFragment> psiJoints = frameEdge.GetAllFragments(typeof(PsiJoint));
+                if (psiJoints.Count <= 0)
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} does not have PsiJoint value assigned.");
+                    return double.NaN;
+                }
+                if (psiJoints.Count > 1)
+                {
+                    BH.Engine.Reflection.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} has more than one PsiJoint value assigned. Each FrameEdge should only have one unique PsiJoint value assigned to it.");
+                    return double.NaN;
+                }
+                double psiJoint = (psiJoints[0] as PsiJoint).PsiValue;
+                psiValues.Add(psiJoint);
+
+                double length = frameEdge.Length();
+                lengths.Add(length);
+            }
+
+            double psiProduct = 0;
+            for (int i = 0; i < lengths.Count; i++)
+            {
+                psiProduct = psiProduct + (lengths[i] * psiValues[i]);
+            }
+
+            double effectiveUValue = (((area * uValue) + psiProduct) / area);
+            return effectiveUValue;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Facade_Engine/Compute/UValueOpeningSAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningSAM.cs
@@ -31,6 +31,7 @@ using BH.Engine.Geometry;
 using BH.Engine.Spatial;
 using BH.Engine.Base;
 using BH.oM.Facade.Fragments;
+using BH.oM.Facade.Results;
 using BH.oM.Reflection;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -45,8 +46,8 @@ namespace BH.Engine.Facade
 
         [Description("Returns effective U-Value of opening calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
         [Input("opening", "Opening to find U-value for.")]
-        [Output("effectiveUValue", "Effective U-value of opening caclulated using SAM.")]
-        public static double UValueOpeningSAM(this Opening opening)
+        [Output("effectiveUValue", "Effective U-value result of opening caclulated using SAM.")]
+        public static OverallUValue UValueOpeningSAM(this Opening opening)
         {
             double area = opening.Area();
 
@@ -54,12 +55,12 @@ namespace BH.Engine.Facade
             if (uValues.Count <= 0)
             {
                 BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have U-value assigned.");
-                return double.NaN;
+                return null;
             }
             if (uValues.Count > 1)
             {
                 BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} has more than one U-value assigned.");
-                return double.NaN;
+                return null;
             }
             double uValue = (uValues[0] as UValueGlassCentre).UValue;
 
@@ -73,12 +74,12 @@ namespace BH.Engine.Facade
                 if (psiJoints.Count <= 0)
                 {
                     BH.Engine.Reflection.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} does not have PsiJoint value assigned.");
-                    return double.NaN;
+                    return null;
                 }
                 if (psiJoints.Count > 1)
                 {
                     BH.Engine.Reflection.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} has more than one PsiJoint value assigned. Each FrameEdge should only have one unique PsiJoint value assigned to it.");
-                    return double.NaN;
+                    return null;
                 }
                 double psiJoint = (psiJoints[0] as PsiJoint).PsiValue;
                 psiValues.Add(psiJoint);
@@ -94,7 +95,8 @@ namespace BH.Engine.Facade
             }
 
             double effectiveUValue = (((area * uValue) + psiProduct) / area);
-            return effectiveUValue;
+            OverallUValue result = new OverallUValue { UValue = effectiveUValue, ObjectIds = new List<IComparable> { opening.BHoM_Guid } };
+            return result;
         }
 
         /***************************************************/

--- a/Facade_Engine/Compute/UValueOpeningSAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningSAM.cs
@@ -43,8 +43,8 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of opening calculated using Psi-tj method. Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
-        [Input("opening", "Opening to find areas for.")]
+        [Description("Returns effective U-Value of opening calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Input("opening", "Opening to find U-value for.")]
         [Output("effectiveUValue", "Effective U-value of opening caclulated using SAM.")]
         public static double UValueOpeningSAM(this Opening opening)
         {

--- a/Facade_Engine/Compute/UValueOpeningsCAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningsCAM.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Facade.Elements;
+using BH.oM.Base;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.Engine.Base;
+using BH.oM.Facade.Fragments;
+using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****          Public Methods                   ****/
+        /***************************************************/
+
+        [Description("Returns effective U-Value of a collection of openings calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Input("openings", "Openings to find U-value for.")]
+        [Output("effectiveUValue", "Effective total U-value of openings calculated using CAM.")]
+        public static double UValueOpeningsCAM(this List<Opening> openings)
+        {
+            double uValueProduct = 0;
+            double totalArea = 0;
+            foreach (Opening opening in openings)
+            {
+                double area = opening.Area();
+                uValueProduct += opening.UValueOpeningCAM() * area;
+                totalArea += area;
+            }
+            if (totalArea == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Openings have a total calculated area of 0. Ensure Openings are valid with associated edges defining their geometry and try again.");
+                return double.NaN;
+            }
+
+            return uValueProduct / totalArea; ;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Facade_Engine/Compute/UValueOpeningsCAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningsCAM.cs
@@ -31,6 +31,7 @@ using BH.Engine.Geometry;
 using BH.Engine.Spatial;
 using BH.Engine.Base;
 using BH.oM.Facade.Fragments;
+using BH.oM.Facade.Results;
 using BH.oM.Reflection;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -45,24 +46,26 @@ namespace BH.Engine.Facade
 
         [Description("Returns effective U-Value of a collection of openings calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
         [Input("openings", "Openings to find U-value for.")]
-        [Output("effectiveUValue", "Effective total U-value of openings calculated using CAM.")]
-        public static double UValueOpeningsCAM(this List<Opening> openings)
+        [Output("effectiveUValue", "Effective total U-value result of openings calculated using CAM.")]
+        public static OverallUValue UValueOpeningsCAM(this List<Opening> openings)
         {
             double uValueProduct = 0;
             double totalArea = 0;
             foreach (Opening opening in openings)
             {
                 double area = opening.Area();
-                uValueProduct += opening.UValueOpeningCAM() * area;
+                uValueProduct += opening.UValueOpeningCAM().UValue * area;
                 totalArea += area;
             }
             if (totalArea == 0)
             {
                 BH.Engine.Reflection.Compute.RecordError("Openings have a total calculated area of 0. Ensure Openings are valid with associated edges defining their geometry and try again.");
-                return double.NaN;
+                return null;
             }
 
-            return uValueProduct / totalArea; ;
+            double effectiveUValue = uValueProduct / totalArea;
+            OverallUValue result = new OverallUValue { UValue = effectiveUValue, ObjectIds = openings.Select(x => x.BHoM_Guid as IComparable).ToList() };
+            return result;
         }
 
         /***************************************************/

--- a/Facade_Engine/Compute/UValueOpeningsSAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningsSAM.cs
@@ -1,0 +1,71 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Facade.Elements;
+using BH.oM.Base;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.Engine.Base;
+using BH.oM.Facade.Fragments;
+using BH.oM.Reflection;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /****          Public Methods                   ****/
+        /***************************************************/
+
+        [Description("Returns effective U-Value of a collection of openings calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Input("openings", "Openings to find U-value for.")]
+        [Output("effectiveUValue", "Effective total U-value of opening caclulated using SAM.")]
+        public static double UValueOpeningsSAM(this List<Opening> openings)
+        {
+            double uValueProduct = 0;
+            double totalArea = 0;
+            foreach (Opening opening in openings)
+            {
+                double area = opening.Area();
+                uValueProduct += opening.UValueOpeningSAM() * area;
+                totalArea += area;
+            }
+            if (totalArea == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Openings have a total calculated area of 0. Ensure Openings are valid with associated edges defining their geometry and try again.");
+                return double.NaN;
+            }
+
+            return uValueProduct / totalArea; ;
+        }
+
+        /***************************************************/
+
+    }
+}

--- a/Facade_Engine/Compute/UValueOpeningsSAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningsSAM.cs
@@ -31,6 +31,7 @@ using BH.Engine.Geometry;
 using BH.Engine.Spatial;
 using BH.Engine.Base;
 using BH.oM.Facade.Fragments;
+using BH.oM.Facade.Results;
 using BH.oM.Reflection;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
@@ -45,24 +46,26 @@ namespace BH.Engine.Facade
 
         [Description("Returns effective U-Value of a collection of openings calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
         [Input("openings", "Openings to find U-value for.")]
-        [Output("effectiveUValue", "Effective total U-value of opening caclulated using SAM.")]
-        public static double UValueOpeningsSAM(this List<Opening> openings)
+        [Output("effectiveUValue", "Effective total U-value result of opening calculated using SAM.")]
+        public static OverallUValue UValueOpeningsSAM(this List<Opening> openings)
         {
             double uValueProduct = 0;
             double totalArea = 0;
             foreach (Opening opening in openings)
             {
                 double area = opening.Area();
-                uValueProduct += opening.UValueOpeningSAM() * area;
+                uValueProduct += opening.UValueOpeningSAM().UValue * area;
                 totalArea += area;
             }
             if (totalArea == 0)
             {
                 BH.Engine.Reflection.Compute.RecordError("Openings have a total calculated area of 0. Ensure Openings are valid with associated edges defining their geometry and try again.");
-                return double.NaN;
+                return null;
             }
 
-            return uValueProduct / totalArea; ;
+            double effectiveUValue =  uValueProduct / totalArea;
+            OverallUValue result = new OverallUValue { UValue = effectiveUValue, ObjectIds = openings.Select(x => x.BHoM_Guid as IComparable).ToList() };
+            return result;
         }
 
         /***************************************************/

--- a/Facade_Engine/Facade_Engine.csproj
+++ b/Facade_Engine/Facade_Engine.csproj
@@ -103,6 +103,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\UValueOpeningCAM.cs" />
+    <Compile Include="Compute\UValueOpeningSAM.cs" />
     <Compile Include="Compute\FacadeAreasByConstruction.cs" />
     <Compile Include="Compute\ComponentAreas.cs" />
     <Compile Include="Compute\EdgeAdjacencies.cs" />

--- a/Facade_Engine/Facade_Engine.csproj
+++ b/Facade_Engine/Facade_Engine.csproj
@@ -103,6 +103,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\UValueOpeningsSAM.cs" />
+    <Compile Include="Compute\UValueOpeningsCAM.cs" />
     <Compile Include="Compute\UValueOpeningCAM.cs" />
     <Compile Include="Compute\UValueOpeningSAM.cs" />
     <Compile Include="Compute\FacadeAreasByConstruction.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1251
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2508 

This PR adds methods for calculating effective UValue of one or many openings based on their constituent frame and glazing U values using two common methods: Single Assessment Method and Component Assessment Method.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Facade_Engine/%232508-UValueCalculationMethods?csf=1&web=1&e=D8xviw

