### PR TITLE
Reflection_Engine: LoadAllAssemblies refined to accept regular expression filters and allow parsing subfolders

### DIFF
--- a/Reflection_Engine/Compute/LoadAllAssemblies.cs
+++ b/Reflection_Engine/Compute/LoadAllAssemblies.cs
@@ -64,7 +64,7 @@ namespace BH.Engine.Reflection
             {
                 string key = folder + "%" + regexFilter + "%" + parseSubfolders;
                 if (!forceParseFolder && m_AlreadyLoaded.ContainsKey(key))
-                    return m_AlreadyLoaded[key];
+                    return m_AlreadyLoaded[key].ToList();
 
                 Regex regex;
                 if (!string.IsNullOrWhiteSpace(regexFilter))
@@ -88,7 +88,7 @@ namespace BH.Engine.Reflection
                     }
                 }
 
-                m_AlreadyLoaded[key] = result;
+                m_AlreadyLoaded[key] = result.ToList();
                 return result;
             }
         }

--- a/Reflection_Engine/Compute/LoadAllAssemblies.cs
+++ b/Reflection_Engine/Compute/LoadAllAssemblies.cs
@@ -70,11 +70,9 @@ namespace BH.Engine.Reflection
                 else
                     regex = new Regex(@"oM$|_Engine$|_UI$");
 
-                foreach (string file in Directory.GetFiles(folder))
+                SearchOption searchOption = parseSubfolders ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
+                foreach (string file in Directory.GetFiles(folder, "*.dll", searchOption))
                 {
-                    if (!file.EndsWith(".dll"))
-                        continue;
-
                     string[] parts = file.Split(new char[] { '.', '\\' });
                     if (parts.Length < 2)
                         continue;

--- a/Reflection_Engine/Compute/LoadAllAssemblies.cs
+++ b/Reflection_Engine/Compute/LoadAllAssemblies.cs
@@ -37,16 +37,18 @@ namespace BH.Engine.Reflection
         /**** Public Methods                            ****/
         /***************************************************/
 
-        //[PreviousVersion("5.0", "BH.Engine.Reflection.Compute.LoadAllAssemblies(System.String)")]
-        //[PreviousVersion("5.0", "BH.Engine.Reflection.Compute.LoadAllAssemblies(System.String, System.String, System.Boolean)")]
-        //[Description("Loads all .dll assemblies with names ending with oM, _Engine and _Adapter (with optional suffixes) from a given folder.")]
-        //[Input("folder", "Folder to load the assemblies from. If left empty, default BHoM assemblies folder will be used.")]
-        //[Input("suffix", "Suffix to be added to the standard BHoM library endings (oM, _Engine, _Adapter) when parsing the folder.\n" +
-        //                 "For example, if this value is equal to '_2018', assemblies ending with oM_2018, _Engine_2018 or _Adapter_2018 will be loaded.")]
-        //[Input("forceParseFolder", "If false, the method will execute only once per lifetime of the process per each combination of folder and suffix values (every attempt after the first will be skipped).\n" +
-        //                           "If true, the given folder will be parsed for assemblies with given suffix on every call of this method.")]
-        //[Output("assemblies", "Assemblies that meet folder and suffix requirements and are loaded to BHoM.")]
-        public static List<Assembly> LoadAllAssemblies(string folder = "", string regexFilter = "", bool parseSubfolders = false, bool forceParseFolder = false)
+        [PreviousVersion("5.0", "BH.Engine.Reflection.Compute.LoadAllAssemblies(System.String)")]
+        [PreviousVersion("5.0", "BH.Engine.Reflection.Compute.LoadAllAssemblies(System.String, System.String, System.Boolean)")]
+        [Description("Loads all .dll assemblies with names ending with oM, _Engine and _Adapter (with optional suffixes) from a given folder.")]
+        [Input("folder", "Folder to load the assemblies from. If left empty, default BHoM assemblies folder will be used.")]
+        [Input("regexFilter", "Regular expression filter to be applied to the assembly names (with .dll already cut off)." +
+                              "Default value is 'oM$|_Engine$|_UI$' (names ending with 'oM', '_Engine' or '_UI')." +
+                              "If the input is left null or blank, filter '.*' will be applied (accepts all names).")]
+        [Input("parseSubfolders", "If true, subfolders of the input folder will be parsed, otherwise only top folder to be considered.")]
+        [Input("forceParseFolder", "If false, the method will execute only once per lifetime of the process per each combination of folder and suffix values (every attempt after the first will be skipped).\n" +
+                                   "If true, the given folder will be parsed for assemblies with given suffix on every call of this method.")]
+        [Output("assemblies", "Assemblies that meet folder and suffix requirements and are loaded to BHoM.")]
+        public static List<Assembly> LoadAllAssemblies(string folder = "", string regexFilter = @"oM$|_Engine$|_UI$", bool parseSubfolders = false, bool forceParseFolder = false)
         {
             List<Assembly> result = new List<Assembly>();
             if (string.IsNullOrEmpty(folder))
@@ -68,7 +70,7 @@ namespace BH.Engine.Reflection
                 if (!string.IsNullOrWhiteSpace(regexFilter))
                     regex = new Regex(regexFilter);
                 else
-                    regex = new Regex(@"oM$|_Engine$|_UI$");
+                    regex = new Regex(".*");
 
                 SearchOption searchOption = parseSubfolders ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
                 foreach (string file in Directory.GetFiles(folder, "*.dll", searchOption))

--- a/Reflection_Engine/Compute/LoadAllAssemblies.cs
+++ b/Reflection_Engine/Compute/LoadAllAssemblies.cs
@@ -42,13 +42,13 @@ namespace BH.Engine.Reflection
         [Description("Loads all .dll assemblies with names ending with oM, _Engine and _Adapter (with optional suffixes) from a given folder.")]
         [Input("folder", "Folder to load the assemblies from. If left empty, default BHoM assemblies folder will be used.")]
         [Input("regexFilter", "Regular expression filter to be applied to the assembly names (with .dll already cut off)." +
-                              "Default value is 'oM$|_Engine$|_UI$' (names ending with 'oM', '_Engine' or '_UI')." +
+                              "Default value is 'oM$|_Engine$|_Adapter$' (names ending with 'oM', '_Engine' or '_Adapter')." +
                               "If the input is left null or blank, filter '.*' will be applied (accepts all names).")]
         [Input("parseSubfolders", "If true, subfolders of the input folder will be parsed, otherwise only top folder to be considered.")]
         [Input("forceParseFolder", "If false, the method will execute only once per lifetime of the process per each combination of folder and suffix values (every attempt after the first will be skipped).\n" +
                                    "If true, the given folder will be parsed for assemblies with given suffix on every call of this method.")]
         [Output("assemblies", "Assemblies that meet folder and suffix requirements and are loaded to BHoM.")]
-        public static List<Assembly> LoadAllAssemblies(string folder = "", string regexFilter = @"oM$|_Engine$|_UI$", bool parseSubfolders = false, bool forceParseFolder = false)
+        public static List<Assembly> LoadAllAssemblies(string folder = "", string regexFilter = @"oM$|_Engine$|_Adapter$", bool parseSubfolders = false, bool forceParseFolder = false)
         {
             List<Assembly> result = new List<Assembly>();
             if (string.IsNullOrEmpty(folder))


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2688
Closes #2691

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine%2F%232690%2DLoadAllAssembliesRefinement&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).

**Important:** please remember to rebuild BHoM_UI - a defaulted parameter has been added to `LoadAllAssemblies` signature, so the binding will be broken, even though CI check core will pass.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->