### PR TITLE
Geometry_Engine: Added tolerance to Create PlanarSurface and methods it relies on

### DIFF
--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -43,6 +43,18 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         public static List<List<Polyline>> DistributeOutlines(this List<Polyline> outlines, double tolerance = Tolerance.Distance)
         {
+            if (outlines == null || outlines.Where(x => x != null).Count() == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null list of outlines.");
+                return new List<List<Polyline>>();
+            }
+
+            if (tolerance == double.NaN)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute outlines as tolerance is null.");
+                return new List<List<Polyline>>();
+            }
+
             foreach (Polyline p in outlines)
             {
                 if (!p.IsClosed(tolerance))
@@ -86,6 +98,18 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         public static List<List<ICurve>> DistributeOutlines(this List<ICurve> outlines, double tolerance = Tolerance.Distance)
         {
+            if (outlines == null || outlines.Where(x => x != null).Count() == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null list of outlines.");
+                return new List<List<ICurve>>();
+            }
+
+            if (tolerance == double.NaN)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute outlines as tolerance is null.");
+                return new List<List<ICurve>>();
+            }
+
             foreach (ICurve p in outlines)
             {
                 if (!p.IIsClosed(tolerance))
@@ -132,6 +156,18 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<Polyline>> DistributeOpenings(this List<Polyline> panels, List<Polyline> openings, double tolerance = Tolerance.Distance)
         {
+            if (panels == null || panels.Where(x => x != null).Count() == 0 || openings == null || openings.Where(x => x != null).Count() == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null list of panels/openings.");
+                return new List<List<Polyline>>();
+            }
+
+            if (tolerance == double.NaN)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute outlines as tolerance is null.");
+                return new List<List<Polyline>>();
+            }
+
             List<List<Polyline>> result = new List<List<Polyline>>();
             foreach (Polyline p in panels)
             {
@@ -163,6 +199,18 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<PolyCurve>> DistributeOpenings(this List<PolyCurve> panels, List<PolyCurve> openings, double tolerance = Tolerance.Distance)
         {
+            if (panels == null || panels.Where(x => x != null).Count() == 0 || openings == null || openings.Where(x => x != null).Count() == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null list of panels/openings.");
+                return new List<List<PolyCurve>>();
+            }
+
+            if (tolerance == double.NaN)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute outlines as tolerance is null.");
+                return new List<List<PolyCurve>>();
+            }
+
             List<List<PolyCurve>> result = new List<List<PolyCurve>>();
             foreach (PolyCurve p in panels)
             {
@@ -194,6 +242,12 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<ICurve>> DistributeOpenings(this List<ICurve> panels, List<ICurve> openings, double tolerance = Tolerance.Distance)
         {
+            if (panels == null || panels.Where(x => x != null).Count() == 0 || openings == null || openings.Where(x => x != null).Count() == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null list of panels/openings.");
+                return new List<List<ICurve>>();
+            }
+
             List<List<ICurve>> result = new List<List<ICurve>>();
             foreach (ICurve p in panels)
             {

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -86,7 +86,7 @@ namespace BH.Engine.Geometry
 
             outlines.Sort(delegate (ICurve p1, ICurve p2)
             {
-                return p1.IArea().CompareTo(p2.IArea());
+                return p1.IArea(tolerance).CompareTo(p2.IArea(tolerance));
             });
             outlines.Reverse();
 

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -49,12 +49,6 @@ namespace BH.Engine.Geometry
                 return new List<List<Polyline>>();
             }
 
-            if (tolerance == double.NaN)
-            {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute outlines as tolerance is null.");
-                return new List<List<Polyline>>();
-            }
-
             foreach (Polyline p in outlines)
             {
                 if (!p.IsClosed(tolerance))
@@ -101,12 +95,6 @@ namespace BH.Engine.Geometry
             if (outlines == null || outlines.Where(x => x != null).Count() == 0)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null list of outlines.");
-                return new List<List<ICurve>>();
-            }
-
-            if (tolerance == double.NaN)
-            {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute outlines as tolerance is null.");
                 return new List<List<ICurve>>();
             }
 
@@ -162,12 +150,6 @@ namespace BH.Engine.Geometry
                 return new List<List<Polyline>>();
             }
 
-            if (tolerance == double.NaN)
-            {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute outlines as tolerance is null.");
-                return new List<List<Polyline>>();
-            }
-
             List<List<Polyline>> result = new List<List<Polyline>>();
             foreach (Polyline p in panels)
             {
@@ -202,12 +184,6 @@ namespace BH.Engine.Geometry
             if (panels == null || panels.Where(x => x != null).Count() == 0 || openings == null || openings.Where(x => x != null).Count() == 0)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null list of panels/openings.");
-                return new List<List<PolyCurve>>();
-            }
-
-            if (tolerance == double.NaN)
-            {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute outlines as tolerance is null.");
                 return new List<List<PolyCurve>>();
             }
 

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -20,12 +20,14 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System.Collections.Generic;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Geometry;
-using System;
-using System.Linq;
 using BH.Engine.Base;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Collections.Generic;
+
 
 namespace BH.Engine.Geometry
 {
@@ -35,7 +37,10 @@ namespace BH.Engine.Geometry
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [DeprecatedAttribute("Moved to Common_Engine")]
+        [Description("Distributes outlines into lists representing containing outlines and the outlines that they each contain.")]
+        [Input("outlines", "The outlines to sort.")]
+        [Input("tolerance", "The tolerance to apply when detecting if outlines are closed and contained.")]
+        [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         public static List<List<Polyline>> DistributeOutlines(this List<Polyline> outlines, double tolerance = Tolerance.Distance)
         {
             foreach (Polyline p in outlines)
@@ -75,7 +80,10 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [DeprecatedAttribute("Moved to Common_Engine")]
+        [Description("Distributes outlines into lists representing containing outlines and the outlines that they each contain.")]
+        [Input("outlines", "The outlines to sort.")]
+        [Input("tolerance", "The tolerance to apply when detecting if outlines are closed and contained.")]
+        [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         public static List<List<ICurve>> DistributeOutlines(this List<ICurve> outlines, double tolerance = Tolerance.Distance)
         {
             foreach (ICurve p in outlines)
@@ -117,7 +125,11 @@ namespace BH.Engine.Geometry
         /**** Private Methods                           ****/
         /***************************************************/
 
-        [DeprecatedAttribute("Moved to Common_Engine")]
+        [Description("Distributes outlines into lists representing containing outlines and the outlines that they each contain.")]
+        [Input("panels", "The Polylines representing the containing outlines.")]
+        [Input("openings", "The Polylines representing the contained outlines.")]
+        [Input("tolerance", "The tolerance to apply when detecting if outlines are closed and contained.")]
+        [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<Polyline>> DistributeOpenings(this List<Polyline> panels, List<Polyline> openings, double tolerance = Tolerance.Distance)
         {
             List<List<Polyline>> result = new List<List<Polyline>>();
@@ -144,7 +156,11 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [DeprecatedAttribute("Moved to Common_Engine")]
+        [Description("Distributes outlines into lists representing containing outlines and the outlines that they each contain.")]
+        [Input("panels", "The PolyCurves representing the containing outlines.")]
+        [Input("openings", "The PolyCurves representing the contained outlines.")]
+        [Input("tolerance", "The tolerance to apply when detecting if outlines are closed and contained.")]
+        [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<PolyCurve>> DistributeOpenings(this List<PolyCurve> panels, List<PolyCurve> openings, double tolerance = Tolerance.Distance)
         {
             List<List<PolyCurve>> result = new List<List<PolyCurve>>();
@@ -171,7 +187,11 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        [DeprecatedAttribute("Moved to Common_Engine")]
+        [Description("Distributes outlines into lists representing containing outlines and the outlines that they each contain.")]
+        [Input("panels", "The curves representing the containing outlines.")]
+        [Input("openings", "The curves representing the contained outlines.")]
+        [Input("tolerance", "The tolerance to apply when detecting if outlines are closed and contained.")]
+        [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<ICurve>> DistributeOpenings(this List<ICurve> panels, List<ICurve> openings, double tolerance = Tolerance.Distance)
         {
             List<List<ICurve>> result = new List<List<ICurve>>();

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -42,6 +42,15 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Create.PlanarSurface(BH.oM.Geometry.ICurve, System.Collections.Generic.List<BH.oM.Geometry.ICurve>)")]
         public static PlanarSurface PlanarSurface(ICurve externalBoundary, List<ICurve> internalBoundaries = null, double tolerance = Tolerance.Distance)
         {
+            if (externalBoundary == null || internalBoundaries == null || internalBoundaries.Where(x => x != null).Count() == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from null curves.");
+                return null;
+            }
+
+            if (tolerance == double.NaN)
+                tolerance = Tolerance.Distance;
+
             //--------------Planar-External-Boundary-----------------------//
             if (!externalBoundary.IIsPlanar(tolerance))
             {
@@ -159,6 +168,15 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Create.PlanarSurface(System.Collections.Generic.List<BH.oM.Geometry.ICurve)")]
         public static List<PlanarSurface> PlanarSurface(List<ICurve> boundaryCurves, double tolerance = Tolerance.Distance)
         {
+            if (boundaryCurves == null || boundaryCurves.Where(x => x != null).Count() == 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from null curves.");
+                return null;
+            }
+
+            if (tolerance == double.NaN)
+                tolerance = Tolerance.Distance;
+
             List<ICurve> checkedCurves = boundaryCurves.Where(x => x.IIsClosed(tolerance) && x.IIsPlanar(tolerance)).ToList();
             List<List<ICurve>> distributed = Compute.DistributeOutlines(checkedCurves, tolerance);
 

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -48,9 +48,6 @@ namespace BH.Engine.Geometry
                 return null;
             }
 
-            if (tolerance == double.NaN)
-                tolerance = Tolerance.Distance;
-
             //--------------Planar-External-Boundary-----------------------//
             if (!externalBoundary.IIsPlanar(tolerance))
             {
@@ -173,9 +170,6 @@ namespace BH.Engine.Geometry
                 BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from null curves.");
                 return null;
             }
-
-            if (tolerance == double.NaN)
-                tolerance = Tolerance.Distance;
 
             List<ICurve> checkedCurves = boundaryCurves.Where(x => x.IIsClosed(tolerance) && x.IIsPlanar(tolerance)).ToList();
             List<List<ICurve>> distributed = Compute.DistributeOutlines(checkedCurves, tolerance);

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -34,11 +34,12 @@ namespace BH.Engine.Geometry
         /***************************************************/
         /**** Public Methods                            ****/
         /***************************************************/
-
-        [Description("Creates a PlanarSurface based on boundary curves. Only processing done by this method is checking (co)planarity and that the curves are closed. Internal edges will be assumed to be inside the External")]
-        [Input("externalBoundary", "The outer boundary curve of the surface. Needs to be closed and planar")]
-        [Input("internalBoundaries", "Optional internal boundary curves descibing any openings inside the external. All internal edges need to be closed and co-planar with the external edge")]
-        [Output("PlanarSurface", "Planar surface corresponding to the provided edge curves")]
+        
+        [Description("Creates a PlanarSurface based on boundary curves. Only processing done by this method is checking (co)planarity and that the curves are closed. Internal edges will be assumed to be inside the External.")]
+        [Input("externalBoundary", "The outer boundary curve of the surface. Needs to be closed and planar.")]
+        [Input("internalBoundaries", "Optional internal boundary curves descibing any openings inside the external. All internal edges need to be closed and co-planar with the external edge.")]
+        [Output("PlanarSurface", "Planar surface corresponding to the provided edge curves.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Create.PlanarSurface(BH.oM.Geometry.ICurve, System.Collections.Generic.List<BH.oM.Geometry.ICurve>)")]
         public static PlanarSurface PlanarSurface(ICurve externalBoundary, List<ICurve> internalBoundaries = null, double tolerance = Tolerance.Distance)
         {
             //--------------Planar-External-Boundary-----------------------//
@@ -139,7 +140,7 @@ namespace BH.Engine.Geometry
             //---------------Contained-By-External-Boundary-----------------//
             count = internalBoundaries.Count;
 
-            internalBoundaries = internalBoundaries.Where(x => x.ISubParts().Any(y => y is NurbsCurve || y is Ellipse) || externalBoundary.IIsContaining(x)).ToList();
+            internalBoundaries = internalBoundaries.Where(x => x.ISubParts().Any(y => y is NurbsCurve || y is Ellipse) || externalBoundary.IIsContaining(x, true, tolerance)).ToList();
 
             if (internalBoundaries.Count != count)
             {
@@ -151,10 +152,11 @@ namespace BH.Engine.Geometry
         }
 
         /***************************************************/
-
-        [Description("Distributes the edge curve and creates a set of boundary planar surfaces")]
-        [Input("boundaryCurves", "Boundary curves to be used. Non-planar and non-closed curves are ignored")]
-        [Output("PlanarSurface", "List of planar surfaces created")]
+        
+        [Description("Distributes the edge curve and creates a set of boundary planar surfaces.")]
+        [Input("boundaryCurves", "Boundary curves to be used. Non-planar and non-closed curves are ignored.")]
+        [Output("PlanarSurface", "List of planar surfaces created.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Create.PlanarSurface(System.Collections.Generic.List<BH.oM.Geometry.ICurve)")]
         public static List<PlanarSurface> PlanarSurface(List<ICurve> boundaryCurves, double tolerance = Tolerance.Distance)
         {
             List<ICurve> checkedCurves = boundaryCurves.Where(x => x.IIsClosed(tolerance) && x.IIsPlanar(tolerance)).ToList();

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -22,9 +22,11 @@
 
 using BH.Engine.Base;
 using BH.oM.Geometry;
+using BH.oM.Reflection.Attributes;
+using System.Linq;
+using System.ComponentModel;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace BH.Engine.Geometry
 {
@@ -34,6 +36,11 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("geometry", "Geometry to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.IArea(BH.oM.Geometry.IGeometry)")]
         public static double IArea(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
             return Area(geometry as dynamic, tolerance);
@@ -44,6 +51,12 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("curve", "The Arc to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.Arc)")]
+        
         public static double Area(this Arc curve, double tolerance = Tolerance.Distance)
         {
             if (curve.IsClosed(tolerance))
@@ -57,12 +70,24 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("curve", "The Circle to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.Circle)")]
+
         public static double Area(this Circle curve, double tolerance = Tolerance.Distance)
         {
             return Math.PI * curve.Radius * curve.Radius;
         }
 
         /***************************************************/
+
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("curve", "The Line to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.Line)")]
 
         public static double Area(this Line curve, double tolerance = Tolerance.Distance)
         {
@@ -72,6 +97,12 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("curve", "The PolyCurve to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.PolyCurve)")]
+        
         public static double Area(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
             if (curve.Curves.Count == 1 && curve.Curves[0] is Circle)
@@ -122,6 +153,12 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("curve", "The Polyline to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.Polyline)")]
+
         public static double Area(this Polyline curve, double tolerance = Tolerance.Distance)
         {
             if (!curve.IsClosed(tolerance))
@@ -157,6 +194,12 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Surfaces                 ****/
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("mesh", "The mesh to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.Mesh)")]
+        
         public static double Area(this Mesh mesh, double tolerance = Tolerance.Distance)
         {
             Mesh tMesh = mesh.Triangulate();
@@ -179,6 +222,12 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("pSurf", "The PolySurface to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.PolySurface)")]
+        
         public static double Area(this PolySurface pSurf, double tolerance = Tolerance.Distance)
         {
             return pSurf.Surfaces.Sum(x => x.IArea(tolerance));
@@ -186,6 +235,12 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("pSurf", "The PlanarSurface to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.PlanarSurface)")]
+        
         public static double Area(this PlanarSurface pSurf, double tolerance = Tolerance.Distance)
         {
             double area = pSurf.ExternalBoundary.IArea(tolerance);
@@ -203,6 +258,13 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Vectors                  ****/
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("v1", "First vector to use for vector-based area calculation.")]
+        [Input("v2", "Second vector to use for vector-based area calculation.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.Vector, BH.oM.Geometry.Vector)")]
+        
         public static double Area(this Vector v1, Vector v2, double tolerance = Tolerance.Distance)
         {
             double area = 0;
@@ -216,6 +278,12 @@ namespace BH.Engine.Geometry
         /**** Private Methods - Fallbacks               ****/
         /***************************************************/
 
+        [Description("Calculates the area of the provided geometry.")]
+        [Input("geometry", "Geometry to get the area of.")]
+        [Input("tolerance", "The tolerance to apply to the area calculation.")]
+        [Output("area", "The area of the geometry.")]
+        [PreviousVersion("4.3", "BH.Engine.Geometry.Query.Area(BH.oM.Geometry.IGeometry)")]
+        
         private static double Area(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
             Reflection.Compute.RecordError("Area for " + geometry.GetType().Name + " is not implemented.");

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -43,6 +43,12 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Query.IArea(BH.oM.Geometry.IGeometry)")]
         public static double IArea(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
+            if (geometry == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+
             return Area(geometry as dynamic, tolerance);
         }
 
@@ -59,6 +65,12 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Arc curve, double tolerance = Tolerance.Distance)
         {
+            if (curve == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+            
             if (curve.IsClosed(tolerance))
                 return Math.PI * curve.Radius * curve.Radius;
             else
@@ -78,6 +90,13 @@ namespace BH.Engine.Geometry
 
         public static double Area(this Circle curve, double tolerance = Tolerance.Distance)
         {
+            if (curve == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+
+
             return Math.PI * curve.Radius * curve.Radius;
         }
 
@@ -105,6 +124,12 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
+            if (curve == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+            
             if (curve.Curves.Count == 1 && curve.Curves[0] is Circle)
                 return (curve.Curves[0] as Circle).Area(tolerance);
 
@@ -161,6 +186,12 @@ namespace BH.Engine.Geometry
 
         public static double Area(this Polyline curve, double tolerance = Tolerance.Distance)
         {
+            if (curve == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+            
             if (!curve.IsClosed(tolerance))
             {
                 Reflection.Compute.RecordWarning("Cannot calculate area for an open curve.");
@@ -202,6 +233,12 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Mesh mesh, double tolerance = Tolerance.Distance)
         {
+            if (mesh == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+            
             Mesh tMesh = mesh.Triangulate();
             double area = 0;
             List<Face> faces = tMesh.Faces;
@@ -230,6 +267,12 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PolySurface pSurf, double tolerance = Tolerance.Distance)
         {
+            if (pSurf == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+            
             return pSurf.Surfaces.Sum(x => x.IArea(tolerance));
         }
 
@@ -243,6 +286,12 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PlanarSurface pSurf, double tolerance = Tolerance.Distance)
         {
+            if (pSurf == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+            
             double area = pSurf.ExternalBoundary.IArea(tolerance);
 
             if (pSurf.InternalBoundaries != null)
@@ -267,6 +316,12 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Vector v1, Vector v2, double tolerance = Tolerance.Distance)
         {
+            if (v2 == null || v2 == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+            
             double area = 0;
             area = Length(CrossProduct(v1, v2)) / 2;
 
@@ -286,6 +341,12 @@ namespace BH.Engine.Geometry
         
         private static double Area(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
+            if (geometry == null)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                return double.NaN;
+            }
+            
             Reflection.Compute.RecordError("Area for " + geometry.GetType().Name + " is not implemented.");
             return double.NaN;
         }

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -43,9 +43,9 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Query.IArea(BH.oM.Geometry.IGeometry)")]
         public static double IArea(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
-            if (geometry == null || tolerance == double.NaN)
+            if (geometry == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
 
@@ -65,9 +65,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Arc curve, double tolerance = Tolerance.Distance)
         {
-            if (curve == null || tolerance == double.NaN)
+            if (curve == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
             
@@ -90,9 +90,9 @@ namespace BH.Engine.Geometry
 
         public static double Area(this Circle curve, double tolerance = Tolerance.Distance)
         {
-            if (curve == null || tolerance == double.NaN)
+            if (curve == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
 
@@ -124,9 +124,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
-            if (curve == null || tolerance == double.NaN)
+            if (curve == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
             
@@ -186,9 +186,9 @@ namespace BH.Engine.Geometry
 
         public static double Area(this Polyline curve, double tolerance = Tolerance.Distance)
         {
-            if (curve == null || tolerance == double.NaN)
+            if (curve == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
             
@@ -233,9 +233,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Mesh mesh, double tolerance = Tolerance.Distance)
         {
-            if (mesh == null || tolerance == double.NaN)
+            if (mesh == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
             
@@ -267,9 +267,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PolySurface pSurf, double tolerance = Tolerance.Distance)
         {
-            if (pSurf == null || tolerance == double.NaN)
+            if (pSurf == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
             
@@ -286,9 +286,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PlanarSurface pSurf, double tolerance = Tolerance.Distance)
         {
-            if (pSurf == null || tolerance == double.NaN)
+            if (pSurf == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
             
@@ -316,9 +316,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Vector v1, Vector v2, double tolerance = Tolerance.Distance)
         {
-            if (v2 == null || v2 == null || tolerance == double.NaN)
+            if (v2 == null || v2 == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
             
@@ -341,9 +341,9 @@ namespace BH.Engine.Geometry
         
         private static double Area(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
-            if (geometry == null || tolerance == double.NaN)
+            if (geometry == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as the geometry is null.");
                 return double.NaN;
             }
             

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -43,9 +43,9 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Query.IArea(BH.oM.Geometry.IGeometry)")]
         public static double IArea(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
-            if (geometry == null)
+            if (geometry == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
 
@@ -65,9 +65,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Arc curve, double tolerance = Tolerance.Distance)
         {
-            if (curve == null)
+            if (curve == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
             
@@ -90,9 +90,9 @@ namespace BH.Engine.Geometry
 
         public static double Area(this Circle curve, double tolerance = Tolerance.Distance)
         {
-            if (curve == null)
+            if (curve == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
 
@@ -124,9 +124,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
-            if (curve == null)
+            if (curve == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
             
@@ -186,9 +186,9 @@ namespace BH.Engine.Geometry
 
         public static double Area(this Polyline curve, double tolerance = Tolerance.Distance)
         {
-            if (curve == null)
+            if (curve == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
             
@@ -233,9 +233,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Mesh mesh, double tolerance = Tolerance.Distance)
         {
-            if (mesh == null)
+            if (mesh == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
             
@@ -267,9 +267,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PolySurface pSurf, double tolerance = Tolerance.Distance)
         {
-            if (pSurf == null)
+            if (pSurf == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
             
@@ -286,9 +286,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this PlanarSurface pSurf, double tolerance = Tolerance.Distance)
         {
-            if (pSurf == null)
+            if (pSurf == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
             
@@ -316,9 +316,9 @@ namespace BH.Engine.Geometry
         
         public static double Area(this Vector v1, Vector v2, double tolerance = Tolerance.Distance)
         {
-            if (v2 == null || v2 == null)
+            if (v2 == null || v2 == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
             
@@ -341,9 +341,9 @@ namespace BH.Engine.Geometry
         
         private static double Area(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
-            if (geometry == null)
+            if (geometry == null || tolerance == double.NaN)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot query the area of null geometry.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot query area as one of the inputs is null.");
                 return double.NaN;
             }
             

--- a/Geometry_Engine/Query/Area.cs
+++ b/Geometry_Engine/Query/Area.cs
@@ -34,9 +34,9 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 
-        public static double IArea(this IGeometry geometry)
+        public static double IArea(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
-            return Area(geometry as dynamic);
+            return Area(geometry as dynamic, tolerance);
         }
 
 
@@ -44,9 +44,9 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Curves                   ****/
         /***************************************************/
 
-        public static double Area(this Arc curve)
+        public static double Area(this Arc curve, double tolerance = Tolerance.Distance)
         {
-            if (curve.IsClosed())
+            if (curve.IsClosed(tolerance))
                 return Math.PI * curve.Radius * curve.Radius;
             else
             {
@@ -57,14 +57,14 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static double Area(this Circle curve)
+        public static double Area(this Circle curve, double tolerance = Tolerance.Distance)
         {
             return Math.PI * curve.Radius * curve.Radius;
         }
 
         /***************************************************/
 
-        public static double Area(this Line curve)
+        public static double Area(this Line curve, double tolerance = Tolerance.Distance)
         {
             Reflection.Compute.RecordWarning("Cannot calculate area for an open curve.");
             return 0;
@@ -72,18 +72,18 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static double Area(this PolyCurve curve)
+        public static double Area(this PolyCurve curve, double tolerance = Tolerance.Distance)
         {
             if (curve.Curves.Count == 1 && curve.Curves[0] is Circle)
-                return (curve.Curves[0] as Circle).Area();
+                return (curve.Curves[0] as Circle).Area(tolerance);
 
-            if (!curve.IsClosed())
+            if (!curve.IsClosed(tolerance))
             {
                 Reflection.Compute.RecordWarning("Cannot calculate area for an open curve.");
                 return 0;
             }
 
-            Plane p = curve.FitPlane();
+            Plane p = curve.FitPlane(tolerance);
             if (p == null)
                 return 0.0;              // points are collinear
 
@@ -122,9 +122,9 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static double Area(this Polyline curve)
+        public static double Area(this Polyline curve, double tolerance = Tolerance.Distance)
         {
-            if (!curve.IsClosed())
+            if (!curve.IsClosed(tolerance))
             {
                 Reflection.Compute.RecordWarning("Cannot calculate area for an open curve.");
                 return 0;
@@ -135,7 +135,7 @@ namespace BH.Engine.Geometry
             if (ptsCount < 4)
                 return 0.0;
 
-            Plane p = pts.FitPlane();
+            Plane p = pts.FitPlane(tolerance);
             if (p == null)
                 return 0.0;              // points are collinear
 
@@ -157,7 +157,7 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Surfaces                 ****/
         /***************************************************/
 
-        public static double Area(this Mesh mesh)
+        public static double Area(this Mesh mesh, double tolerance = Tolerance.Distance)
         {
             Mesh tMesh = mesh.Triangulate();
             double area = 0;
@@ -179,20 +179,20 @@ namespace BH.Engine.Geometry
 
         /***************************************************/
 
-        public static double Area(this PolySurface pSurf)
+        public static double Area(this PolySurface pSurf, double tolerance = Tolerance.Distance)
         {
-            return pSurf.Surfaces.Sum(x => x.IArea());
+            return pSurf.Surfaces.Sum(x => x.IArea(tolerance));
         }
 
         /***************************************************/
 
-        public static double Area(this PlanarSurface pSurf)
+        public static double Area(this PlanarSurface pSurf, double tolerance = Tolerance.Distance)
         {
-            double area = pSurf.ExternalBoundary.IArea();
+            double area = pSurf.ExternalBoundary.IArea(tolerance);
 
             if (pSurf.InternalBoundaries != null)
             {
-                area -= pSurf.InternalBoundaries.Sum(x => x.IArea());
+                area -= pSurf.InternalBoundaries.Sum(x => x.IArea(tolerance));
             }
 
             return area;
@@ -203,7 +203,7 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Vectors                  ****/
         /***************************************************/
 
-        public static double Area(this Vector v1, Vector v2)
+        public static double Area(this Vector v1, Vector v2, double tolerance = Tolerance.Distance)
         {
             double area = 0;
             area = Length(CrossProduct(v1, v2)) / 2;
@@ -216,7 +216,7 @@ namespace BH.Engine.Geometry
         /**** Private Methods - Fallbacks               ****/
         /***************************************************/
 
-        private static double Area(this IGeometry geometry)
+        private static double Area(this IGeometry geometry, double tolerance = Tolerance.Distance)
         {
             Reflection.Compute.RecordError("Area for " + geometry.GetType().Name + " is not implemented.");
             return double.NaN;


### PR DESCRIPTION
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2575 

Tolerance param has been added to the create planar surface method and the `IArea` method that it relies on by way of the `DistributeOutlines` method. Take note of the change this has on the `IArea` method, as it now invokes tolerance but only a couple of the overloads actually use this tolerance (eg if `IIsClosed` is called before getting the area).


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Geometry_Engine/%232575-ToleranceForPlanarSurfaceCreate?csf=1&web=1&e=Y0M3jI

Note that the test file shows a specific example of tolerance behaving as desired, but does not cover all existing unit tests and the like. @pawelbaran @rolyhudson please add a link here to any relevant test files we already have for this create method, as I could not find them if they do already exist.