### PR TITLE
Verification: Additional exceptions as errors for null checks

### DIFF
--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -145,7 +145,7 @@ namespace BH.Test.Engine
             }
             catch (Exception e)
             {
-                if (e is TargetInvocationException && e.InnerException != null)
+                while (e is TargetInvocationException && e.InnerException != null)
                     e = e.InnerException;
 
                 if (e is NullReferenceException)

--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -166,6 +166,15 @@ namespace BH.Test.Engine
                         Message = $"Error: A ArgumentNullException was received from method {methodDescription}.",
                     };
                 }
+                else if (e is Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
+                {
+                    return new TestResult
+                    {
+                        Description = methodDescription,
+                        Status = TestStatus.Error,
+                        Message = $"Error: A RuntimeBinderException was received from method {methodDescription}. This indicates trying to cast a null as dynamic.",
+                    };
+                }
                 else
                 {
                     return new TestResult

--- a/.ci/code/Engine_Test/Verify/NullChecks.cs
+++ b/.ci/code/Engine_Test/Verify/NullChecks.cs
@@ -157,6 +157,15 @@ namespace BH.Test.Engine
                         Message = $"Error: A NullReferenceException was received from method {methodDescription}.",
                     };
                 }
+                else if (e is ArgumentNullException)
+                {
+                    return new TestResult
+                    {
+                        Description = methodDescription,
+                        Status = TestStatus.Error,
+                        Message = $"Error: A ArgumentNullException was received from method {methodDescription}.",
+                    };
+                }
                 else
                 {
                     return new TestResult


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2513

<!-- Add short description of what has been fixed -->

- Changing from If to while statement to get nested inner exception. needed to fetch the actual exception for edge cases
- Adding `ArgumentNullException` as an explicit exception to raise as an error
- Adding `RuntimeBinderException` as an explicit exception to be raised as an error. Generally the exception thrown when calling an interface method with null, while it is trying to case as dynamic and fails to find a method matching
- Calling LoadAllAssemblies in begining, as no longer done by MethodList
- initialising empty dictionaries and hashsets instead of lists for those types.


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->