### PR TITLE
Reflection_Engine: Provide better support for setting a DateTime property with a string input

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -102,6 +102,18 @@ namespace BH.Engine.Reflection
                     }   
                 }
 
+                if (propType == typeof(DateTime) && value is string)
+                {
+                    DateTime date;
+                    if (DateTime.TryParse(value as string, out date))
+                        value = date;
+                    else
+                    {
+                        Engine.Reflection.Compute.RecordError($"The value provided for {propName} is not a valid DateTime.");
+                        value = DateTime.MinValue;
+                    }
+                }
+
                 if (propType == typeof(Type) && value is string)
                     value = Create.Type(value as string);
 


### PR DESCRIPTION

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2534

This is as good as it can get without providing the format of the string containing the date. The C# method `dateTime.TryParse` does its best to figure out the format (e.g. even if only the date is provided without the time) but there will always be cases that are unsolvable. For example the American `mm-dd-yyyy` vs the British `dd-mm-yyyy`.  Better than what we had before without breaking anything so I am happy with the state of this PR.


### Test files
This was mainly created within the context of the [Building Performance Excel form](https://github.com/BuroHappoldEngineering/BuildingPerformance_Toolkit/pull/6). So I recommend to make sure invalid dates are now properly handled within that context. 
