### PR TITLE
Serialiser_Engine: Serialisation of properties of type MethodInfo enabled

### DIFF
--- a/Serialiser_Engine/Convert/Bson.cs
+++ b/Serialiser_Engine/Convert/Bson.cs
@@ -177,6 +177,7 @@ namespace BH.Engine.Serialiser
                 BsonSerializer.RegisterSerializer(typeof(object), new BH_ObjectSerializer());
                 BsonSerializer.RegisterSerializer(typeof(System.Drawing.Color), new ColourSerializer());
                 BsonSerializer.RegisterSerializer(typeof(MethodBase), new MethodBaseSerializer());
+                BsonSerializer.RegisterSerializer(typeof(MethodInfo), new MethodBaseSerializer());
                 BsonSerializer.RegisterSerializer(typeof(Guid), new GuidSerializer(BsonType.String));
                 BsonSerializer.RegisterSerializer(typeof(CustomObject), new CustomObjectSerializer());
                 BsonSerializer.RegisterSerializer(typeof(FragmentSet), new BHoMCollectionSerializer<FragmentSet, IFragment>());

--- a/Serialiser_Engine/Convert/Bson.cs
+++ b/Serialiser_Engine/Convert/Bson.cs
@@ -176,8 +176,6 @@ namespace BH.Engine.Serialiser
             {
                 BsonSerializer.RegisterSerializer(typeof(object), new BH_ObjectSerializer());
                 BsonSerializer.RegisterSerializer(typeof(System.Drawing.Color), new ColourSerializer());
-                BsonSerializer.RegisterSerializer(typeof(MethodBase), new MethodBaseSerializer());
-                BsonSerializer.RegisterSerializer(typeof(MethodInfo), new MethodBaseSerializer());
                 BsonSerializer.RegisterSerializer(typeof(Guid), new GuidSerializer(BsonType.String));
                 BsonSerializer.RegisterSerializer(typeof(CustomObject), new CustomObjectSerializer());
                 BsonSerializer.RegisterSerializer(typeof(FragmentSet), new BHoMCollectionSerializer<FragmentSet, IFragment>());
@@ -190,6 +188,10 @@ namespace BH.Engine.Serialiser
                 var typeSerializer = new TypeSerializer();
                 BsonSerializer.RegisterSerializer(typeof(Type), typeSerializer);
                 BsonSerializer.RegisterSerializer(Type.GetType("System.RuntimeType"), typeSerializer);
+
+                var methodBaseSerializer = new MethodBaseSerializer();
+                BsonSerializer.RegisterSerializer(typeof(MethodBase), methodBaseSerializer);
+                BsonSerializer.RegisterSerializer(typeof(MethodInfo), methodBaseSerializer);
 
                 BsonDefaults.DynamicDocumentSerializer = new CustomObjectSerializer();
 

--- a/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
@@ -51,6 +51,12 @@ namespace BH.Engine.Serialiser.BsonSerializers
         public override void Serialize(BsonSerializationContext context, BsonSerializationArgs args, MethodBase value)
         {
             var bsonWriter = context.Writer;
+            if (value == null)
+            {
+                bsonWriter.WriteNull();
+                return;
+            }
+
             bsonWriter.WriteStartDocument();
 
             var discriminator = m_DiscriminatorConvention.GetDiscriminator(typeof(object), typeof(MethodBase));

--- a/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
@@ -86,6 +86,12 @@ namespace BH.Engine.Serialiser.BsonSerializers
         public override MethodBase Deserialize(BsonDeserializationContext context, BsonDeserializationArgs args)
         {
             var bsonReader = context.Reader;
+            if (bsonReader.CurrentBsonType == BsonType.Null)
+            {
+                context.Reader.ReadNull();
+                return null;
+            }
+
             bsonReader.ReadStartDocument();
 
             string text = bsonReader.ReadName();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2678

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FSerialiser%5FEngine%2F%232679%2DMethodInfoPropertyBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
As discovered together with @IsakNaslundBh, registering `MethodBaseSerializer` for `MethodInfo` seems to fix the issue. However, when we wanted to push it forward and do the same for other types such as `Type.GetType("System.RuntimeMethodInfo")` or `Type.GetType("System.RuntimeConstructorInfo")`, we broke the entire serialisation system. Therefore, the intervention I am proposing in this PR is as small as possible, with any further changes to be done in a separate, dedicated thread (if ever needed).