### PR TITLE
Structure_Engine: Replace calls to Clone, IClone, and GetShallowClone methods with calls to DeepClone and ShallowClone 

### DIFF
--- a/Structure_Engine/Compute/PlasticModulus.cs
+++ b/Structure_Engine/Compute/PlasticModulus.cs
@@ -32,6 +32,7 @@ using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Geometry.CoordinateSystem;
 using BH.oM.Quantities.Attributes;
+using BH.Engine.Base;
 
 namespace BH.Engine.Structure
 {
@@ -167,7 +168,7 @@ namespace BH.Engine.Structure
             }
 
             d = 0;
-            return curve.IClone();
+            return curve.DeepClone();
         }
 
         /***************************************************/

--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -51,7 +51,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Node result = node.ShallowClone() as Node;
+            Node result = node.ShallowClone();
             result.Position = result.Position.Transform(transform);
             result.Orientation = result.Orientation?.Transform(transform);
             return result;
@@ -72,7 +72,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Bar result = bar.ShallowClone() as Bar;
+            Bar result = bar.ShallowClone();
             result.StartNode = result.StartNode.Transform(transform, tolerance);
             result.EndNode = result.EndNode.Transform(transform, tolerance);
             
@@ -98,7 +98,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            RigidLink result = link.ShallowClone() as RigidLink;
+            RigidLink result = link.ShallowClone();
             result.PrimaryNode = result.PrimaryNode.Transform(transform, tolerance);
             result.SecondaryNodes = result.SecondaryNodes.Select(x => x.Transform(transform, tolerance)).ToList();
             return result;
@@ -119,7 +119,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Edge result = edge.ShallowClone() as Edge;
+            Edge result = edge.ShallowClone();
             result.Curve = result.Curve.ITransform(transform);
             return result;
         }
@@ -139,7 +139,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Opening result = opening.ShallowClone() as Opening;
+            Opening result = opening.ShallowClone();
             result.Edges = result.Edges.Select(x => x.Transform(transform, tolerance)).ToList();
             return result;
         }
@@ -159,7 +159,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Panel result = panel.ShallowClone() as Panel;
+            Panel result = panel.ShallowClone();
             result.ExternalEdges = result.ExternalEdges.Select(x => x.Transform(transform, tolerance)).ToList();
             result.Openings = result.Openings.Select(x => x.Transform(transform, tolerance)).ToList();
 
@@ -187,7 +187,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            FEMesh result = mesh.ShallowClone() as FEMesh;
+            FEMesh result = mesh.ShallowClone();
             result.Nodes = result.Nodes.Select(x => x.Transform(transform, tolerance)).ToList();
 
             List<Basis> orientationsBefore = mesh.LocalOrientations();
@@ -203,4 +203,3 @@ namespace BH.Engine.Structure
         /***************************************************/
     }
 }
-

--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -20,6 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.Engine.Geometry;
 using BH.Engine.Spatial;
 using BH.oM.Geometry;
@@ -50,7 +51,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Node result = node.GetShallowClone() as Node;
+            Node result = node.ShallowClone() as Node;
             result.Position = result.Position.Transform(transform);
             result.Orientation = result.Orientation?.Transform(transform);
             return result;
@@ -71,7 +72,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Bar result = bar.GetShallowClone() as Bar;
+            Bar result = bar.ShallowClone() as Bar;
             result.StartNode = result.StartNode.Transform(transform, tolerance);
             result.EndNode = result.EndNode.Transform(transform, tolerance);
             
@@ -97,7 +98,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            RigidLink result = link.GetShallowClone() as RigidLink;
+            RigidLink result = link.ShallowClone() as RigidLink;
             result.PrimaryNode = result.PrimaryNode.Transform(transform, tolerance);
             result.SecondaryNodes = result.SecondaryNodes.Select(x => x.Transform(transform, tolerance)).ToList();
             return result;
@@ -118,7 +119,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Edge result = edge.GetShallowClone() as Edge;
+            Edge result = edge.ShallowClone() as Edge;
             result.Curve = result.Curve.ITransform(transform);
             return result;
         }
@@ -138,7 +139,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Opening result = opening.GetShallowClone() as Opening;
+            Opening result = opening.ShallowClone() as Opening;
             result.Edges = result.Edges.Select(x => x.Transform(transform, tolerance)).ToList();
             return result;
         }
@@ -158,7 +159,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            Panel result = panel.GetShallowClone() as Panel;
+            Panel result = panel.ShallowClone() as Panel;
             result.ExternalEdges = result.ExternalEdges.Select(x => x.Transform(transform, tolerance)).ToList();
             result.Openings = result.Openings.Select(x => x.Transform(transform, tolerance)).ToList();
 
@@ -186,7 +187,7 @@ namespace BH.Engine.Structure
                 return null;
             }
 
-            FEMesh result = mesh.GetShallowClone() as FEMesh;
+            FEMesh result = mesh.ShallowClone() as FEMesh;
             result.Nodes = result.Nodes.Select(x => x.Transform(transform, tolerance)).ToList();
 
             List<Basis> orientationsBefore = mesh.LocalOrientations();


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2201

<!-- Add short description of what has been fixed -->
See BHoM/admin#9

- Replaced calls to Geometry.Clone and Geometry.IClone to calls to Engine.Base.DeepClone(). Feel free to use Engine.Base.ShallowClone() where you feel appropriate.
- Replaced calls to GetShallowClone with calls to Engine.Base.ShallowClone()

### Test files
<!-- Link to test files to validate the proposed changes -->

Just compliance, no functional change.

- Review the code itself to make sure it compiles and makes sense
- Run the standard testing procedure that involve the structure engine

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->