### PR TITLE
Reflection_Engine: Ensure type description is shown if input classification is available

### DIFF
--- a/Reflection_Engine/Query/Description.cs
+++ b/Reflection_Engine/Query/Description.cs
@@ -54,7 +54,7 @@ namespace BH.Engine.Reflection
             if (descriptionAttribute != null && !string.IsNullOrWhiteSpace(descriptionAttribute.Description))
                 desc = descriptionAttribute.Description + Environment.NewLine;
 
-            if (addTypeDescription && member is PropertyInfo && (typeof(IObject).IsAssignableFrom(((PropertyInfo)member).PropertyType)))
+            if (addTypeDescription && member is PropertyInfo && (typeof(IObject).IsAssignableFrom(((PropertyInfo)member).PropertyType) || classification != null))
             {
                 desc += ((PropertyInfo)member).PropertyType.Description(classification) + Environment.NewLine;
             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2628

<!-- Add short description of what has been fixed -->

Ensures input classification is shown if available for all properties, no matter if the type is of IObject type or not.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->