### PR TITLE
Verification: Make sure NullCheck method can call Generic methods

### DIFF
--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -87,16 +87,13 @@ namespace BH.Test.Engine
             {
                 if (method.IsGenericMethodDefinition)
                     method = method.MakeFromGeneric();
+
+                if (method == null)
+                    return GenericsFailedResult(methodDescription);
             }
             catch (Exception e)
             {
-                return new TestResult
-                {
-                    Description = methodDescription,
-                    Status = TestStatus.Warning,
-                    Message = $"Warning: Failed to make method {methodDescription} into a generic method. It will not be tested.",
-                    Information = new List<ITestInformation> { new EventMessage { Message = e.Message, StackTrace = e.StackTrace } }
-                };
+                return GenericsFailedResult(methodDescription, e);
             }
 
             // Collect the inputs setting themm to null when relevant
@@ -162,6 +159,23 @@ namespace BH.Test.Engine
 
             // All test objects passed the test
             return BH.Engine.Test.Create.PassResult(methodDescription);
+        }
+
+        /*************************************/
+
+        private static TestResult GenericsFailedResult(string methodDescription, Exception e = null)
+        {
+            List<ITestInformation> information = new List<ITestInformation>();
+            if (e != null)
+                information.Add(new EventMessage { Message = e.Message, StackTrace = e.StackTrace });
+
+            return new TestResult
+            {
+                Description = methodDescription,
+                Status = TestStatus.Warning,
+                Message = $"Warning: Failed to make method {methodDescription} into a generic method. It will not be tested.",
+                Information = information
+            };
         }
 
         /*************************************/

--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -115,6 +115,9 @@ namespace BH.Test.Engine
             // Try invoking the method
             try
             {
+                if (method.IsGenericMethodDefinition)
+                    method = method.MakeFromGeneric();
+
                 method.Invoke(null, inputs);
             }
             catch (Exception e)

--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -82,6 +82,23 @@ namespace BH.Test.Engine
         {
             string methodDescription = method.IToText(true);
 
+            //Check if method is generic type, and if so, make it generic based on its constraints
+            try
+            {
+                if (method.IsGenericMethodDefinition)
+                    method = method.MakeFromGeneric();
+            }
+            catch (Exception e)
+            {
+                return new TestResult
+                {
+                    Description = methodDescription,
+                    Status = TestStatus.Warning,
+                    Message = $"Warning: Failed to make method {methodDescription} into a generic method. It will not be tested.",
+                    Information = new List<ITestInformation> { new EventMessage { Message = e.Message, StackTrace = e.StackTrace } }
+                };
+            }
+
             // Collect the inputs setting themm to null when relevant
             object[] inputs = new object[0];
             try
@@ -115,9 +132,6 @@ namespace BH.Test.Engine
             // Try invoking the method
             try
             {
-                if (method.IsGenericMethodDefinition)
-                    method = method.MakeFromGeneric();
-
                 method.Invoke(null, inputs);
             }
             catch (Exception e)

--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -80,6 +80,17 @@ namespace BH.Test.Engine
 
         public static TestResult NullChecks(MethodInfo method)
         {
+            //Check if the method provided is null
+            if (method == null)
+            {
+                return new TestResult
+                {
+                    Description = "",
+                    Status = TestStatus.Warning,
+                    Message = $"Warning: The provided method is null and can not be tested.",
+                };
+            }
+
             string methodDescription = method.IToText(true);
 
             //Check if method is generic type, and if so, make it generic based on its constraints

--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -87,7 +87,7 @@ namespace BH.Test.Engine
                 {
                     Description = "",
                     Status = TestStatus.Warning,
-                    Message = $"Warning: The provided method is null and can not be tested.",
+                    Message = $"Warning: The provided method is null and cannot be tested.",
                 };
             }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2529 

<!-- Add short description of what has been fixed -->

Adding check if the method is a Generic method, and if so, making use of the MakeFromGeneric method to make sure it can be called.

Code without this change simply crashes for all generic methods.

### Test files
<!-- Link to test files to validate the proposed changes -->

Testfile for a couple of methods here:
https://burohappold.sharepoint.com/:f:/s/BHoM/EjNwbhC-4KFMkZBRlmhKV0gBNiFkDp-F0fKFZXf2tBeuuQ?e=pWaxCa

Note that all of the methods in the testfile are not passing, but that they now throw more appropriate errors and warnings, not failing to cast errors.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->