### PR TITLE
Spatial_Engine: Add query dominant vector

### DIFF
--- a/Geometry_Engine/Geometry_Engine.csproj
+++ b/Geometry_Engine/Geometry_Engine.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Query\Cells.cs" />
     <Compile Include="Query\Centroid.cs" />
     <Compile Include="Query\ClosestPoints.cs" />
+    <Compile Include="Query\IsOrthogonal.cs" />
     <Compile Include="Query\IsRigidTransformation.cs" />
     <Compile Include="Query\PrincipalCurvatureAtParameter.cs" />
     <Compile Include="Query\CurveIntersections.cs" />

--- a/Geometry_Engine/Query/IsOrthogonal.cs
+++ b/Geometry_Engine/Query/IsOrthogonal.cs
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.ComponentModel;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /****         Public Methods - Vectors          ****/
+        /***************************************************/
+        
+        [Description("Queries whether a vector is orthogonal in relation to global X, Y or Z axis.")]
+        [Input("vector", "The vector to evaluate.")]
+        [Input("angleTolerance", "Optional, the angle discrepancy in radians from the global axis to consider as tolerance.")]
+        [Output("isOrthogonal", "The boolean value of whether the vector is orthogonal or not.")]
+        public static bool IsOrthogonal(this Vector vector, double angleTolerance = Tolerance.Angle)
+        {
+            return (vector.IsParallel(Vector.XAxis, angleTolerance) != 0 || vector.IsParallel(Vector.YAxis, angleTolerance) != 0 || vector.IsParallel(Vector.ZAxis, angleTolerance) != 0);
+        }
+
+        /***************************************************/
+
+       
+
+
+    }
+}

--- a/Geometry_Engine/Query/IsOrthogonal.cs
+++ b/Geometry_Engine/Query/IsOrthogonal.cs
@@ -39,13 +39,16 @@ namespace BH.Engine.Geometry
         [Output("isOrthogonal", "The boolean value of whether the vector is orthogonal or not.")]
         public static bool IsOrthogonal(this Vector vector, double angleTolerance = Tolerance.Angle)
         {
+            if (vector == null || angleTolerance == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("One or more of the inputs is empty or null.");
+                return false;
+            }
+
             return (vector.IsParallel(Vector.XAxis, angleTolerance) != 0 || vector.IsParallel(Vector.YAxis, angleTolerance) != 0 || vector.IsParallel(Vector.ZAxis, angleTolerance) != 0);
         }
 
         /***************************************************/
-
-       
-
 
     }
 }

--- a/Spatial_Engine/Query/DominantVector.cs
+++ b/Spatial_Engine/Query/DominantVector.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Spatial
         [Input("orthogonalLengthTolerance", "Optional, tests the orthogonal vector length's in relation to the actual non-orthogonal dominant vector. For example if the dominant vector is 10 in length but the orthogonal is only 5 in length, then this number should be 0.5 for it to pass the test.")]
         [Input("angleTolerance", "Optional, angle in radians that vectors will be considered similar.")]
         [Output("dominantVector", "The dominant vector of an Element1D.")]
