### PR TITLE
Geometry_Engine: planar surface creation and DistributeOutlines checks/messages refined

### DIFF
--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -67,12 +67,6 @@ namespace BH.Engine.Geometry
                 return new List<List<Polyline>>();
             }
 
-            if (outlines.Any(p => p.IsSelfIntersecting(tolerance)))
-            {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is self-intersecting.");
-                return new List<List<Polyline>>();
-            }
-
             outlines.Sort(delegate (Polyline p1, Polyline p2)
             {
                 return p1.Area().CompareTo(p2.Area());
@@ -137,12 +131,6 @@ namespace BH.Engine.Geometry
             if (outlines.Any(p => !p.IIsPlanar(tolerance)))
             {
                 BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not planar within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
-                return new List<List<ICurve>>();
-            }
-
-            if (outlines.Any(p => p.IIsSelfIntersecting(tolerance)))
-            {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is self-intersecting.");
                 return new List<List<ICurve>>();
             }
 

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -55,20 +55,19 @@ namespace BH.Engine.Geometry
                 return new List<List<Polyline>>();
             }
 
-            List<Point> controlPoints = outlines.SelectMany(x => x.IControlPoints()).ToList();
-            if (!controlPoints.IsCoplanar(tolerance))
-            {
-                BH.Engine.Reflection.Compute.RecordError("The input outline curves are not coplanar, therefore they could not be distributed. Please try changing the tolerance if this behaviour is not expected.");
-                return new List<List<Polyline>>();
-            }
-
             if (outlines.Any(p => !p.IsClosed(tolerance)))
             {
                 BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not closed within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
                 return new List<List<Polyline>>();
             }
 
-            if (outlines.Any(p => p.IsSelfIntersecting(tolerance)))
+            if (outlines.Any(p => !p.IsPlanar(tolerance)))
+            {
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not planar within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
+                return new List<List<Polyline>>();
+            }
+
+            if (outlines.Any(p => !p.IsSelfIntersecting(tolerance)))
             {
                 BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is self-intersecting.");
                 return new List<List<Polyline>>();
@@ -129,16 +128,15 @@ namespace BH.Engine.Geometry
                 return new List<List<ICurve>>();
             }
 
-            List<Point> controlPoints = outlines.SelectMany(x => x.IControlPoints()).ToList();
-            if (!controlPoints.IsCoplanar(tolerance))
-            {
-                BH.Engine.Reflection.Compute.RecordError("The input outline curves are not coplanar, therefore they could not be distributed. Please try changing the tolerance if this behaviour is not expected.");
-                return new List<List<ICurve>>();
-            }
-
             if (outlines.Any(p => !p.IIsClosed(tolerance)))
             {
                 BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not closed within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
+                return new List<List<ICurve>>();
+            }
+
+            if (outlines.Any(p => !p.IIsPlanar(tolerance)))
+            {
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not planar within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
                 return new List<List<ICurve>>();
             }
 

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -43,27 +43,15 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         public static List<List<Polyline>> DistributeOutlines(this List<Polyline> outlines, double tolerance = Tolerance.Distance)
         {
-            if (outlines == null)
+            if (outlines == null || outlines.Count == 0)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of outlines.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of outlines.");
                 return new List<List<Polyline>>();
             }
 
-            if (outlines.Any(x => x == null))
+            if (outlines.Any(p => !p.IIsClosed(tolerance)))
             {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is a null curve.");
-                return new List<List<Polyline>>();
-            }
-
-            if (outlines.Any(p => !p.IsClosed(tolerance)))
-            {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not closed within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
-                return new List<List<Polyline>>();
-            }
-
-            if (outlines.Any(p => !p.IsPlanar(tolerance)))
-            {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not planar within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
+                BH.Engine.Reflection.Compute.RecordError("All outlines need to be closed to create a panel.");
                 return new List<List<Polyline>>();
             }
 
@@ -104,33 +92,15 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         public static List<List<ICurve>> DistributeOutlines(this List<ICurve> outlines, double tolerance = Tolerance.Distance)
         {
-            if (outlines == null)
+            if (outlines == null || outlines.Count == 0)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of outlines.");
-                return new List<List<ICurve>>();
-            }
-
-            if (outlines.Any(x => x == null))
-            {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is a null curve.");
-                return new List<List<ICurve>>();
-            }
-
-            if (outlines.Any(x => x is NurbsCurve || x is Ellipse))
-            {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is an ellipse or a nurbs curve, which is not supported at the moment.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of outlines.");
                 return new List<List<ICurve>>();
             }
 
             if (outlines.Any(p => !p.IIsClosed(tolerance)))
             {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not closed within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
-                return new List<List<ICurve>>();
-            }
-
-            if (outlines.Any(p => !p.IIsPlanar(tolerance)))
-            {
-                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not planar within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
+                BH.Engine.Reflection.Compute.RecordError("All outlines need to be closed to create a panel.");
                 return new List<List<ICurve>>();
             }
 
@@ -174,9 +144,9 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<Polyline>> DistributeOpenings(this List<Polyline> panels, List<Polyline> openings, double tolerance = Tolerance.Distance)
         {
-            if (panels == null)
+            if (panels == null || panels.Count == 0)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of panels.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of panels.");
                 return new List<List<Polyline>>();
             }
 
@@ -223,9 +193,9 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<PolyCurve>> DistributeOpenings(this List<PolyCurve> panels, List<PolyCurve> openings, double tolerance = Tolerance.Distance)
         {
-            if (panels == null)
+            if (panels == null || panels.Count == 0)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of panels.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of panels.");
                 return new List<List<PolyCurve>>();
             }
 
@@ -272,9 +242,9 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<ICurve>> DistributeOpenings(this List<ICurve> panels, List<ICurve> openings, double tolerance = Tolerance.Distance)
         {
-            if (panels == null)
+            if (panels == null || panels.Count == 0)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of panels.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of panels.");
                 return new List<List<ICurve>>();
             }
 

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -43,15 +43,34 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         public static List<List<Polyline>> DistributeOutlines(this List<Polyline> outlines, double tolerance = Tolerance.Distance)
         {
-            if (outlines == null || outlines.Count == 0)
+            if (outlines == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of outlines.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of outlines.");
                 return new List<List<Polyline>>();
             }
 
-            if (outlines.Any(p => !p.IIsClosed(tolerance)))
+            if (outlines.Any(x => x == null))
             {
-                BH.Engine.Reflection.Compute.RecordError("All outlines need to be closed to create a panel.");
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is a null curve.");
+                return new List<List<Polyline>>();
+            }
+
+            List<Point> controlPoints = outlines.SelectMany(x => x.IControlPoints()).ToList();
+            if (!controlPoints.IsCoplanar(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("The input outline curves are not coplanar, therefore they could not be distributed. Please try changing the tolerance if this behaviour is not expected.");
+                return new List<List<Polyline>>();
+            }
+
+            if (outlines.Any(p => !p.IsClosed(tolerance)))
+            {
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not closed within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
+                return new List<List<Polyline>>();
+            }
+
+            if (outlines.Any(p => p.IsSelfIntersecting(tolerance)))
+            {
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is self-intersecting.");
                 return new List<List<Polyline>>();
             }
 
@@ -92,15 +111,40 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         public static List<List<ICurve>> DistributeOutlines(this List<ICurve> outlines, double tolerance = Tolerance.Distance)
         {
-            if (outlines == null || outlines.Count == 0)
+            if (outlines == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of outlines.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of outlines.");
+                return new List<List<ICurve>>();
+            }
+
+            if (outlines.Any(x => x == null))
+            {
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is a null curve.");
+                return new List<List<ICurve>>();
+            }
+
+            if (outlines.Any(x => x is NurbsCurve || x is Ellipse))
+            {
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is an ellipse or a nurbs curve, which is not supported at the moment.");
+                return new List<List<ICurve>>();
+            }
+
+            List<Point> controlPoints = outlines.SelectMany(x => x.IControlPoints()).ToList();
+            if (!controlPoints.IsCoplanar(tolerance))
+            {
+                BH.Engine.Reflection.Compute.RecordError("The input outline curves are not coplanar, therefore they could not be distributed. Please try changing the tolerance if this behaviour is not expected.");
                 return new List<List<ICurve>>();
             }
 
             if (outlines.Any(p => !p.IIsClosed(tolerance)))
             {
-                BH.Engine.Reflection.Compute.RecordError("All outlines need to be closed to create a panel.");
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is not closed within the input tolerance. Please try changing the tolerance if this behaviour is not expected.");
+                return new List<List<ICurve>>();
+            }
+
+            if (outlines.Any(p => p.IIsSelfIntersecting(tolerance)))
+            {
+                BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is self-intersecting.");
                 return new List<List<ICurve>>();
             }
 
@@ -144,9 +188,9 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<Polyline>> DistributeOpenings(this List<Polyline> panels, List<Polyline> openings, double tolerance = Tolerance.Distance)
         {
-            if (panels == null || panels.Count == 0)
+            if (panels == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of panels.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of panels.");
                 return new List<List<Polyline>>();
             }
 
@@ -193,9 +237,9 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<PolyCurve>> DistributeOpenings(this List<PolyCurve> panels, List<PolyCurve> openings, double tolerance = Tolerance.Distance)
         {
-            if (panels == null || panels.Count == 0)
+            if (panels == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of panels.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of panels.");
                 return new List<List<PolyCurve>>();
             }
 
@@ -242,9 +286,9 @@ namespace BH.Engine.Geometry
         [Output("distributedOutlines", "Lists representing each set of outlines. For each list, the first outline is the containing outline and the remainder are the outlines it contains.")]
         private static List<List<ICurve>> DistributeOpenings(this List<ICurve> panels, List<ICurve> openings, double tolerance = Tolerance.Distance)
         {
-            if (panels == null || panels.Count == 0)
+            if (panels == null)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null or empty collection of panels.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot distribute a null collection of panels.");
                 return new List<List<ICurve>>();
             }
 

--- a/Geometry_Engine/Compute/DistributeOutlines.cs
+++ b/Geometry_Engine/Compute/DistributeOutlines.cs
@@ -67,7 +67,7 @@ namespace BH.Engine.Geometry
                 return new List<List<Polyline>>();
             }
 
-            if (outlines.Any(p => !p.IsSelfIntersecting(tolerance)))
+            if (outlines.Any(p => p.IsSelfIntersecting(tolerance)))
             {
                 BH.Engine.Reflection.Compute.RecordError("At least one of the input outlines is self-intersecting.");
                 return new List<List<Polyline>>();

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -165,17 +165,15 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Create.PlanarSurface(System.Collections.Generic.List<BH.oM.Geometry.ICurve)")]
         public static List<PlanarSurface> PlanarSurface(List<ICurve> boundaryCurves, double tolerance = Tolerance.Distance)
         {
-            if (boundaryCurves == null || boundaryCurves.Count == 0)
+            if (boundaryCurves == null || boundaryCurves.Count(x => x != null) == 0)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from a null or empty collection of boundary curves.");
                 return null;
             }
 
-            List<PlanarSurface> surfaces = new List<PlanarSurface>();
             List<List<ICurve>> distributed = Compute.DistributeOutlines(boundaryCurves, tolerance);
-            if (distributed == null || distributed.Count == 0)
-                return surfaces;
 
+            List<PlanarSurface> surfaces = new List<PlanarSurface>();
             for (int i = 0; i < distributed.Count; i++)
             {
                 PlanarSurface srf = new PlanarSurface(

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -197,7 +197,7 @@ namespace BH.Engine.Geometry
 
             if (checkedCurves.Count == 0)
             {
-                Reflection.Compute.RecordError("Planar surface could not be created because all input boundary curves turned to be invalid (null, unsupported type, non-planar, not closed within the tolerance).");
+                Reflection.Compute.RecordError("Planar surface could not be created because all input boundary curves are invalid (null, unsupported type, non-planar, not closed within the tolerance).");
                 return new List<PlanarSurface>();
             }
 

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -165,7 +165,7 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Create.PlanarSurface(System.Collections.Generic.List<BH.oM.Geometry.ICurve)")]
         public static List<PlanarSurface> PlanarSurface(List<ICurve> boundaryCurves, double tolerance = Tolerance.Distance)
         {
-            if (boundaryCurves == null || boundaryCurves.Count(x => x != null) == 0)
+            if (boundaryCurves == null || boundaryCurves.Count == 0 || boundaryCurves.All(x => x == null))
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from a null or empty collection of boundary curves.");
                 return null;

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -165,9 +165,9 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Create.PlanarSurface(System.Collections.Generic.List<BH.oM.Geometry.ICurve)")]
         public static List<PlanarSurface> PlanarSurface(List<ICurve> boundaryCurves, double tolerance = Tolerance.Distance)
         {
-            if (boundaryCurves == null)
+            if (boundaryCurves == null || boundaryCurves.Count == 0)
             {
-                BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from null curves.");
+                BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from a null or empty collection of boundary curves.");
                 return null;
             }
 

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -170,10 +170,12 @@ namespace BH.Engine.Geometry
                 BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from null curves.");
                 return null;
             }
-            
-            List<List<ICurve>> distributed = Compute.DistributeOutlines(boundaryCurves, tolerance);
 
             List<PlanarSurface> surfaces = new List<PlanarSurface>();
+            List<List<ICurve>> distributed = Compute.DistributeOutlines(boundaryCurves, tolerance);
+            if (distributed == null || distributed.Count == 0)
+                return surfaces;
+
             for (int i = 0; i < distributed.Count; i++)
             {
                 PlanarSurface srf = new PlanarSurface(
@@ -183,7 +185,7 @@ namespace BH.Engine.Geometry
 
                 surfaces.Add(srf);
             }
-
+            
             return surfaces;
         }
         

--- a/Geometry_Engine/Create/PlanarSurface.cs
+++ b/Geometry_Engine/Create/PlanarSurface.cs
@@ -165,17 +165,15 @@ namespace BH.Engine.Geometry
         [PreviousVersion("4.3", "BH.Engine.Geometry.Create.PlanarSurface(System.Collections.Generic.List<BH.oM.Geometry.ICurve)")]
         public static List<PlanarSurface> PlanarSurface(List<ICurve> boundaryCurves, double tolerance = Tolerance.Distance)
         {
-            if (boundaryCurves == null || boundaryCurves.Where(x => x != null).Count() == 0)
+            if (boundaryCurves == null)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot create planar surface from null curves.");
                 return null;
             }
-
-            List<ICurve> checkedCurves = boundaryCurves.Where(x => x.IIsClosed(tolerance) && x.IIsPlanar(tolerance)).ToList();
-            List<List<ICurve>> distributed = Compute.DistributeOutlines(checkedCurves, tolerance);
+            
+            List<List<ICurve>> distributed = Compute.DistributeOutlines(boundaryCurves, tolerance);
 
             List<PlanarSurface> surfaces = new List<PlanarSurface>();
-
             for (int i = 0; i < distributed.Count; i++)
             {
                 PlanarSurface srf = new PlanarSurface(


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2621

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Problem-specific test file has been uploaded on [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FGeometry%5FEngine%2F%232622%2DDistributeOutlinesChecks&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)
On top of that, worth running it in parallel with https://github.com/BHoM/Revit_Toolkit/pull/1082 and check the test files there (this was the original source of the issue actually).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
This PR is as minimalistic as possible, it only sorts out the checks and messages, but does not change the return values etc. to avoid breaking changes if possible - to merge it safely before the Beta release. Possible future improvements in the next milestone:
- ignore invalid/unsupported curves in `Create.PlanarSurface(List<ICurve>)` instead of crashing the entire method, to align to the behaviour of `Create.PlanarSurface(ICurve, List<ICurve>)`
- add a check whether the input curves to `Create.PlanarSurface(List<ICurve>)` are coplanar, if not then raise warning
- get rid of `DistributeOutlines` for polylines and leave only one version taking `IEnumerable<ICurve>`
- get rid of `DistributeOpenings` overloads that do not work on `ICurves`
- get rid of checks inside `DistributeOpenings` (they are redundant, the method is `private` and the checks are done by the caller)

The above to be picked up after the Beta.