### PR TITLE
MEP_Engine: Transform added for Fitting objects

### DIFF
--- a/MEP_Engine/Modify/Transform.cs
+++ b/MEP_Engine/Modify/Transform.cs
@@ -26,15 +26,39 @@ using BH.oM.Geometry;
 using BH.oM.MEP.System;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
+using System.Linq;
+using BH.oM.MEP.System.Fittings;
 
 namespace BH.Engine.MEP
 {
     public static partial class Modify
     {
         /***************************************************/
-        /**** Interface Methods - IElements             ****/
+        /****               Public Methods              ****/
         /***************************************************/
 
+        [Description("Transforms the Fitting's location and connections location points by the transform matrix. Only rigid body transformations are supported.")]
+        [Input("fitting", "Fitting to transform.")]
+        [Input("transform", "Transform matrix.")]
+        [Input("tolerance", "Tolerance used in the check whether the input matrix is equivalent to the rigid body transformation.")]
+        [Output("transformed", "Modified Fitting with unchanged properties, but transformed location and connections location points.")]
+        public static Fitting Transform(this Fitting fitting, TransformMatrix transform, double tolerance = Tolerance.Distance)
+        {
+            if (!transform.IsRigidTransformation(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
+                return null;
+            }
+
+            Fitting result = fitting.GetShallowClone() as Fitting;
+            result.Location = result.Location.Transform(transform);
+            result.ConnectionsLocation = result.ConnectionsLocation.Select(x=>x.Transform(transform)).ToList();
+
+            return result;
+        }
+
+        /***************************************************/
+        
         [Description("Transforms the CableTray's end points and orientation angle by the transform matrix. Only rigid body transformations are supported.")]
         [Input("cableTray", "CableTray to transform.")]
         [Input("transform", "Transform matrix.")]

--- a/MEP_Engine/Modify/Transform.cs
+++ b/MEP_Engine/Modify/Transform.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.MEP
                 return null;
             }
 
-            Fitting result = fitting.GetShallowClone() as Fitting;
+            Fitting result = fitting.ShallowClone();
             result.Location = result.Location.Transform(transform);
             result.ConnectionsLocation = result.ConnectionsLocation.Select(x => x.Transform(transform)).ToList();
 
@@ -112,4 +112,3 @@ namespace BH.Engine.MEP
         /***************************************************/
     }
 }
-

--- a/MEP_Engine/Modify/Transform.cs
+++ b/MEP_Engine/Modify/Transform.cs
@@ -52,7 +52,7 @@ namespace BH.Engine.MEP
 
             Fitting result = fitting.GetShallowClone() as Fitting;
             result.Location = result.Location.Transform(transform);
-            result.ConnectionsLocation = result.ConnectionsLocation.Select(x=>x.Transform(transform)).ToList();
+            result.ConnectionsLocation = result.ConnectionsLocation.Select(x => x.Transform(transform)).ToList();
 
             return result;
         }
@@ -112,5 +112,4 @@ namespace BH.Engine.MEP
         /***************************************************/
     }
 }
-
 

--- a/MEP_Engine/Query/Geometry.cs
+++ b/MEP_Engine/Query/Geometry.cs
@@ -60,9 +60,14 @@ namespace BH.Engine.MEP
                 return null;
             
             List<Line> result = new List<Line>();
-            if (fitting.ConnectionsLocation.Count == 2)
-                result.Add(BH.Engine.Geometry.Create.Line(fitting.ConnectionsLocation[0], fitting.ConnectionsLocation[1]));
             
+            if (fitting.ConnectionsLocation.Count <= 1)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Only one or less connectors were found in this fitting. Could not query the intended geometry.");
+                return result;
+            }
+            else if (fitting.ConnectionsLocation.Count == 2)
+                result.Add(BH.Engine.Geometry.Create.Line(fitting.ConnectionsLocation[0], fitting.ConnectionsLocation[1]));
             else
             {
                 foreach (Point point in fitting.ConnectionsLocation)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->



   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2545 

<!-- Add short description of what has been fixed -->

The Fitting object requires a `Modify.Transform` method for certain Revit convert operations.



### Changelog
Modified `BH.Engine.MEP.Modify.Transform`
Modified `BH.Engine.MEP.Query.Geometry`

### Additional comments
Added a safety check in `BH.Engine.MEP.Query.Geometry`. 