-        public static BH.oM.Geometry.Vector DominantVector(IElement1D element1D, bool orthogonalPriority = true, double orthogonalLengthTolerance = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
+        public static BH.oM.Geometry.Vector DominantVector(IElement1D element1D, bool orthogonalPriority = true, double orthogonalLengthFactor = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
         {
             List<ICurve> curves = element1D.IGeometry().ISubParts().ToList();
             
@@ -64,7 +64,7 @@ namespace BH.Engine.Spatial
             List<Vector> largestOrthogonal = groupByNormal.FirstOrDefault(x => (x.First().IsOrthogonal(angleTolerance)));
             if (largestOrthogonal != null)
             {
-                if (largestGlobal.Sum(x => x.Length()) * orthogonalLengthTolerance > largestOrthogonal.Sum(x => x.Length()))
+                if (largestGlobal.Sum(x => x.Length()) * orthogonalLengthFactor > largestOrthogonal.Sum(x => x.Length()))
                     BH.Engine.Reflection.Compute.RecordWarning("Orthogonal vector was found but didn't pass the length tolerance in relation to the actual non-orthogonal dominant vector. The actual dominant vector is the output.");
                 else
                     dominantVector = largestOrthogonal[0].Normalise();
@@ -80,13 +80,13 @@ namespace BH.Engine.Spatial
         [Description("Gets the the dominant vector (orientation) of an Element2D based on its lines lengths.")]
         [Input("element1D", "Element2D to evaluate.")]
         [Input("orthogonalPriority", "Optional, if true gives priority to curves that are on the orthogonal axis (X, Y or Z vectors.")]
-        [Input("orthogonalLengthTolerance", "Optional, tests the orthogonal vector length's in relation to the actual non-orthogonal dominant vector. For example if the dominant vector is 10 in length but the orthogonal is only 5 in length, then this number should be 0.5 for it to pass the test.")]
+        [Input("orthogonalLengthFactor", "Optional, tests the orthogonal vector length's in relation to the actual non-orthogonal dominant vector. For example if the dominant vector is 10 in length but the orthogonal is only 5 in length, then this number should be 0.5 for it to pass the test.")]
         [Input("angleTolerance", "Optional, angle in radians that vectors will be considered similar.")]
         [Output("dominantVector", "The dominant vector of an Element2D.")]
-        public static BH.oM.Geometry.Vector DominantVector(IElement2D element2D, bool orthogonalPriority = true, double orthogonalLengthTolerance = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
+        public static BH.oM.Geometry.Vector DominantVector(IElement2D element2D, bool orthogonalPriority = true, double orthogonalLengthFactor = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
         {
             IElement1D outline = BH.Engine.Geometry.Create.PolyCurve(element2D.IOutlineElements1D().Select(x =>x.IGeometry()));
-            return DominantVector(outline, orthogonalPriority, orthogonalLengthTolerance, angleTolerance);
+            return DominantVector(outline, orthogonalPriority, orthogonalLengthFactor, angleTolerance);
         }
         
         /******************************************/

--- a/Spatial_Engine/Query/DominantVector.cs
+++ b/Spatial_Engine/Query/DominantVector.cs
@@ -89,10 +89,7 @@ namespace BH.Engine.Spatial
             
             //check if length tolerance passes
             if (orthogonalLengths.Max() < groupedLengths.Max() * orthogonalLengthTolerance)
-            {
                 return dominantVector;
-                //display warning
-            }
 
             return orthogonalDominantVector;
         }
@@ -112,6 +109,7 @@ namespace BH.Engine.Spatial
             IElement1D outline = BH.Engine.Geometry.Create.PolyCurve(element2D.IOutlineElements1D().Select(x =>x as ICurve));
             return DominantVector(outline, orthogonalPriority, orthogonalLengthTolerance, angleTolerance);
         }
+        
         /******************************************/
         /****              Private             ****/
         /******************************************/

--- a/Spatial_Engine/Query/DominantVector.cs
+++ b/Spatial_Engine/Query/DominantVector.cs
@@ -45,8 +45,11 @@ namespace BH.Engine.Spatial
         [Output("dominantVector", "The dominant vector of an Element1D.")]
         public static BH.oM.Geometry.Vector DominantVector(this IElement1D element1D, bool orthogonalPriority = true, double orthogonalLengthFactor = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
         {
-            if (element1D == null)
+            if (element1D == null || orthogonalPriority == null || orthogonalLengthFactor == null || angleTolerance == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("One or more of the inputs is empty or null.");
                 return null;
+            }
 
             List<ICurve> curves = element1D.IGeometry().ISubParts().ToList();
             
@@ -88,9 +91,12 @@ namespace BH.Engine.Spatial
         [Output("dominantVector", "The dominant vector of an Element2D.")]
         public static BH.oM.Geometry.Vector DominantVector(this IElement2D element2D, bool orthogonalPriority = true, double orthogonalLengthFactor = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
         {
-            if (element2D == null)
+            if (element2D == null || orthogonalPriority == null || orthogonalLengthFactor == null || angleTolerance == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("One or more of the inputs is empty or null.");
                 return null;
-            
+            }
+
             IElement1D outline = BH.Engine.Geometry.Create.PolyCurve(element2D.IOutlineElements1D().Select(x =>x.IGeometry()));
             return DominantVector(outline, orthogonalPriority, orthogonalLengthFactor, angleTolerance);
         }

--- a/Spatial_Engine/Query/DominantVector.cs
+++ b/Spatial_Engine/Query/DominantVector.cs
@@ -40,11 +40,14 @@ namespace BH.Engine.Spatial
         [Description("Gets the the dominant vector (orientation) of an Element1D based on its lines lengths.")]
         [Input("element1D", "Element1D to evaluate.")]
         [Input("orthogonalPriority", "Optional, if true gives priority to curves that are on the orthogonal axis (X, Y or Z vectors).")]
-        [Input("orthogonalLengthTolerance", "Optional, tests the orthogonal vector length's in relation to the actual non-orthogonal dominant vector. For example if the dominant vector is 10 in length but the orthogonal is only 5 in length, then this number should be 0.5 for it to pass the test.")]
+        [Input("orthogonalLengthFactor", "Optional, tests the orthogonal vector length's in relation to the actual non-orthogonal dominant vector. For example if the dominant vector is 10 in length but the orthogonal is only 5 in length, then this number should be 0.5 for it to pass the test.")]
         [Input("angleTolerance", "Optional, angle in radians that vectors will be considered similar.")]
         [Output("dominantVector", "The dominant vector of an Element1D.")]
-        public static BH.oM.Geometry.Vector DominantVector(IElement1D element1D, bool orthogonalPriority = true, double orthogonalLengthFactor = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
+        public static BH.oM.Geometry.Vector DominantVector(this IElement1D element1D, bool orthogonalPriority = true, double orthogonalLengthFactor = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
         {
+            if (element1D == null)
+                return null;
+
             List<ICurve> curves = element1D.IGeometry().ISubParts().ToList();
             
             if(!curves.Any(x=> x.IIsLinear()))
@@ -78,13 +81,16 @@ namespace BH.Engine.Spatial
         /******************************************/
         
         [Description("Gets the the dominant vector (orientation) of an Element2D based on its lines lengths.")]
-        [Input("element1D", "Element2D to evaluate.")]
+        [Input("element2D", "Element2D to evaluate.")]
         [Input("orthogonalPriority", "Optional, if true gives priority to curves that are on the orthogonal axis (X, Y or Z vectors.")]
         [Input("orthogonalLengthFactor", "Optional, tests the orthogonal vector length's in relation to the actual non-orthogonal dominant vector. For example if the dominant vector is 10 in length but the orthogonal is only 5 in length, then this number should be 0.5 for it to pass the test.")]
         [Input("angleTolerance", "Optional, angle in radians that vectors will be considered similar.")]
         [Output("dominantVector", "The dominant vector of an Element2D.")]
-        public static BH.oM.Geometry.Vector DominantVector(IElement2D element2D, bool orthogonalPriority = true, double orthogonalLengthFactor = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
+        public static BH.oM.Geometry.Vector DominantVector(this IElement2D element2D, bool orthogonalPriority = true, double orthogonalLengthFactor = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
         {
+            if (element2D == null)
+                return null;
+            
             IElement1D outline = BH.Engine.Geometry.Create.PolyCurve(element2D.IOutlineElements1D().Select(x =>x.IGeometry()));
             return DominantVector(outline, orthogonalPriority, orthogonalLengthFactor, angleTolerance);
         }

--- a/Spatial_Engine/Query/DominantVector.cs
+++ b/Spatial_Engine/Query/DominantVector.cs
@@ -1,0 +1,156 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using BH.oM.Reflection.Attributes;
+
+namespace BH.Engine.Spatial
+{
+    public static partial class Query
+    {
+        /******************************************/
+        /****            IElement1D            ****/
+        /******************************************/
+        
+        [Description("Gets the the dominant vector (orientation) of an Element1D based on its lines lengths.")]
+        [Input("element1D", "Element1D to evaluate.")]
+        [Input("orthogonalPriority", "Optional, if true gives priority to curves that are on the orthogonal axis.")]
+        [Input("orthogonalTolerance", "Optional, when orthogonalPriority is true it will only return orthogonal vector when its length is higher this number multiplied by the actual dominant vector lengths. For example if the dominant vector is 10 in length but the orthogonal is only 5 in length, then this number should be 0.5.")]
+        [Input("angleTolerance", "Optional, angle in radians that vectors will be considered similar. Default value in radians is approximately 5 degrees.")]
+        [Output("dominantVector", "The the dominant vector of an Element1D.")]
+        public static BH.oM.Geometry.Vector DominantVector(IElement1D element1D, bool orthogonalPriority = true, double orthogonalLengthTolerance = 0.5, double angleTolerance = 0.087)
+        {
+            List<Vector> vectors = new List<Vector>();
+            List<ICurve> curves = element1D.IGeometry().ISubParts().ToList();
+
+            foreach (ICurve curve in curves)
+            {                
+                //get vector from curves and make all of them positive to better group similar vectors 
+                double x = curve.IStartDir().X;
+                double y = curve.IStartDir().Y;
+                double z = curve.IStartDir().Z;
+
+                Vector vector = BH.Engine.Geometry.Create.Vector(x, y, z);
+                vectors.Add(vector*curve.Length());
+            }
+
+            //group vectors by direction whilst comparing angle for tolerance
+            List<List<Vector>> groupByNormal = GroupSimilarVectorsWithTolerance(vectors, angleTolerance);
+
+            //then sum their total length
+            List<double> groupedLengths = groupByNormal.Select(x => x.Select(y => y.Length()).Sum()).ToList();
+
+            //get index of biggest length, which will be dominant vector
+            int biggestLengthIndex = groupedLengths.IndexOf(groupedLengths.Max());
+
+            Vector dominantVector = groupByNormal[biggestLengthIndex].First().Normalise();
+            
+            if(!orthogonalPriority)
+                return dominantVector;
+
+            if (dominantVector.X == 0 || dominantVector.X == 1)
+                return dominantVector;
+
+            //filter grouped vectors to find only curves that are X = 0 or 1 (horizontal or vertical lines)
+            var orthogonalVectors = groupByNormal.Where(x => x.First().Normalise().X == 0 || x.First().Normalise().X == 1).ToList();
+            //then sum their total length
+            List<double> orthogonalLengths = orthogonalVectors.Select(x => x.Select(y => y.Length()).Sum()).ToList();
+            //get index of biggest length, which will be dominant vector
+            int biggestOrthogonalLengthIndex = orthogonalLengths.IndexOf(orthogonalLengths.Max());
+            
+            Vector orthogonalDominantVector = orthogonalVectors[biggestOrthogonalLengthIndex].First().Normalise();
+            if (dominantVector.IsEqual(orthogonalDominantVector))
+                return dominantVector;
+            
+            //check if length tolerance passes
+            if (orthogonalLengths.Max() < groupedLengths.Max() * orthogonalLengthTolerance)
+            {
+                return dominantVector;
+                //display warning
+            }
+
+            return orthogonalDominantVector;
+        }
+
+        /******************************************/
+        /****            IElement2D            ****/
+        /******************************************/
+        
+        [Description("Gets the the dominant vector (orientation) of an Element2D based on its outter lines lengths.")]
+        [Input("element2D", "Element2D to evaluate.")]
+        [Input("orthogonalPriority", "Optional, if true gives priority to curves that are on the orthogonal axis.")]
+        [Input("orthogonalTolerance", "Optional, when orthogonalPriority is true it will only return orthogonal vector when its length is higher this number multiplied by the actual dominant vector lengths. For example if the dominant vector is 10 in length but the orthogonal is only 5 in length, then this number should be 0.5.")]
+        [Input("angleTolerance", "Optional, angle in radians that vectors will be considered similar. Default value in radians is approximately 5 degrees.")]
+        [Output("dominantVector", "The the dominant vector of an Element1D.")]
+        public static BH.oM.Geometry.Vector DominantVector(IElement2D element2D, bool orthogonalPriority = true, double orthogonalLengthTolerance = 0.5, double angleTolerance = 0.087)
+        {
+            IElement1D outline = BH.Engine.Geometry.Create.PolyCurve(element2D.IOutlineElements1D().Select(x =>x as ICurve));
+            return DominantVector(outline, orthogonalPriority, orthogonalLengthTolerance, angleTolerance);
+        }
+        /******************************************/
+        /****              Private             ****/
+        /******************************************/
+
+        [Description("Groups vectors by direction whilst allowing for an angle discrepancy tolerance.")]
+        [Input("vectors", "Vectors to evaluate.")]
+        [Input("angleTolerance", "The angle in radians to compare vectors with each other for tolerance when grouping.")]
+        [Output("GroupSimilarVectorsWithTolerance", "The grouped vectors.")]
+        private static List<List<Vector>> GroupSimilarVectorsWithTolerance(List<Vector> vectors, double angleTolerance)
+        {
+            List<List<Vector>> result = new List<List<Vector>>();
+            List<Vector> orderByLength = vectors.OrderBy(x => x.Length()).ToList();
+
+            for (int i = 0; i < orderByLength.Count; i++)
+            {
+                List<Vector> sublist = new List<Vector>();
+                sublist.Add(orderByLength[i]);
+                
+                for (int j = 0; j < orderByLength.Count; j++)
+                {
+                    if(!orderByLength[i].Equals(orderByLength[j]))
+                    {
+                        if (orderByLength[i].Angle(orderByLength[j]) <= angleTolerance)
+                        {
+                            sublist.Add(orderByLength[j]);
+                            orderByLength.RemoveAt(j);
+                            j = j - 1;
+                        }
+                    }
+                }
+                orderByLength.RemoveAt(i);
+                i = i - 1;
+                result.Add(sublist);
+            }
+
+            return result;
+        }
+
+        /******************************************/
+    }
+}
+

--- a/Spatial_Engine/Query/DominantVector.cs
+++ b/Spatial_Engine/Query/DominantVector.cs
@@ -114,22 +114,20 @@ namespace BH.Engine.Spatial
             List<List<Vector>> result = new List<List<Vector>>();
             List<Vector> orderByLength = vectors.OrderByDescending(x => x.Length()).ToList();
 
-            for (int i = 0; i < orderByLength.Count; i++)
+            while (orderByLength.Count != 0)
             {
                 List<Vector> sublist = new List<Vector>();
-                sublist.Add(orderByLength[i]);
+                sublist.Add(orderByLength[0]);
                 
-                for (int j = 1; j < orderByLength.Count; j++)
+                for (int i = orderByLength.Count - 1; i > 0; i--)
                 {
-                    if (orderByLength[i].IsParallel(orderByLength[j],angleTolerance) != 0)
+                    if (orderByLength[0].IsParallel(orderByLength[i],angleTolerance) != 0)
                     {
-                        sublist.Add(orderByLength[j]);
-                        orderByLength.RemoveAt(j);
-                        j = j - 1;
+                        sublist.Add(orderByLength[i]);
+                        orderByLength.RemoveAt(i);
                     }
                 }
-                orderByLength.RemoveAt(i);
-                i = i - 1;
+                orderByLength.RemoveAt(0);
                 result.Add(sublist);
             }
 
@@ -139,4 +137,3 @@ namespace BH.Engine.Spatial
         /******************************************/
     }
 }
-

--- a/Spatial_Engine/Query/DominantVector.cs
+++ b/Spatial_Engine/Query/DominantVector.cs
@@ -46,7 +46,11 @@ namespace BH.Engine.Spatial
         public static BH.oM.Geometry.Vector DominantVector(IElement1D element1D, bool orthogonalPriority = true, double orthogonalLengthTolerance = 0.5, double angleTolerance = BH.oM.Geometry.Tolerance.Angle)
         {
             List<ICurve> curves = element1D.IGeometry().ISubParts().ToList();
-            List<Vector> vectors = curves.Select(x => x.IStartDir() * x.Length()).ToList();
+            
+            if(!curves.Any(x=> x.IIsLinear()))
+                BH.Engine.Reflection.Compute.RecordWarning("Non-linear curves are using an approximate vector between its start and end.");
+            
+            List<Vector> vectors = curves.Select(x => (x.IStartPoint() -x.IEndPoint())).ToList();
 
             //group vectors by direction whilst comparing angle for tolerance
             List<List<Vector>> groupByNormal = GroupSimilarVectorsWithTolerance(vectors, angleTolerance);

--- a/Spatial_Engine/Spatial_Engine.csproj
+++ b/Spatial_Engine/Spatial_Engine.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Modify\MapPositionDomain.cs" />
     <Compile Include="Modify\RoundCoordinates.cs" />
     <Compile Include="Modify\Transform.cs" />
+    <Compile Include="Query\DominantVector.cs" />
     <Compile Include="Query\HasMergeablePropertiesWith.cs" />
     <Compile Include="Query\InternalOutlineCurves.cs" />
     <Compile Include="Create\NewElement0D.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2537

This new method queries `IElement1D` and `IElement2D` for their dominant vector (orientation). The logic is very simple, it groups all similar vectors and sort them by summed lengths. The longest length is the dominant vector and hence it's selected. The method also allows for orthogonal vector priority, where if true it tries to return orthogonal vectors, and a angle discrepancy tolerance when grouping vectors.


### Test files
Test file is [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FSpatial%5FEngine%2F%232537%2DAddQueryDominantVector). I have not included a GH proof because quite honestly I don't even know how to do it with standard nodes. 


### Changelog
Adds `BH.Engine.Spatial.Query.DominantVector`

