### PR TITLE
Diffing_Engine: allow Toolkit-specific methods to be called depending on presence of IPersistentAdapterId

### DIFF
--- a/BHoM_Engine/Query/Hash.cs
+++ b/BHoM_Engine/Query/Hash.cs
@@ -258,6 +258,10 @@ namespace BH.Engine.Base
                     string propertyHashString = "";
                     string propertyName = prop.Name;
                     string propertyPath = $"{currentPropertyFullName}.{propertyName}";
+                    
+                    // Invoke the PropertyFullNameModifier, if specified.
+                    if (cc.ComparisonFunctions?.PropertyFullNameModifier != null)
+                        propertyPath = cc.ComparisonFunctions.PropertyFullNameModifier.Invoke(propertyPath, obj);
 
                     bool isInPropertyExceptions = cc.PropertyExceptions.Any(ex => propertyPath.EndsWith(ex) || currentPropertyFullName.EndsWith(ex));
 
@@ -267,10 +271,6 @@ namespace BH.Engine.Base
                     object propertyValue = prop.GetValue(obj);
                     if (propertyValue != null)
                     {
-                        // Invoke the PropertyFullNameModifier, if specified.
-                        if (cc.ComparisonFunctions?.PropertyFullNameModifier != null)
-                            propertyPath = cc.ComparisonFunctions.PropertyFullNameModifier.Invoke(propertyPath, obj);
-
                         // Invoke the PropertyFullNameFilter, if specified.
                         if (cc.ComparisonFunctions?.PropertyFullNameFilter != null)
                             if (cc.ComparisonFunctions.PropertyFullNameFilter.Invoke(propertyPath, obj))

--- a/Diffing_Engine/Compute/IDiffing.cs
+++ b/Diffing_Engine/Compute/IDiffing.cs
@@ -180,7 +180,8 @@ namespace BH.Engine.Diffing
             Diff fragmentDiff = null;
 
             // For the BHoMObjects having a common PeristentAdapterId we can compute the Diff by using it.
-            if (diffingType == DiffingType.Automatic || diffingType == DiffingType.PersistentId
+            if ((diffingType == DiffingType.Automatic || diffingType == DiffingType.PersistentId)
+                && commonPersistentId_past != null
                 && commonPersistentId_past == commonPersistentId_following
                 && bHoMObjects_past_persistId.Count != 0 && bHoMObjects_following_persistId.Count != 0)
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2657

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/Revit_Toolkit/pull/1113

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->