### PR TITLE
Reflection_Engine: Add ability to set Fragment property from list of objects

### DIFF
--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -102,16 +102,21 @@ namespace BH.Engine.Reflection
                     }   
                 }
 
-                if (propType == typeof(DateTime) && value is string)
+                if (propType == typeof(DateTime))
                 {
-                    DateTime date;
-                    if (DateTime.TryParse(value as string, out date))
-                        value = date;
-                    else
+                    if (value is string)
                     {
-                        Engine.Reflection.Compute.RecordError($"The value provided for {propName} is not a valid DateTime.");
-                        value = DateTime.MinValue;
+                        DateTime date;
+                        if (DateTime.TryParse(value as string, out date))
+                            value = date;
+                        else
+                        {
+                            Engine.Reflection.Compute.RecordError($"The value provided for {propName} is not a valid DateTime.");
+                            value = DateTime.MinValue;
+                        }
                     }
+                    else if (value is double)
+                        value = DateTime.FromOADate((double)value);
                 }
 
                 if (propType == typeof(Type) && value is string)

--- a/Reflection_Engine/Modify/SetPropertyValue.cs
+++ b/Reflection_Engine/Modify/SetPropertyValue.cs
@@ -117,6 +117,14 @@ namespace BH.Engine.Reflection
                 if (propType == typeof(Type) && value is string)
                     value = Create.Type(value as string);
 
+                if (propType == typeof(FragmentSet))
+                {
+                    if (value is IFragment)
+                        value = new FragmentSet { value as IFragment };
+                    else if (value is IEnumerable && !(value is FragmentSet))
+                        value = new FragmentSet(((IEnumerable)value).OfType<IFragment>().ToList());
+                }
+
                 if (value != null)
                 {
                     if (value.GetType() != propType && value.GetType().GenericTypeArguments.Length > 0 && propType.GenericTypeArguments.Length > 0)


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2613
Closes #2614 

### Test files
- FragmentSet: The best way to test this is to try to push load combinations using [this file](https://burohappold.sharepoint.com/:x:/r/sites/Direction/designtechnology/RandDWishlist/00270_Load%20Case%20and%20Combinations%20Excel%20Tool/BuroHappold_BHoM_v4.3.beta_Loadcases%20and%20Combinations.xlsm?d=w20416a094cc24266aa6225fad5d7a64b&csf=1&web=1&e=RkFIKq)
- DateTime: [this file](https://burohappold.sharepoint.com/:x:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Reflection_Engine/%232614-DatetimeTest.xlsx?d=wb41a7dd8771d42b3ae21ae122eb662e3&csf=1&web=1&e=gSkxtv)


