### PR TITLE
Facade_Engine: Panel Create method bug fixed for Opening FrameEdgeProperty

### DIFF
--- a/Facade_Engine/Create/Elements/Panel.cs
+++ b/Facade_Engine/Create/Elements/Panel.cs
@@ -88,7 +88,7 @@ namespace BH.Engine.Facade
                 Reflection.Compute.RecordError("Outline not closed. Could not create Panel.");
                 return null;
             }
-            List<Opening> pOpenings = openings != null ? openings.Select(o => Create.Opening(new List<ICurve> {o}, openingConstruction, frameEdgeProperty)).Where(x => x != null).ToList() : new List<Opening>();
+            List<Opening> pOpenings = openings != null ? openings.Select(o => Create.Opening(new List<ICurve> {o}, openingConstruction, openingFrameEdgeProperty)).Where(x => x != null).ToList() : new List<Opening>();
             List<FrameEdge> externalEdges = outline.ISubParts().Select(x => new FrameEdge { Curve = x, FrameEdgeProperty = frameEdgeProperty }).ToList();
 
             return Create.Panel(externalEdges, pOpenings, construction, panelType, name);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2653 

A bug was fixed where the created panel and openings had the same FrameEdgeProperty applied instead of the two separate specified properties in the method.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Facade_Engine/%232653-PanelCreateEdgePropBug?csf=1&web=1&e=kGFfmW
