### PR TITLE
Diffing_Engine: Toolkit-specific Diffing methods; restructured Diff; numeric Tolerance

### DIFF
--- a/Analytical_Engine/Query/Graph/UniqueEntitiesReplacementMap.cs
+++ b/Analytical_Engine/Query/Graph/UniqueEntitiesReplacementMap.cs
@@ -45,9 +45,9 @@ namespace BH.Engine.Analytical
         [Input("entities", "A collection of IBHoMObjects from which unique instances are identified.")]
         [Input("comparisonConfig", "Configuration of diffing used to find unique entities.")]
         [Output("replacementMap", "A Dictionary replacement map of the entities where the keys are the Guid of the original entity and the Values the matching IBHoMObject entity.")]
-        public static Dictionary<Guid, IBHoMObject> UniqueEntitiesReplacementMap(this List<IBHoMObject> entities, ComparisonConfig comparisonConfig = null)
+        public static Dictionary<Guid, IBHoMObject> UniqueEntitiesReplacementMap(this List<IBHoMObject> entities, BaseComparisonConfig comparisonConfig = null)
         {
-            ComparisonConfig cc = comparisonConfig ?? new ComparisonConfig();
+            BaseComparisonConfig cc = comparisonConfig ?? new ComparisonConfig();
 
             Dictionary<Guid, IBHoMObject> replaceMap = new Dictionary<Guid, IBHoMObject>();
             Dictionary<IBHoMObject, string> entitiesHash = new Dictionary<IBHoMObject, string>();

--- a/BHoM_Engine.sln
+++ b/BHoM_Engine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31205.134
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1684
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BHoM_Engine", "BHoM_Engine\BHoM_Engine.csproj", "{AEAF161D-8206-40B8-93A7-67ABEBF2EE19}"
 EndProject

--- a/BHoM_Engine/BHoM_Engine.csproj
+++ b/BHoM_Engine/BHoM_Engine.csproj
@@ -21,7 +21,6 @@
   <ItemGroup>
     <PackageReference Include="DeepCloner" Version="0.10.2" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
-    <PackageReference Include="System.Management.Automation.dll" Version="10.0.10586" />
   </ItemGroup>
 
   <ItemGroup>

--- a/BHoM_Engine/Modify/PropertyInclusionsToFullNames.cs
+++ b/BHoM_Engine/Modify/PropertyInclusionsToFullNames.cs
@@ -1,0 +1,133 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Base
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Parse the ComparisonConfig's property inclusions (the `PropertiesToConsider` and `PropertyExceptions`), and get them all as Full Names." +
+            "This allows to make sure we collect all relevant properties, even if we are given partial names or wildcards (e.g. `StartNode.*.X`).")]
+        [Input("comparisonConfig", "ComparisonConfig object whose `PropertiesToConsider` and `PropertyExceptions` will be parsed." +
+            "If they contain partial names or wildcards, they will be expanded with all the matching property FullNames found for the specified Type.")]
+        [Input("type", "Object type whose properties will be collected and matched against the comparisonConfig's `PropertiesToConsider` and `PropertyExceptions`.")]
+        [Input("cache", "If set to true and the object already contains a fragment of the type being added, the fragment will be replaced by this instance.")]
+        public static void PropertyInclusionsToFullNames(this BaseComparisonConfig comparisonConfig, Type type, bool cache = true)
+        {
+            // Null checks.
+            if (comparisonConfig == null || !typeof(IObject).IsAssignableFrom(type))
+                return;
+
+            // Result variables.
+            List<string> propertiesToConsider_fullNames = null;
+            List<string> propertyExceptions_fullNames = null;
+
+            // If all the propertiesToConsider/propertyExceptions are already in FullName form and without wildcards, do nothing.
+            List<string> propertiesToConsiderToParse = comparisonConfig.PropertiesToConsider.Where(p => !p.StartsWith("BH.") || p.Contains("*")).ToList();
+            List<string> propertyExceptionsToParse = comparisonConfig.PropertyExceptions.Where(p => !p.StartsWith("BH.") || p.Contains("*")).ToList();
+
+            if (!propertiesToConsiderToParse.Any() && !propertyExceptionsToParse.Any())
+                return;
+
+            // Collect all property FullNames for this Type of object.
+            HashSet<string> allPropertiesFullNames = BH.Engine.Reflection.Query.GetAllPropertyFullNames(type, comparisonConfig.MaxNesting, true);
+
+            // Check if we already have encountered and cached this same object Type and PropertiesToConsider.
+            string propertiesToConsiderCacheKey = $"{type.FullName}:{string.Join(",", comparisonConfig.PropertiesToConsider)}";
+            if (cache && !m_cachedPropertiesToConsider.TryGetValue(propertiesToConsiderCacheKey, out propertiesToConsider_fullNames))
+            {
+                propertiesToConsider_fullNames = new List<string>();
+
+                // If not, parse the PropertiesToConsider and all the Properties of the object,
+                // so we convert partial property names/wildcards to their matching Full Name form.
+                foreach (var propToConsider in propertiesToConsiderToParse)
+                    foreach (var propertyFullName in allPropertiesFullNames)
+                        if (IsMatchingInclusion(propertyFullName, propToConsider))
+                            propertiesToConsider_fullNames.Add(propertyFullName);
+
+                m_cachedPropertiesToConsider[propertiesToConsiderCacheKey] = propertiesToConsider_fullNames;
+            }
+
+            // Check if we already have encountered and cached this same object Type and PropertyExceptions.
+            string propertyExceptionsCacheKey = $"{type.FullName}:{string.Join(",", comparisonConfig.PropertyExceptions)}";
+            if (cache && !m_cachedPropertiesToConsider.TryGetValue(propertyExceptionsCacheKey, out propertyExceptions_fullNames))
+            {
+                propertyExceptions_fullNames = new List<string>();
+
+                // If not, parse the PropertyExceptions and all the Properties of the object,
+                // so we convert partial property names/wildcards to their matching Full Name form.
+                foreach (var propException in propertyExceptionsToParse)
+                    foreach (var propertyFullName in allPropertiesFullNames)
+                        if (IsMatchingInclusion(propertyFullName, propException))
+                            comparisonConfig.PropertyExceptions.Add(propertyFullName);
+
+                m_cachedPropertyExceptions[propertyExceptionsCacheKey] = propertyExceptions_fullNames;
+            }
+
+            // Add the results to the ComparisonConfig.
+            comparisonConfig.PropertiesToConsider.AddRange(propertiesToConsider_fullNames);
+            comparisonConfig.PropertyExceptions.AddRange(propertyExceptions_fullNames);
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        // Check if the given propertyFullName matches with the input inclusionOrExclusion.
+        private static bool IsMatchingInclusion(string propertyFullName, string inclusionOrExclusion)
+        {
+            // If the propertyFullName ends with the inclusion or exclusion, it is a match.
+            // E.g. propertyFullName = "BH.oM.Engine.Structure.Elements.Bar.Name"; inclusionOrExclusion = "Name".
+            if (propertyFullName.EndsWith($".{inclusionOrExclusion}"))
+                return true;
+
+            // If the inclusionOrExclusion is not a FullName (i.e. it does not start with "BH.")
+            // and it also does NOT have a starting wildcard (i.e. "StartNode.*.X" and not "*.StartNode.*.X"),
+            // a wildcard must be prepended to make sure we match all possible properties.
+            if (!inclusionOrExclusion.StartsWith("BH") && !inclusionOrExclusion.StartsWith("*"))
+                inclusionOrExclusion = $"*{inclusionOrExclusion}";
+
+            // Finds if there is a match.
+            return Query.WildcardMatch(propertyFullName, inclusionOrExclusion);
+        }
+
+        /***************************************************/
+        /**** Private Fields                            ****/
+        /***************************************************/
+
+        private static Dictionary<string, List<string>> m_cachedPropertiesToConsider = new Dictionary<string, List<string>>();
+        private static Dictionary<string, List<string>> m_cachedPropertyExceptions = new Dictionary<string, List<string>>();
+    }
+}

--- a/BHoM_Engine/Modify/SetHashFragment.cs
+++ b/BHoM_Engine/Modify/SetHashFragment.cs
@@ -64,6 +64,9 @@ namespace BH.Engine.Base
             "\nIf the hashFragment already existed, it is replaced.")]
         public static T SetHashFragment<T>(this T obj, string hash) where T : IBHoMObject
         {
+            if (obj == null)
+                return default(T);
+
             // Clone the current object to avoid modification by reference.
             T obj_cloned = BH.Engine.Base.Query.DeepClone(obj);
 

--- a/BHoM_Engine/Objects/EqualityComparers/HashComparer.cs
+++ b/BHoM_Engine/Objects/EqualityComparers/HashComparer.cs
@@ -30,11 +30,10 @@ using BH.Engine.Serialiser;
 using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Reflection;
-using BH.Engine.Diffing;
 using System.Collections;
 using BH.Engine.Base;
 
-namespace BH.Engine.Diffing
+namespace BH.Engine.Base.Objects
 {
     [Description("Computes and compares the Hash of the given Objects.")]
     public class HashComparer<T> : IEqualityComparer<T>
@@ -50,19 +49,19 @@ namespace BH.Engine.Diffing
         public bool RetrieveStoredHash { get; set; } = false;
 
         [Description("If the objects are IObjects, computes the BHoM Hash using these configurations.")]
-        public ComparisonConfig ComparisonConfig { get; set; } = new ComparisonConfig();
+        public BaseComparisonConfig ComparisonConfig { get; set; } = new ComparisonConfig();
 
         public HashComparer() { }
 
         [Input("comparisonConfig", "If the objects are IObjects, computes the BHoM Hash using these configurations.")]
-        public HashComparer(ComparisonConfig comparisonConfig)
+        public HashComparer(BaseComparisonConfig comparisonConfig)
         {
             ComparisonConfig = comparisonConfig;
         }
 
         [Input("comparisonConfig", "If the objects are IObjects, computes the BHoM Hash using these configurations.")]
         [Input("storeHash", "If true, stores the computed hash for input BHoMObjects as a new HashFragment. False by default.")]
-        public HashComparer(ComparisonConfig comparisonConfig, bool storeHash) : this(comparisonConfig)
+        public HashComparer(BaseComparisonConfig comparisonConfig, bool storeHash) : this(comparisonConfig)
         {
             StoreHash = storeHash;
         }
@@ -70,7 +69,7 @@ namespace BH.Engine.Diffing
         [Input("comparisonConfig", "If the objects are IObjects, computes the BHoM Hash using these configurations.")]
         [Input("storeHash", "If true, stores the computed hash for input BHoMObjects as a new HashFragment. False by default.")]
         [Input("retrieveStoredHash", "If true, attempts to retrieve a hash stored in the object's Fragments instead of computing it. False by default.")]
-        public HashComparer(ComparisonConfig comparisonConfig, bool storeHash, bool retrieveStoredHash) : this(comparisonConfig, storeHash)
+        public HashComparer(BaseComparisonConfig comparisonConfig, bool storeHash, bool retrieveStoredHash) : this(comparisonConfig, storeHash)
         {
             RetrieveStoredHash = retrieveStoredHash;
         }

--- a/BHoM_Engine/Query/FilterByType.cs
+++ b/BHoM_Engine/Query/FilterByType.cs
@@ -41,6 +41,9 @@ namespace BH.Engine.Base
         [Output("List", "Filtered list containing only objects assignable from the provided type.")]
         public static List<object> FilterByType(this IEnumerable<object> list, Type type)
         {
+            if (list == null)
+                return null;
+
             return list.Where(x => type.IsAssignableFrom(x.GetType())).ToList();
         }
     }

--- a/BHoM_Engine/Query/GroupByType.cs
+++ b/BHoM_Engine/Query/GroupByType.cs
@@ -38,8 +38,11 @@ namespace BH.Engine.Base
         [Description("Groups a list of objects by their type")]
         [Input("list", "List of objects to group")]
         [Output("Groups", "List of List of objects. Each inner list will correspond to one object type")]
-        public static List<List<T>> GroupByType<T>(IEnumerable<T> list)
+        public static List<List<T>> GroupByType<T>(this IEnumerable<T> list)
         {
+            if (list == null)
+                return null;
+
             return list.GroupBy(x => x.GetType()).Select(x => x.ToList()).ToList();
         }
 

--- a/BHoM_Engine/Query/PropertyNumericTolerance.cs
+++ b/BHoM_Engine/Query/PropertyNumericTolerance.cs
@@ -25,7 +25,6 @@ using BH.oM.Reflection.Attributes;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
-using System.Management.Automation;
 
 namespace BH.Engine.Base
 {
@@ -42,7 +41,7 @@ namespace BH.Engine.Base
         [Input("comparisonConfig", "Comparison Config from where tolerance information should be extracted.")]
         [Input("propertyFullName", "Full name (path) of the property for which we want to extract the numerical Tolerance.")]
         [Input("getGlobalSmallest", "(Optional, defaults to false) If true, extract the smallest (most precise) tolerance amongst all CustomTolerances for all properties and the global numeric tolerance.")]
-        public static double ToleranceFromConfig(this BaseComparisonConfig comparisonConfig, string propertyFullName)
+        public static double PropertyNumericTolerance(this BaseComparisonConfig comparisonConfig, string propertyFullName)
         {
             return ToleranceFromConfig(comparisonConfig, propertyFullName, false);
         }
@@ -63,13 +62,13 @@ namespace BH.Engine.Base
             double tolerance = double.MaxValue;
 
             // Take care of CustomTolerances.
-            if (comparisonConfig.CustomTolerances?.Any() ?? false)
+            if (comparisonConfig.PropertyNumericTolerances?.Any() ?? false)
             {
                 // Iterate the specified CustomTolerances. If more than one match with the current property is found, take the safest (smallest) value.
                 List<string> matchingCustomTolerancesNames = new List<string>();
-                foreach (var ct in comparisonConfig.CustomTolerances)
+                foreach (var ct in comparisonConfig.PropertyNumericTolerances)
                 {
-                    if (getGlobalSmallest || propertyFullName.EndsWith($".{ct.Name}") || new WildcardPattern(ct.Name).IsMatch(propertyFullName))
+                    if (getGlobalSmallest || propertyFullName.EndsWith($".{ct.Name}") || propertyFullName.WildcardMatch(ct.Name))
                     {
                         if (!getGlobalSmallest)
                             matchingCustomTolerancesNames.Add(ct.Name);

--- a/BHoM_Engine/Query/RoundWithTolerance.cs
+++ b/BHoM_Engine/Query/RoundWithTolerance.cs
@@ -1,0 +1,129 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Reflection;
+using BH.Engine.Serialiser;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+using BH.Engine.Base;
+using System.Collections;
+using System.Data;
+
+namespace BH.Engine.Base
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Rounds a number using the given tolerance, rounding (to floor) to the nearest tolerance multiplier." +
+            "Supports any fractional, integer, positive or negative numbers." +
+            "\nSome examples:" +
+            "\n\t RoundWithTolerance(12, 20) ==> 0" +
+            "\n\t RoundWithTolerance(121, 2) ==> 120" +
+            "\n\t RoundWithTolerance(1.2345, 1.1) ==> 1.1" +
+            "\n\t RoundWithTolerance(0.014, 0.01) ==> 0.01" +
+            "\n\t RoundWithTolerance(0.014, 0.02) ==> 0" +
+            "\nand so on.")]
+        [Input("number", "Number to be rounded.")]
+        [Input("tolerance", "Tolerance to use for rounding.")]
+        public static double RoundWithTolerance(this double number, double tolerance)
+        {
+            if (tolerance < 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Tolerance cannot be less than 0.");
+                return default(double);
+            }
+
+            // First check if the tolerance can be converted into fractional digits, i.e. is a number in the form of 10^someExp.
+            // This avoids imprecisions with the approximation formula below.
+            int fractionalDigits = Math.Abs(Convert.ToInt32(Math.Log10(tolerance)));
+            if (tolerance < 1 && Math.Pow(10, -fractionalDigits) == tolerance)
+                // If so, just return Math.Round().
+                return Math.Round(number, fractionalDigits);
+
+            // Otherwise, perform the approximation with the given tolerance.
+            int unitStep = number > 0 ? 1 : -1; // Useful to deal with negative numbers.
+            return tolerance * Math.Floor(number * unitStep / tolerance) * unitStep;
+        }
+
+        /***************************************************/
+
+        // NOTE: Although we could be satisfied with just one method "RoundWithTolerance" from the UI perspective,
+        // we also need a dedicated method for Integers, to avoid a performance hit when using this method from other parts of the code, e.g. in Hash().
+
+        [Description("Rounds an integer number using the given tolerance, rounding (to floor) to the nearest tolerance multiplier." +
+            "\nSome examples:" +
+            "\n\t RoundWithTolerance(12, 20) ==> 0" +
+            "\n\t RoundWithTolerance(121, 2) ==> 120" +
+            "\n\t RoundWithTolerance(-40, 20) ==> -40" +
+            "\nand so on.")]
+        [Input("number", "Number to be rounded.")]
+        [Input("tolerance", "Tolerance to use for rounding.")]
+        public static int RoundWithTolerance(this int number, double tolerance)
+        {
+            if (tolerance < 1)
+                return number; 
+
+            if (number > 0 && tolerance > number)
+                return 0;
+
+            if (tolerance < 0)
+            {
+                BH.Engine.Reflection.Compute.RecordError("Tolerance cannot be less than 0.");
+                return 0;
+            }
+
+            int unitStep = number > 0 ? 1 : -1;
+            int flooredIntegerTolerance = (int)tolerance;
+            return FlooredIntegerDivision(number * unitStep, flooredIntegerTolerance) * flooredIntegerTolerance * unitStep;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static int FlooredIntegerDivision(int a, int b)
+        {
+            if (a < 0)
+            {
+                if (b > 0)
+                    return (a - b + 1) / b;
+            }
+            else if (a > 0)
+            {
+                if (b < 0)
+                    return (a - b - 1) / b;
+            }
+            return a / b;
+        }
+    }
+}
+

--- a/BHoM_Engine/Query/SmallestToleranceFromConfig.cs
+++ b/BHoM_Engine/Query/SmallestToleranceFromConfig.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
@@ -20,47 +20,23 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BH.oM.Reflection.Attributes;
-using System.ComponentModel;
-
-using BH.oM.Physical.Constructions;
-
-using BH.oM.Diffing;
 using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Management.Automation;
 
-namespace BH.Engine.Physical
+namespace BH.Engine.Base
 {
     public static partial class Query
     {
-        [Description("Returns a collection of unique constructions from a list of construction objects")]
-        [Input("constructions", "A collection of Constructions")]
-        [Input("includeConstructionName", "Flag to determine whether or not to use the construction name as a parameter of uniqueness. Default false")]
-        [Output("uniqueConstructions", "A collection of unique Construction objects")]
-        public static List<Construction> UniqueConstructions(this List<Construction> constructions, bool includeConstructionName = false)
+        [Description("Extract the smallest (most precise) numeric tolerance from the ComparisonConfig," +
+            "which is the smallest value amongst all CustomTolerances (irrespective of the properties they were paired with) and the global numeric tolerance.")]
+        [Input("comparisonConfig", "Comparison Config from where tolerance information should be extracted.")]
+        public static double SmallestToleranceFromConfig(this BaseComparisonConfig comparisonConfig)
         {
-            ComparisonConfig cc = new ComparisonConfig()
-            {
-                PropertyExceptions = new List<string>
-                {
-                    "CustomData"
-                },
-                NumericTolerance = BH.oM.Geometry.Tolerance.Distance
-            };
-
-            if (!includeConstructionName)
-                cc.PropertyExceptions.Add("Name");
-
-            List<Construction> allConstructions = constructions.Where(x => x != null).ToList();
-            List<Construction> uniqueConstructions = BH.Engine.Diffing.Modify.RemoveDuplicatesByHash<Construction>(allConstructions, cc).ToList();
-
-            return uniqueConstructions;
+            return ToleranceFromConfig(comparisonConfig, "", true); // the `propertyFullName` input is ignored when `getGlobalSmallest` is set to true.
         }
     }
 }
-

--- a/BHoM_Engine/Query/ToleranceFromConfig.cs
+++ b/BHoM_Engine/Query/ToleranceFromConfig.cs
@@ -1,0 +1,97 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Management.Automation;
+
+namespace BH.Engine.Base
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Extract the numeric tolerance from the ComparisonConfig." +
+            "If a CustomTolerance match is found for this property Full Name, then return it. " +
+            "If multiple matches are found, return the most sensistive tolerance. " +
+            "If no match is found, return the generic numeric tolerance.")]
+        [Input("comparisonConfig", "Comparison Config from where tolerance information should be extracted.")]
+        [Input("propertyFullName", "Full name (path) of the property for which we want to extract the numerical Tolerance.")]
+        [Input("getGlobalSmallest", "(Optional, defaults to false) If true, extract the smallest (most precise) tolerance amongst all CustomTolerances for all properties and the global numeric tolerance.")]
+        public static double ToleranceFromConfig(this BaseComparisonConfig comparisonConfig, string propertyFullName)
+        {
+            return ToleranceFromConfig(comparisonConfig, propertyFullName, false);
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        [Description("Extract the numeric tolerance from the ComparisonConfig." +
+            "If a CustomTolerance match is found for this property Full Name, then return it. " +
+            "If multiple matches are found, return the most sensistive tolerance. " +
+            "If no match is found, return the generic numeric tolerance.")]
+        [Input("comparisonConfig", "Comparison Config from where tolerance information should be extracted.")]
+        [Input("propertyFullName", "Full name (path) of the property for which we want to extract the numerical Tolerance.")]
+        [Input("getGlobalSmallest", "(Optional, defaults to false) If true, extract the smallest (most precise) tolerance amongst all CustomTolerances for all properties and the global numeric tolerance. Setting this to true makes `propertyFullName` irrelevant.")]
+        private static double ToleranceFromConfig(this BaseComparisonConfig comparisonConfig, string propertyFullName, bool getGlobalSmallest = false)
+        {
+            double tolerance = double.MaxValue;
+
+            // Take care of CustomTolerances.
+            if (comparisonConfig.CustomTolerances?.Any() ?? false)
+            {
+                // Iterate the specified CustomTolerances. If more than one match with the current property is found, take the safest (smallest) value.
+                List<string> matchingCustomTolerancesNames = new List<string>();
+                foreach (var ct in comparisonConfig.CustomTolerances)
+                {
+                    if (getGlobalSmallest || propertyFullName.EndsWith($".{ct.Name}") || new WildcardPattern(ct.Name).IsMatch(propertyFullName))
+                    {
+                        if (!getGlobalSmallest)
+                            matchingCustomTolerancesNames.Add(ct.Name);
+
+                        if (ct.Tolerance < tolerance)
+                            tolerance = ct.Tolerance;
+                    }
+                }
+
+                if (matchingCustomTolerancesNames.Count > 1)
+                    BH.Engine.Reflection.Compute.RecordWarning($"The property `{propertyFullName}` matched with {matchingCustomTolerancesNames.Count} CustomTolerances: `{string.Join("`, ", matchingCustomTolerancesNames)}`." +
+                    $"\nThe most sensitive tolerance was picked (smallest value): {tolerance}.");
+            }
+
+            // If no matching CustomTolerance was found, set the tolerance to be the general tolerance.
+            if (tolerance == double.MaxValue)
+                tolerance = comparisonConfig.NumericTolerance;
+
+            if (getGlobalSmallest && tolerance > comparisonConfig.NumericTolerance)
+                tolerance = comparisonConfig.NumericTolerance;
+
+            return tolerance;
+        }
+    }
+}

--- a/BHoM_Engine/Query/WildcardMatch.cs
+++ b/BHoM_Engine/Query/WildcardMatch.cs
@@ -1,0 +1,289 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Base
+{
+    public static partial class Query
+    {
+        [Description("Checks a wildcardPattern (e.g. *.someExtension) matches an input text.")]
+        [Input("text", "Text to match against the wildcard pattern.")]
+        [Input("wildcardPattern", "WildcardPattern (e.g. *.someExtension) to be used to see if a match is found against the input text.")]
+        public static bool WildcardMatch(this string text, string wildcardPattern)
+        {
+            if (string.IsNullOrWhiteSpace(text) || string.IsNullOrWhiteSpace(wildcardPattern))
+                return false;
+
+            try
+            {
+                bool isLike = true;
+                byte matchCase = 0;
+                char[] filter;
+                char[] reversedFilter;
+                char[] reversedWord;
+                char[] word;
+                int currentPatternStartIndex = 0;
+                int lastCheckedHeadIndex = 0;
+                int lastCheckedTailIndex = 0;
+                int reversedWordIndex = 0;
+                List<char[]> reversedPatterns = new List<char[]>();
+
+                if (text == null || wildcardPattern == null)
+                    return false;
+
+                word = text.ToCharArray();
+                filter = wildcardPattern.ToCharArray();
+
+                //Set which case will be used (0 = no wildcards, 1 = only ?, 2 = only *, 3 = both ? and *
+                for (int i = 0; i < filter.Length; i++)
+                {
+                    if (filter[i] == '?')
+                    {
+                        matchCase += 1;
+                        break;
+                    }
+                }
+
+                for (int i = 0; i < filter.Length; i++)
+                {
+                    if (filter[i] == '*')
+                    {
+                        matchCase += 2;
+                        break;
+                    }
+                }
+
+                if ((matchCase == 0 || matchCase == 1) && word.Length != filter.Length)
+                    return false;
+
+                switch (matchCase)
+                {
+                    case 0:
+                        isLike = (text == wildcardPattern);
+                        break;
+
+                    case 1:
+                        for (int i = 0; i < text.Length; i++)
+                        {
+                            if ((word[i] != filter[i]) && filter[i] != '?')
+                            {
+                                isLike = false;
+                            }
+                        }
+                        break;
+
+                    case 2:
+                        //Search for matches until first *
+                        for (int i = 0; i < filter.Length; i++)
+                        {
+                            if (filter[i] != '*')
+                            {
+                                if (filter[i] != word[i])
+                                {
+                                    return false;
+                                }
+                            }
+                            else
+                            {
+                                lastCheckedHeadIndex = i;
+                                break;
+                            }
+                        }
+                        //Search Tail for matches until first *
+                        for (int i = 0; i < filter.Length; i++)
+                        {
+                            if (filter[filter.Length - 1 - i] != '*')
+                            {
+                                if (filter[filter.Length - 1 - i] != word[word.Length - 1 - i])
+                                    return false;
+
+                            }
+                            else
+                            {
+                                lastCheckedTailIndex = i;
+                                break;
+                            }
+                        }
+
+
+                        //Create a reverse word and filter for searching in reverse. The reversed word and filter do not include already checked chars
+                        reversedWord = new char[word.Length - lastCheckedHeadIndex - lastCheckedTailIndex];
+                        reversedFilter = new char[filter.Length - lastCheckedHeadIndex - lastCheckedTailIndex];
+
+                        for (int i = 0; i < reversedWord.Length; i++)
+                            reversedWord[i] = word[word.Length - (i + 1) - lastCheckedTailIndex];
+
+                        for (int i = 0; i < reversedFilter.Length; i++)
+                            reversedFilter[i] = filter[filter.Length - (i + 1) - lastCheckedTailIndex];
+
+                        //Cut up the filter into seperate patterns, exclude * as they are not longer needed
+                        for (int i = 0; i < reversedFilter.Length; i++)
+                        {
+                            if (reversedFilter[i] == '*')
+                            {
+                                if (i - currentPatternStartIndex > 0)
+                                {
+                                    char[] pattern = new char[i - currentPatternStartIndex];
+                                    for (int j = 0; j < pattern.Length; j++)
+                                        pattern[j] = reversedFilter[currentPatternStartIndex + j];
+
+                                    reversedPatterns.Add(pattern);
+                                }
+                                currentPatternStartIndex = i + 1;
+                            }
+                        }
+
+                        //Search for the patterns
+                        for (int i = 0; i < reversedPatterns.Count; i++)
+                        {
+                            for (int j = 0; j < reversedPatterns[i].Length; j++)
+                            {
+
+                                if ((reversedPatterns[i].Length - 1 - j) > (reversedWord.Length - 1 - reversedWordIndex))
+                                    return false;
+
+                                if (reversedPatterns[i][j] != reversedWord[reversedWordIndex + j])
+                                {
+                                    reversedWordIndex += 1;
+                                    j = -1;
+                                }
+                                else
+                                {
+                                    if (j == reversedPatterns[i].Length - 1)
+                                        reversedWordIndex = reversedWordIndex + reversedPatterns[i].Length;
+                                }
+                            }
+                        }
+                        break;
+
+                    case 3:
+                        //Same as Case 2 except ? is considered a match
+                        //Search Head for matches util first *
+                        for (int i = 0; i < filter.Length; i++)
+                        {
+                            if (filter[i] != '*')
+                            {
+                                if (filter[i] != word[i] && filter[i] != '?')
+                                    return false;
+                            }
+                            else
+                            {
+                                lastCheckedHeadIndex = i;
+                                break;
+                            }
+                        }
+                        //Search Tail for matches until first *
+                        for (int i = 0; i < filter.Length; i++)
+                        {
+                            if (filter[filter.Length - 1 - i] != '*')
+                            {
+                                if (filter[filter.Length - 1 - i] != word[word.Length - 1 - i] && filter[filter.Length - 1 - i] != '?')
+                                    return false;
+                            }
+                            else
+                            {
+                                lastCheckedTailIndex = i;
+                                break;
+                            }
+                        }
+                        // Reverse and trim word and filter
+                        reversedWord = new char[word.Length - lastCheckedHeadIndex - lastCheckedTailIndex];
+                        reversedFilter = new char[filter.Length - lastCheckedHeadIndex - lastCheckedTailIndex];
+
+                        for (int i = 0; i < reversedWord.Length; i++)
+                            reversedWord[i] = word[word.Length - (i + 1) - lastCheckedTailIndex];
+
+                        for (int i = 0; i < reversedFilter.Length; i++)
+                            reversedFilter[i] = filter[filter.Length - (i + 1) - lastCheckedTailIndex];
+
+                        for (int i = 0; i < reversedFilter.Length; i++)
+                        {
+                            if (reversedFilter[i] == '*')
+                            {
+                                if (i - currentPatternStartIndex > 0)
+                                {
+                                    char[] pattern = new char[i - currentPatternStartIndex];
+                                    for (int j = 0; j < pattern.Length; j++)
+                                        pattern[j] = reversedFilter[currentPatternStartIndex + j];
+                                    reversedPatterns.Add(pattern);
+                                }
+
+                                currentPatternStartIndex = i + 1;
+                            }
+                        }
+                        //Search for the patterns
+                        for (int i = 0; i < reversedPatterns.Count; i++)
+                        {
+                            for (int j = 0; j < reversedPatterns[i].Length; j++)
+                            {
+                                if ((reversedPatterns[i].Length - 1 - j) > (reversedWord.Length - 1 - reversedWordIndex))
+                                    return false;
+
+                                if (reversedPatterns[i][j] != '?' && reversedPatterns[i][j] != reversedWord[reversedWordIndex + j])
+                                {
+                                    reversedWordIndex += 1;
+                                    j = -1;
+                                }
+                                else
+                                {
+                                    if (j == reversedPatterns[i].Length - 1)
+                                        reversedWordIndex = reversedWordIndex + reversedPatterns[i].Length;
+                                }
+                            }
+                        }
+                        break;
+                }
+
+                return isLike;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /***************************************************/
+
+        [Description("Checks a wildcardPattern (e.g. *.someExtension) matches an input text.")]
+        [Input("text", "Text to match against the wildcard pattern.")]
+        [Input("wildcardPattern", "WildcardPattern (e.g. *.someExtension) to be used to see if a match is found against the input text.")]
+        [Input("ignoreCase", "If we want to ignore the text case (lowercase/uppercase).")]
+        public static bool WildcardMatch(this string text, string wildcardPattern, bool ignoreCase)
+        {
+            if (string.IsNullOrWhiteSpace(text) || string.IsNullOrWhiteSpace(wildcardPattern))
+                return false;
+
+            if (ignoreCase == true)
+                return text.ToLower().WildcardMatch(wildcardPattern.ToLower());
+            else
+                return text.WildcardMatch(wildcardPattern);
+        }
+    }
+}

--- a/BHoM_Engine/Versioning_50.json
+++ b/BHoM_Engine/Versioning_50.json
@@ -1,0 +1,22 @@
+{
+    "Namespace": {
+        "ToNew": {
+        },
+        "ToOld": {
+        }
+    },
+    "Type": {
+        "ToNew": {
+            "BH.Engine.Diffing.HashComparer": "BH.Engine.Base.Objects.HashComparer"
+        },
+        "ToOld": {
+            "BH.Engine.Base.Objects.HashComparer": "BH.Engine.Diffing.HashComparer"
+        }
+    },
+    "Property": {
+        "ToNew": {
+        },
+        "ToOld": {
+        }
+    }
+}

--- a/Diffing_Engine/Compute/DiffRevisions.cs
+++ b/Diffing_Engine/Compute/DiffRevisions.cs
@@ -134,7 +134,7 @@ namespace BH.Engine.Diffing
             List<IBHoMObject> readObjs = pastObjects.ToList();
 
             // Make dictionary with object hashes to speed up the next lookups
-            Dictionary<string, IBHoMObject> readObjs_dict = readObjs.ToDictionary(obj => obj.RevisionFragment().Hash, obj => obj);
+            Dictionary<string, IBHoMObject> readObjs_dict = readObjs.ToDictionary(obj => obj.RevisionFragment()?.Hash, obj => obj);
 
             // Dispatch the objects: new, modified or old
             List<IBHoMObject> newObjs = new List<IBHoMObject>();

--- a/Diffing_Engine/Compute/DiffWithCustomDataKeyId.cs
+++ b/Diffing_Engine/Compute/DiffWithCustomDataKeyId.cs
@@ -56,8 +56,8 @@ namespace BH.Engine.Diffing
             if (InputObjectsNullOrEmpty(pastObjects, followingObjects, out outputDiff, diffingConfig))
                 return outputDiff;
 
-            HashSet<string> pastObjectsIds = new HashSet<string>();
-            HashSet<string> followingObjectsIds = new HashSet<string>();
+            List<string> pastObjectsIds = new List<string>();
+            List<string> followingObjectsIds = new List<string>();
 
             // Verifies inputs and populates the id lists, then if successfull perform the Diffing.
             if (ExtractIdFromCustomData(pastObjects, followingObjects, customdataIdKey, out followingObjectsIds, out pastObjectsIds))
@@ -70,14 +70,14 @@ namespace BH.Engine.Diffing
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static bool ExtractIdFromCustomData(IEnumerable<IBHoMObject> pastObjects, IEnumerable<IBHoMObject> followingObjects, string customdataIdKey, out HashSet<string> out_currentObjectsIds, out HashSet<string> out_pastObjectsIds)
+        private static bool ExtractIdFromCustomData(IEnumerable<IBHoMObject> pastObjects, IEnumerable<IBHoMObject> followingObjects, string customdataIdKey, out List<string> out_currentObjectsIds, out List<string> out_pastObjectsIds)
         {
             // Output ids
-            out_currentObjectsIds = new HashSet<string>();
-            out_pastObjectsIds = new HashSet<string>();
+            out_currentObjectsIds = new List<string>();
+            out_pastObjectsIds = new List<string>();
 
-            HashSet<string> followingObjectsIds = new HashSet<string>();
-            HashSet<string> pastObjectsIds = new HashSet<string>();
+            List<string> followingObjectsIds = new List<string>();
+            List<string> pastObjectsIds = new List<string>();
 
             // Check on customDataKey
             if (string.IsNullOrWhiteSpace(customdataIdKey))

--- a/Diffing_Engine/Compute/DiffWithCustomIds.cs
+++ b/Diffing_Engine/Compute/DiffWithCustomIds.cs
@@ -132,7 +132,7 @@ namespace BH.Engine.Diffing
             List<object> modifiedObjs = new List<object>();
             List<object> removedObjs = new List<object>();
             List<object> unchangedObjs = new List<object>();
-            Dictionary<string, Dictionary<string, Tuple<object, object>>> objModifiedProps = new Dictionary<string, Dictionary<string, Tuple<object, object>>>();
+            List<ObjectDifferences> modifiedObjectsDifferences = new List<ObjectDifferences>();
 
             foreach (var kv_foll in follObjs_dict)
             {
@@ -157,13 +157,13 @@ namespace BH.Engine.Diffing
                     // If we are also asking for what properties changed, let's rely on DifferentProperties to see whether the object changed or not.
 
                     // Determine the changed properties.
-                    var differentProps = Query.DifferentProperties(followingObj, correspondingPastObj, diffingConfig);
+                    ObjectDifferences objectDifferences = Query.ObjectDifferences(correspondingPastObj, followingObj, diffingConfig.ComparisonConfig);
 
-                    if (differentProps != null && differentProps.Count > 0)
+                    if (objectDifferences != null && (objectDifferences.Differences?.Any() ?? false))
                     {
                         // It's been modified
                         modifiedObjs.Add(followingObj);
-                        objModifiedProps.Add(followingObjID, differentProps);
+                        modifiedObjectsDifferences.Add(objectDifferences);
                     }
                     else
                     {
@@ -218,7 +218,7 @@ namespace BH.Engine.Diffing
             }
 
             // If no modifed property was found, set the field to null (otherwise will get empty list)
-            objModifiedProps = !objModifiedProps.Any() ? null : objModifiedProps;
+            modifiedObjectsDifferences = !modifiedObjectsDifferences.Any() ? null : modifiedObjectsDifferences;
 
             // All PastObjects that cannot be found by id in the CurrentObjs are old.
             removedObjs = pastObjs_dict.Keys.Except(follObjs_dict.Keys)
@@ -258,7 +258,7 @@ namespace BH.Engine.Diffing
                     $"No {nameof(BH.oM.Diffing.Diff.ModifiedObjects)} were found. Make sure that the specified `{nameof(DiffingConfig)}.{nameof(DiffingConfig.ComparisonConfig)}.{nameof(DiffingConfig.ComparisonConfig.PropertiesToConsider)}` is set correctly.");
             }
 
-            return new Diff(addedObjs, removedObjs, modifiedObjs, diffingConfig, objModifiedProps, unchangedObjs);
+            return new Diff(addedObjs, removedObjs, modifiedObjs, diffingConfig, modifiedObjectsDifferences, unchangedObjs);
         }
     }
 }

--- a/Diffing_Engine/Compute/DiffWithFragmentId.cs
+++ b/Diffing_Engine/Compute/DiffWithFragmentId.cs
@@ -68,12 +68,6 @@ namespace BH.Engine.Diffing
                     $"\nDefaulted to `{typeof(IPersistentAdapterId).FullName}.{nameof(IPersistentAdapterId.PersistentId)}`.");
             }
 
-            if (string.IsNullOrWhiteSpace(fragmentIdProperty))
-            {
-                BH.Engine.Reflection.Compute.RecordError($"No {nameof(fragmentIdProperty)} specified.");
-                return null;
-            }
-
             // Checks on the specified fragmentType/fragmentIdProperty combination.
             var propertiesOnFragment = fragmentType.GetProperties().Where(pi => pi.Name == fragmentIdProperty);
             if (!propertiesOnFragment.Any())
@@ -82,8 +76,8 @@ namespace BH.Engine.Diffing
                 return null;
             }
 
-            IEnumerable<string> pastObjsIds = pastObjects.Select(o => o.GetIdFromFragment(fragmentType, fragmentIdProperty)).Where(s => !s.IsNullOrEmpty());
-            IEnumerable<string> follObjsIds = followingObjs.Select(o => o.GetIdFromFragment(fragmentType, fragmentIdProperty)).Where(s => !s.IsNullOrEmpty());
+            List<string> pastObjsIds = pastObjects.Select(o => o.GetIdFromFragment(fragmentType, fragmentIdProperty)).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
+            List<string> follObjsIds = followingObjs.Select(o => o.GetIdFromFragment(fragmentType, fragmentIdProperty)).Where(s => !string.IsNullOrWhiteSpace(s)).ToList();
 
             bool missingIds = false;
             if (pastObjsIds.Count() != pastObjects.Count())
@@ -121,7 +115,7 @@ namespace BH.Engine.Diffing
 
             IFragment idFragm = null;
             var idFragments = obj.GetAllFragments(fragmentType);
-            if (idFragments.Count > 1)
+            if (idFragments != null && idFragments.Count > 1)
             {
                 BH.Engine.Reflection.Compute.RecordWarning($"Object of type {obj.GetType()}, guid {obj.BHoM_Guid} contains more than one fragment of the provided Fragment type {fragmentType}. Unable to decide which one to pick.");
                 return null;

--- a/Diffing_Engine/Compute/DiffWithHash.cs
+++ b/Diffing_Engine/Compute/DiffWithHash.cs
@@ -37,6 +37,7 @@ using BH.oM.Reflection.Attributes;
 using BH.oM.Reflection;
 using System.Collections;
 using BH.Engine.Base;
+using BH.Engine.Base.Objects;
 
 namespace BH.Engine.Diffing
 {
@@ -80,8 +81,6 @@ namespace BH.Engine.Diffing
 
         private static Diff DiffingWithHash(IEnumerable<object> pastObjects, IEnumerable<object> followingObjs, DiffingConfig diffingConfig = null, bool storeHash = false, bool retrieveStoredHash = false)
         {
-            diffingConfig = diffingConfig ?? new DiffingConfig();
-
             Diff outputDiff = null;
             if (InputObjectsNullOrEmpty(pastObjects, followingObjs, out outputDiff, diffingConfig))
                 return outputDiff;

--- a/Diffing_Engine/Create/DiffingConfig.cs
+++ b/Diffing_Engine/Create/DiffingConfig.cs
@@ -61,9 +61,7 @@ namespace BH.Engine.Diffing
                 IncludeUnchangedObjects = storeUnchangedObjects,
                 ComparisonConfig = new ComparisonConfig()
                 {
-                    //PropertyNamesToConsider = propertyNamesToConsider,
-                    //PropertyExceptions = propertiesToIgnore,
-                    //CustomdataKeysExceptions = (customDataToIgnore == null || !customDataToIgnore.Any()) ? new List<string>() { "RenderMesh" } : customDataToIgnore
+                    PropertiesToConsider = propertyNamesToConsider,
                 },
             };
         }

--- a/Diffing_Engine/Query/AdaptersDiffingMethods.cs
+++ b/Diffing_Engine/Query/AdaptersDiffingMethods.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Diffing
         /***************************************************/
 
         [Description("Return the Diffing methods found in all Toolkits (i.e. not in the BHoM_Engine)." +
-            "\nA diffing method is a method called 'Diffing' and that has these parameters:" +
+            "\nA diffing method is a method whose name ends with 'Diffing' and that has these parameters:" +
             "an IEnumerable<objects> for the past set; an IEnumerable<objects> for the following set;" +
             "any number of other optional parameters; and one DiffingConfig parameter.")]
         [Output("Diffing methods found in all Toolkits (i.e. not in the BHoM_Engine).")]
@@ -50,10 +50,9 @@ namespace BH.Engine.Diffing
             List<MethodBase> adaptersDiffingMethods = new List<MethodBase>();
 
             List<MethodBase> diffingMethods = BH.Engine.Reflection.Query.AllMethodList()
-                .Where(x => x.Name == "Diffing")
+                .Where(x => x.Name.EndsWith("Diffing"))
                 .Where(mi => mi.DeclaringType.Module.Name != typeof(BH.Engine.Diffing.Query).Module.Name)
                 .ToList();
-
 
             // Checks on the parameters.
             foreach (var mi in diffingMethods)

--- a/Diffing_Engine/Query/CombinedDiff.cs
+++ b/Diffing_Engine/Query/CombinedDiff.cs
@@ -57,11 +57,8 @@ namespace BH.Engine.Diffing
                 diff.RemovedObjects != null ? diff.RemovedObjects.Concat(toAdd.RemovedObjects ?? new List<object>()) : toAdd.RemovedObjects ?? new List<object>(),
                 diff.ModifiedObjects != null ? diff.ModifiedObjects.Concat(toAdd.ModifiedObjects ?? new List<object>()) : toAdd.ModifiedObjects ?? new List<object>(),
                 diff?.DiffingConfig ?? new DiffingConfig(),
-                diff.ModifiedPropsPerObject != null ?
-                        diff.ModifiedPropsPerObject
-                        .Concat(toAdd.ModifiedPropsPerObject ?? new Dictionary<string, Dictionary<string, Tuple<object, object>>>())
-                        .ToDictionary(x => x.Key, x => x.Value)
-                        : toAdd.ModifiedPropsPerObject ?? new Dictionary<string, Dictionary<string, Tuple<object, object>>>(),
+                diff.ModifiedObjectsDifferences != null ? diff.ModifiedObjectsDifferences.Concat(toAdd.ModifiedObjectsDifferences ?? new List<ObjectDifferences>())
+                        : toAdd.ModifiedObjectsDifferences ?? new List<ObjectDifferences>(),
                 diff.UnchangedObjects != null ? diff.UnchangedObjects.Concat(toAdd.UnchangedObjects ?? new List<object>()) : toAdd.UnchangedObjects ?? new List<object>()
                 );
         }

--- a/Diffing_Engine/Query/DifferentProperties.cs
+++ b/Diffing_Engine/Query/DifferentProperties.cs
@@ -29,7 +29,7 @@ using System.ComponentModel;
 using BH.oM.Reflection.Attributes;
 using BH.oM.Diffing;
 using BH.oM.Base;
-using KellermanSoftware.CompareNetObjects;
+using kellerman = KellermanSoftware.CompareNetObjects;
 using System.Reflection;
 using BH.Engine.Base;
 
@@ -40,131 +40,36 @@ namespace BH.Engine.Diffing
         [Description("Checks two BHoMObjects property by property and returns the differences.")]
         [Input("obj1", "First object to compare for differences.")]
         [Input("obj2", "Second object to compare for differences.")]
-        [Input("diffingConfig", "Config to be used for the comparison. Can set numeric tolerance, wheter to check the guid, if custom data should be ignored and if any additional properties should be ignored.")]
-        [Output("Dictionary whose key is the name of the property, and value is a tuple with the different values found in obj1 and obj2.\n" +
-            "This dictionary can be 'exploded' in the UI by using `ListDifferentProperties` method.")]
-        public static Dictionary<string, Tuple<object, object>> DifferentProperties(this object obj1, object obj2, DiffingConfig diffingConfig = null)
+        [Input("comparisonConfig", "Additional configurations to be used for the comparison.")]
+        [Output("Dictionary whose Key is the Full Name of the property that is different among the two objects, " +
+            "and whose Value is a Tuple: Item1 is the value of the property in obj1, Item2 the value in obj2." +
+            "\nThis dictionary can be 'exploded' in the UI by using the `ListDifferentProperties()` method." +
+            "\nIf no difference was found, returns null.")]
+        [PreviousVersion("5.0", "BH.Engine.Diffing.Query.DifferentProperties(System.Object, System.Object, BH.oM.Diffing.DiffingConfig)")]
+        public static Dictionary<string, Tuple<object,object>> DifferentProperties(this object obj1, object obj2, ComparisonConfig comparisonConfig = null)
         {
-            bool differentTypes = false;
-            Type commonType = obj1?.GetType();
-            if (commonType != obj2?.GetType())
-            {
-                differentTypes = true;
-                commonType = BH.Engine.Reflection.Query.CommonBaseType(new List<Type>() { obj1?.GetType(), obj2?.GetType() });
-            }
+            // Call Query.ObjectDifferences(). 
+            // This method returns an object `ObjectDifferences`, which stores differences in a "temporal" manner (e.g. pastValue, followingValue, etc.),
+            // because it is used for change control purposes.
+            // Instead, the purpose of this current method `DifferentProperties()` is to return a similar result, but without the "temporal" qualification.
+            ObjectDifferences objectDifferences = Query.ObjectDifferences(obj1, obj2, comparisonConfig);
 
-            // Set configurations if DiffingConfig is null. Clone it for immutability in the UI.
-            DiffingConfig dc = diffingConfig == null ? new DiffingConfig() : diffingConfig.DeepClone() as DiffingConfig;
-
-            object obj1Copy = obj1.DeepClone();
-            object obj2Copy = obj2.DeepClone();
-
-            var dict = new Dictionary<string, Tuple<object, object>>();
-
-            CompareLogic comparer = new CompareLogic();
-
-            // General configurations.
-            comparer.Config.MaxDifferences = dc.MaxPropertyDifferences;
-            comparer.Config.DoublePrecision = dc.ComparisonConfig.NumericTolerance;
-
-            // Set the properties to be ignored.
-            if (!dc.ComparisonConfig.PropertyExceptions?.Contains("BHoM_Guid") ?? true)
-                dc.ComparisonConfig.PropertyExceptions.Add("BHoM_Guid");
-            // the above should be replaced by BH.Engine.Reflection.Compute.RecordWarning($"`BHoM_Guid` should generally be ignored when computing the diffing. Consider adding it to the {nameof(DiffingConfig.PropertiesToIgnore)}.");
-            // when the bug in the auto Create() method ("auto-property initialisers for ByRef values like lists do not populate default values") is resolved.
-
-            comparer.Config.MembersToIgnore = dc.ComparisonConfig.PropertyExceptions;
-
-            // Never include the changes in HashFragment.
-            comparer.Config.TypesToIgnore.Add(typeof(HashFragment));
-            comparer.Config.TypesToIgnore.Add(typeof(RevisionFragment));
-            comparer.Config.TypesToIgnore.AddRange(dc.ComparisonConfig.TypeExceptions);
-
-            // Perform the comparison.
-            ComparisonResult result = comparer.Compare(obj1Copy, obj2Copy);
-
-            if (result.Differences.Count == dc.MaxPropertyDifferences)
-                BH.Engine.Reflection.Compute.RecordWarning($"Hit the limit of {nameof(DiffingConfig.MaxPropertyDifferences)} specified in the {nameof(DiffingConfig)}.");
-
-            // Parse and store the differnces as appropriate.
-            foreach (var difference in result.Differences)
-            {
-                string propertyName = difference.PropertyName;
-                string propertyFullName = differentTypes ? commonType + "." + propertyName : propertyName; // propertyPath does not need to record the base common type if the types are equal.
-
-                // The property path without indexes in square brackets is useful to check if it matches with any property exception.
-                // E.g. Bar.Fragments[1].Parameters[5].Name becomes Bar.Fragments.Parameters.Name, so we can check that against exceptions like `Parameters.Name`.
-                string propertyFullName_noIndexes = propertyFullName.RemoveSquareIndexing();
-
-                // If there is a PropertyFullNameModifier, invoke it to modify the property full name.
-                if (dc.ComparisonConfig.ComparisonFunctions?.PropertyFullNameModifier != null)
-                {
-                    propertyFullName = dc.ComparisonConfig.ComparisonFunctions.PropertyFullNameModifier.Invoke(propertyFullName, difference.ParentObject2);
-                    propertyFullName_noIndexes = propertyFullName;
-                }
-
-                // If there is a PropertyFullNameFilter, invoke it to see if we should discard this property difference.
-                if (dc.ComparisonConfig.ComparisonFunctions.PropertyFullNameFilter != null)
-                    if (dc.ComparisonConfig.ComparisonFunctions.PropertyFullNameFilter.Invoke(propertyFullName_noIndexes, difference.ParentObject2))
-                        continue;
-
-                // Skip if the property is among the PropertyExceptions.
-                if (dc.ComparisonConfig.PropertyExceptions.Any() && dc.ComparisonConfig.PropertyExceptions.Any(pe => propertyFullName_noIndexes.EndsWith(pe)))
-                    continue;
-
-                // Check if this difference is a difference in terms of CustomData.
-                if (propertyFullName.Contains("CustomData") && propertyFullName.Contains("Value"))
-                {
-                    // Get the custom data Key, so we can check if it belongs to the exceptions.
-                    int keyStart = propertyFullName.IndexOf('[') + 1;
-                    int keyEnd = propertyFullName.IndexOf(']');
-                    string customDataKey = propertyFullName.Substring(keyStart, keyEnd - keyStart);
-
-                    // If there is a CustomDataKeyFilter, invoke it to see if we should discard this CustomData difference.
-                    if (dc.ComparisonConfig.ComparisonFunctions.CustomDataKeyFilter != null)
-                        if (dc.ComparisonConfig.ComparisonFunctions.CustomDataKeyFilter.Invoke(customDataKey, difference.ParentObject2))
-                            continue;
-
-                    // If there are CustomdataKeysToInclude specified and this customDataKey is not among them, skip it.
-                    if ((dc.ComparisonConfig.CustomdataKeysToInclude?.Any() ?? false) && !dc.ComparisonConfig.CustomdataKeysToInclude.Contains(customDataKey))
-                        continue;
-
-                    // Skip this custom data if the key belongs to the exceptions.
-                    if (dc.ComparisonConfig.CustomdataKeysExceptions.Contains(customDataKey))
-                        continue;
-
-                    // Just for aesthetic reasons, remove the first dot in the name between CustomData.[keyname].etc
-                    propertyFullName = propertyFullName.Remove(propertyFullName.IndexOf('.'), 1);
-                }
-
-                // Check if the property Full name matches any of the specified PropertiesToConsider.
-                if (dc.ComparisonConfig.PropertiesToConsider.Any())
-                {
-                    if (!dc.ComparisonConfig.PropertiesToConsider.Any(ptc => propertyFullName == ptc || propertyFullName.EndsWith($".{ptc}")))
-                        continue; // no match found, skip this property.
-                }
-
-                // If there is a PropertyDisplayNameModifier, invoke it to modify the property full name.
-                if (dc.ComparisonConfig.ComparisonFunctions?.PropertyDisplayNameModifier != null)
-                {
-                    propertyFullName = dc.ComparisonConfig.ComparisonFunctions.PropertyDisplayNameModifier.Invoke(propertyFullName, difference.ParentObject2);
-                    propertyFullName_noIndexes = propertyFullName;
-                }
-
-                // Add to the final result.
-                dict[propertyFullName] = new Tuple<object, object>(difference.Object1, difference.Object2);
-            }
-
-            if (dict.Count == 0)
+            if (objectDifferences == null)
                 return null;
 
-            return dict; // this Dictionary may be exploded in the UI by using the method "ListDifferentProperties".
-        }
+            // Group the `ObjectDifferences` in a Dictionary.
+            Dictionary<string, Tuple<object, object>> result = objectDifferences.Differences.GroupBy(d => d.FullName)
+                .ToDictionary(
+                g => g.Key,
+                g => 
+                {
+                    // By grouping by FullName, only one propertyDifference will be found per group.
+                    PropertyDifference firstPropertyDifference = g.ToList().FirstOrDefault();
 
-        [Description("Removes square bracket indexing from property paths, e.g. `Bar.Fragments[0].Something` is returned as `Bar.Fragments.Something`.")]
-        private static string RemoveSquareIndexing(this string propertyPath)
-        {
-            return System.Text.RegularExpressions.Regex.Replace(propertyPath, @"\[(.*?)\]", string.Empty);
+                    return new Tuple<object, object>(firstPropertyDifference.PastValue, firstPropertyDifference.FollowingValue);
+                });
+
+            return result;
         }
     }
 }

--- a/Diffing_Engine/Query/ListModifiedProperties.cs
+++ b/Diffing_Engine/Query/ListModifiedProperties.cs
@@ -40,6 +40,7 @@ namespace BH.Engine.Diffing
         [MultiOutput(1, "propNames", "List of properties changed per each object.")]
         [MultiOutput(2, "value_current", "List of current values of the properties.")]
         [MultiOutput(3, "value_past", "List of past values of the properties.")]
+        [ToBeRemoved("5.0", "Deprecated due to the new Diff object structure.")]
         public static Output<List<List<string>>, List<List<string>>, List<List<object>>, List<List<object>>> ListModifiedProperties(this Dictionary<string, Dictionary<string, Tuple<object, object>>> modProps, List<string> filterNames = null)
         {
             var output = new Output<List<List<string>>, List<List<string>>, List<List<object>>, List<List<object>>>();

--- a/Diffing_Engine/Query/ObjectDifferences.cs
+++ b/Diffing_Engine/Query/ObjectDifferences.cs
@@ -1,0 +1,175 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Diffing;
+using BH.oM.Base;
+using kellerman = KellermanSoftware.CompareNetObjects;
+using System.Reflection;
+using BH.Engine.Base;
+
+namespace BH.Engine.Diffing
+{
+    public static partial class Query
+    {
+        [Description("Compare two versions of the same object that sustained some modification over time, and returns differences.")]
+        [Input("pastObject", "Past version of the object (created before `followingObject`).")]
+        [Input("followingObject", "Following version of the object (modified or created after `pastObject`).")]
+        [Input("comparisonConfig", "Additional configurations to be used for the comparison.")]
+        [Output("Returns an `ObjectDifferences` object storing all the found differences between `previousObject` and `followingObject`." +
+            "\nIf no difference was found, returns null.")]
+        [PreviousVersion("5.0", "BH.Engine.Diffing.DifferentProperties(System.Object, System.Object, BH.oM.Base.ComparisonConfig)")]
+        public static ObjectDifferences ObjectDifferences(this object pastObject, object followingObject, BaseComparisonConfig comparisonConfig = null)
+        {
+            // Result object.
+            ObjectDifferences result = new ObjectDifferences() { PastObject = pastObject, FollowingObject = followingObject };
+
+            // Null check. At least one of the objects must be not null.
+            if (pastObject == null && followingObject == null)
+                return result;
+
+            // Set ComparisonConfig if null. Clone it for immutability in the UI.
+            BaseComparisonConfig cc = comparisonConfig == null ? new ComparisonConfig() : comparisonConfig.DeepClone();
+
+            // Make sure that the propertiesToConsider and propertyExceptions are specified with their FullName form.
+            cc.PropertyInclusionsToFullNames(pastObject.GetType());
+            cc.PropertyInclusionsToFullNames(followingObject.GetType());
+
+            // Make sure that `BHoM_Guid` will NOT be considered amongst the property differences.
+            if (!cc.PropertyExceptions?.Contains("BHoM_Guid") ?? true)
+                cc.PropertyExceptions.Add("BHoM_Guid"); // (this can be specified in "non-full
+
+            // General Kellerman configurations.
+            kellerman.CompareLogic kellermanComparer = new kellerman.CompareLogic();
+            kellermanComparer.Config.MaxDifferences = cc.MaxPropertyDifferences;
+            kellermanComparer.Config.DoublePrecision = cc.NumericTolerance;
+            kellermanComparer.Config.TypesToIgnore.Add(typeof(HashFragment)); // Never include the changes in HashFragment.
+            kellermanComparer.Config.TypesToIgnore.Add(typeof(RevisionFragment)); // Never include the changes in RevisionFragment.
+            kellermanComparer.Config.TypesToIgnore.AddRange(cc.TypeExceptions);
+            kellermanComparer.Config.MembersToIgnore = cc.PropertyExceptions;
+
+            // Perform the comparison using the Kellerman library.
+            kellerman.ComparisonResult kellermanResult = kellermanComparer.Compare(pastObject, followingObject);
+
+            // Alert if the maximum properties cap was hit.
+            if (kellermanResult.Differences.Count == cc.MaxPropertyDifferences)
+                BH.Engine.Reflection.Compute.RecordWarning($"Hit the limit of {nameof(cc.MaxPropertyDifferences)} specified in the {nameof(oM.Base.ComparisonConfig)}.");
+
+            // Iterate all property differences found by Kellerman.
+            string objectFullName = pastObject == null ? pastObject.GetType().FullName : followingObject.GetType().FullName;
+            foreach (var kellermanPropertyDifference in kellermanResult.Differences)
+            {
+                string propertyName = kellermanPropertyDifference.PropertyName;
+                string propertyFullName = objectFullName + "." + propertyName;
+                string propertyDisplayName = propertyName;
+
+                // Check if there is a `PropertyComparisonInclusion()` extension method available for this property difference.
+                object propCompIncl = null;
+                object[] parameters = new object[] { propertyFullName, cc };
+                if (BH.Engine.Reflection.Compute.TryRunExtensionMethod(kellermanPropertyDifference.ParentObject2, "ComparisonInclusion", parameters, out propCompIncl))
+                {
+                    ComparisonInclusion propComparisonInclusion = propCompIncl as ComparisonInclusion;
+
+                    if (propComparisonInclusion.Include)
+                    {
+                        // Add to the final result.
+                        result.Differences.Add(new PropertyDifference()
+                        {
+                            DisplayName = propComparisonInclusion.DisplayName,
+                            PastValue = kellermanPropertyDifference.Object1,
+                            FollowingValue = kellermanPropertyDifference.Object2,
+                            FullName = propertyFullName
+                        });
+                    }
+
+                    // Because a `PropertyComparisonInclusion()` extension method was found, we've already determined if this property difference was to be added or not. Continue.
+                    continue;
+                }
+
+                // Get the property path without indexes in square brackets.
+                // This is useful to check if it matches with any propertyExceptions/propertiesToConsider.
+                // E.g. Bar.Fragments[1].Parameters[5].Name becomes Bar.Fragments.Parameters.Name, so we can check that against exceptions like `Parameters.Name`.
+                string propertyFullName_noIndexes = propertyFullName.RemoveSquareIndexing();
+
+                // Skip if the property is among the PropertyExceptions, or if it's a BHoM_Guid.
+                if ((cc.PropertyExceptions?.Contains(propertyFullName_noIndexes) ?? false) || propertyFullName_noIndexes.EndsWith("BHoM_Guid"))
+                    continue;
+
+                // If the PropertiesToConsider contains at least a value, ensure that this property is among them.
+                if ((cc.PropertiesToConsider?.Any() ?? false) && !cc.PropertiesToConsider.Contains(propertyFullName_noIndexes))
+                    continue;
+
+                // Check if this difference is a difference in terms of CustomData.
+                if (propertyFullName.Contains("CustomData") && propertyFullName.Contains("Value"))
+                {
+                    // Get the custom data Key, so we can check if it belongs to the exceptions.
+                    int keyStart = propertyFullName.IndexOf('[') + 1;
+                    int keyEnd = propertyFullName.IndexOf(']');
+                    string customDataKey = propertyFullName.Substring(keyStart, keyEnd - keyStart);
+
+                    // If there are CustomdataKeysToInclude specified and this customDataKey is not among them, skip it.
+                    if ((cc.CustomdataKeysToInclude?.Any() ?? false) && !cc.CustomdataKeysToInclude.Contains(customDataKey))
+                        continue;
+
+                    // Skip this custom data if the key belongs to the exceptions.
+                    if (cc.CustomdataKeysExceptions?.Contains(customDataKey) ?? false)
+                        continue;
+
+                    // Just for aesthetic reasons, remove the first dot in the name between CustomData.[keyname].etc
+                    propertyDisplayName = propertyFullName.Remove(propertyFullName.IndexOf('.'), 1);
+                }
+
+                // Add to the final result.
+                result.Differences.Add(new PropertyDifference()
+                {
+                    DisplayName = propertyDisplayName,
+                    PastValue = kellermanPropertyDifference.Object1,
+                    FollowingValue = kellermanPropertyDifference.Object2,
+                    FullName = propertyFullName
+                });
+            }
+
+            if (result.Differences.Count == 0)
+                return null;
+
+            return result;
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        [Description("Removes square bracket indexing from property paths, e.g. `Bar.Fragments[0].Something` is returned as `Bar.Fragments.Something`.")]
+        private static string RemoveSquareIndexing(this string propertyPath)
+        {
+            return System.Text.RegularExpressions.Regex.Replace(propertyPath, @"\[(.*?)\]", string.Empty);
+        }
+    }
+}
+
+

--- a/Diffing_Engine/Query/ObjectDifferences.cs
+++ b/Diffing_Engine/Query/ObjectDifferences.cs
@@ -57,8 +57,8 @@ namespace BH.Engine.Diffing
             BaseComparisonConfig cc = comparisonConfig == null ? new ComparisonConfig() : comparisonConfig.DeepClone();
 
             // Make sure that the propertiesToConsider and propertyExceptions are specified with their FullName form.
-            cc.PropertyInclusionsToFullNames(pastObject.GetType());
-            cc.PropertyInclusionsToFullNames(followingObject.GetType());
+            cc.PropertyNamesToFullNames(pastObject.GetType());
+            cc.PropertyNamesToFullNames(followingObject.GetType());
 
             // Make sure that `BHoM_Guid` will NOT be considered amongst the property differences.
             if (!cc.PropertyExceptions?.Contains("BHoM_Guid") ?? true)
@@ -151,10 +151,10 @@ namespace BH.Engine.Diffing
                 }
 
                 // Check if we specified CustomTolerances and if this difference is a floating-point number difference.
-                if (comparisonConfig.CustomTolerances.Any() && kellermanPropertyDifference.Object1.IsFloatingPointNumber() && kellermanPropertyDifference.Object2.IsFloatingPointNumber())
+                if (cc.PropertyNumericTolerances.Any() && kellermanPropertyDifference.Object1.IsFloatingPointNumber() && kellermanPropertyDifference.Object2.IsFloatingPointNumber())
                 {
                     // Retrieve the numeric Tolerance to be used for this property.
-                    double tolerance = cc.ToleranceFromConfig(propertyFullName_noIndexes);
+                    double tolerance = cc.PropertyNumericTolerance(propertyFullName_noIndexes);
 
                     // Convert from the Numeric Tolerance to fractionalDigits (required for rounding).
                     int fractionalDigits = Math.Abs(System.Convert.ToInt32(Math.Log10(tolerance)));

--- a/Environment_Engine/Query/HasMergeablePropertiesWith.cs
+++ b/Environment_Engine/Query/HasMergeablePropertiesWith.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Environment
         [Input("element", "An Environment Edge to compare the properties of with an other Environment Edge")]
         [Input("other", "The Environment Edge to compare with the other Environment Edge.")]
         [Output("equal", "True if the Objects non-geometrical property is equal to the point that they could be merged into one object")]
-        public static bool HasMergeablePropertiesWith(Edge element, Edge other)
+        public static bool HasMergeablePropertiesWith(this Edge element, Edge other)
         {
             return true; //Environment Edges have no additional data to be checked so geometric edges can be merged
         }
@@ -54,13 +54,11 @@ namespace BH.Engine.Environment
         [Input("element", "An Environment Panel to compare the properties of with an other Environment Panel")]
         [Input("other", "The Environment Panel to compare with the other Environment Panel.")]
         [Output("equal", "True if the Objects non-geometrical property is equal to the point that they could be merged into one object")]
-        public static bool HasMergeablePropertiesWith(Panel element, Panel other)
+        public static bool HasMergeablePropertiesWith(this Panel element, Panel other)
         {
-            DiffingConfig config = new DiffingConfig()
+            ComparisonConfig cc = new ComparisonConfig()
             {
-                ComparisonConfig = new ComparisonConfig()
-                {
-                    PropertyExceptions = new List<string>
+                PropertyExceptions = new List<string>
                     {
                         "ExternalEdges",
                         "Openings",
@@ -69,24 +67,21 @@ namespace BH.Engine.Environment
                         "BHoM_Guid",
                         "CustomData",
                     },
-                    NumericTolerance = BH.oM.Geometry.Tolerance.Distance
-                }
+                NumericTolerance = BH.oM.Geometry.Tolerance.Distance
             };
 
-            return Diffing.Query.DifferentProperties(element, other, config) == null;
+            return !Diffing.Query.DifferentProperties(element, other, cc)?.Any() ?? true;
         }
 
         [Description("Evaluates if the two elements non-geometrical data is equal to the point that they could be merged into one object")]
         [Input("element", "An Environment Opening to compare the properties of with an other Environment Opening")]
         [Input("other", "The Environment Opening to compare with the other Environment Opening.")]
         [Output("equal", "True if the Objects non-geometrical property is equal to the point that they could be merged into one object")]
-        public static bool HasMergeablePropertiesWith(Opening element, Opening other)
+        public static bool HasMergeablePropertiesWith(this Opening element, Opening other)
         {
-            DiffingConfig config = new DiffingConfig()
+            ComparisonConfig cc = new ComparisonConfig()
             {
-                ComparisonConfig = new ComparisonConfig()
-                {
-                    PropertyExceptions = new List<string>
+                PropertyExceptions = new List<string>
                     {
                         "Edges",
                         "FrameFactorValue",
@@ -95,20 +90,19 @@ namespace BH.Engine.Environment
                         "BHoM_Guid",
                         "CustomData",
                     },
-                    NumericTolerance = BH.oM.Geometry.Tolerance.Distance
-                }
+                NumericTolerance = BH.oM.Geometry.Tolerance.Distance
             };
 
-            return Diffing.Query.DifferentProperties(element, other, config) == null;
+            return !Diffing.Query.DifferentProperties(element, other, cc)?.Any() ?? true;
         }
 
         [Description("Evaluates if the two elements non-geometrical data is equal to the point that they could be merged into one object. Environment Nodes are checked for their ID only")]
         [Input("element", "An Environment Node to compare the properties of with an other Environment Node")]
         [Input("other", "The Environment Node to compare with the other Environment Node")]
         [Output("equal", "True if the Objects non-geometrical property is equal to the point that they could be merged into one object")]
-        public static bool HasMergeablePropertiesWith(Node element, Node other)
+        public static bool HasMergeablePropertiesWith(this Node element, Node other)
         {
-            if(element == null || other == null)
+            if (element == null || other == null)
                 return false; //If either node is null, then it can probably can't have its properties merged
 
             return element.ID == other.ID; //If the IDs match, then they can be merged assuming their geometrical placement is the same
@@ -118,24 +112,22 @@ namespace BH.Engine.Environment
         [Input("element", "An Environment Space to compare the properties of with an other Environment Space")]
         [Input("other", "The Environment Space to compare with the other Environment Space")]
         [Output("equal", "True if the Objects non-geometrical property is equal to the point that they could be merged into one object")]
-        public static bool HasMergeablePropertiesWith(Space element, Space other)
+        public static bool HasMergeablePropertiesWith(this Space element, Space other)
         {
-            DiffingConfig config = new DiffingConfig()
+            ComparisonConfig cc = new ComparisonConfig()
             {
-                ComparisonConfig = new ComparisonConfig()
-                {
-                    PropertyExceptions = new List<string>
+                PropertyExceptions = new List<string>
                     {
                         "Location",
                         "Type",
                         "BHoM_Guid",
                         "CustomData",
                     },
-                    NumericTolerance = BH.oM.Geometry.Tolerance.Distance,
-                }
+                NumericTolerance = BH.oM.Geometry.Tolerance.Distance,
+
             };
 
-            return Diffing.Query.DifferentProperties(element, other, config) == null;
+            return !Diffing.Query.DifferentProperties(element, other, cc)?.Any() ?? true;
         }
     }
 }

--- a/Physical_Engine/Query/HasMergeablePropertiesWith.cs
+++ b/Physical_Engine/Query/HasMergeablePropertiesWith.cs
@@ -32,6 +32,7 @@ using System.ComponentModel;
 using BH.oM.Physical.Elements;
 using BH.oM.Diffing;
 using BH.Engine.Geometry;
+using BH.oM.Base;
 
 namespace BH.Engine.Physical
 {
@@ -78,7 +79,7 @@ namespace BH.Engine.Physical
             if (element.Property.Name != other.Property.Name)
                 return false;
 
-            return Diffing.Query.DifferentProperties(element.Property, other.Property, new DiffingConfig()) == null;
+            return !Diffing.Query.DifferentProperties(element.Property, other.Property, new ComparisonConfig())?.Any() ?? true;
         }
         
 
@@ -108,7 +109,7 @@ namespace BH.Engine.Physical
             if (element.Construction.Name != other.Construction.Name)
                 return false;
 
-            return Diffing.Query.DifferentProperties(element.Construction, other.Construction, new DiffingConfig()) == null;
+            return !Diffing.Query.DifferentProperties(element.Construction, other.Construction, new ComparisonConfig())?.Any() ?? true;
         }
 
         /***************************************************/

--- a/Reflection_Engine/Modify/CopyPropertiesFromParent.cs
+++ b/Reflection_Engine/Modify/CopyPropertiesFromParent.cs
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Copy the properties from an object of a parent Type to an object of a child Type.")]
+        [Input("childObject", "Object whose properties in common with `parentObject` will be copied from there.")]
+        [Input("parentObject", "Object of a Type that is a super (parent) type of the type of childObject.")]
+        public static void CopyPropertiesFromParent<P, C>(this C childObject, P parentObject) where C : IObject, P
+        {
+            if (childObject == null || parentObject == null)
+                return;
+
+            Type p = typeof(P);
+            Type c = typeof(C);
+
+            var parentProps = p.GetProperties();
+            var childProps = c.GetProperties();
+
+            foreach (var childProp in childProps)
+            {
+                var correspondingParentProp = parentProps.FirstOrDefault(pp => pp.Name == childProp.Name);
+                if (correspondingParentProp == null)
+                    continue;
+
+                var correspondingParentPropValue = correspondingParentProp.GetValue(parentObject);
+                childProp.SetValue(childObject, correspondingParentPropValue);
+            }
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Reflection_Engine/Query/ExtensionMethodToCall.cs
+++ b/Reflection_Engine/Query/ExtensionMethodToCall.cs
@@ -90,7 +90,7 @@ namespace BH.Engine.Reflection
                 bool matchingTypes = true;
                 for (int i = 1; i < parameters.Length; i++)
                 {
-                    if (!paramInfo[i].ParameterType.IsAssignableFromIncludeGenerics(parameters[i].GetType()))
+                    if (!paramInfo[i].ParameterType.IsAssignableFromIncludeGenericsAndRefTypes(parameters[i].GetType()))
                     {
                         //Parameter does not match, abort for this method
                         matchingTypes = false;

--- a/Reflection_Engine/Query/ExtensionMethodToCall.cs
+++ b/Reflection_Engine/Query/ExtensionMethodToCall.cs
@@ -90,7 +90,7 @@ namespace BH.Engine.Reflection
                 bool matchingTypes = true;
                 for (int i = 1; i < parameters.Length; i++)
                 {
-                    if (!paramInfo[i].ParameterType.IsAssignableFromIncludeGenericsAndRefTypes(parameters[i].GetType()))
+                    if (!paramInfo[i].ParameterType.IsAssignableFromIncludeGenerics(parameters[i].GetType()))
                     {
                         //Parameter does not match, abort for this method
                         matchingTypes = false;

--- a/Reflection_Engine/Query/GetAllPropertyFullNames.cs
+++ b/Reflection_Engine/Query/GetAllPropertyFullNames.cs
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Reflection.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+
+namespace BH.Engine.Reflection
+{
+	public static partial class Query
+	{
+		/***************************************************/
+		/**** Public Methods                            ****/
+		/***************************************************/
+
+		[Description("Get all the Properties and Sub properties of the given type in their full name form.")]
+		[Input("type", "Type to get the properties from.")]
+		[Input("maxDepth", "(Optional, defaults to 100) Maximum property nesting level.")]
+		[Input("cached", "(Optional, defaults to true) If true, caches the FullNames found for a type," +
+			"so that if the same type is encountered again in the same session the computation is faster.")]
+		public static HashSet<string> GetAllPropertyFullNames(this Type type, int maxDepth = 100, bool cached = true)
+		{
+			if (maxDepth < 1)
+				return new HashSet<string>();
+
+			HashSet<string> allPropertyFullNames = null;
+
+			if (cached && m_cachedPropertyFullNames.TryGetValue(type, out allPropertyFullNames))
+				return allPropertyFullNames;
+
+			allPropertyFullNames = new HashSet<string>();
+
+			PropertyNameTree(type.FullName, type.GetProperties(), 0, maxDepth, ref allPropertyFullNames);
+
+			// Results for the same type are cached for performance, if required.
+			if (cached)
+				m_cachedPropertyFullNames[type] = allPropertyFullNames;
+
+			return allPropertyFullNames;
+		}
+
+		/***************************************************/
+		/**** Private Methods                           ****/
+		/***************************************************/
+
+		private static void PropertyNameTree(string toCombine, PropertyInfo[] properties, int currentDepth, int maxDepth, ref HashSet<string> allPropertyFullNames)
+		{
+			if (currentDepth >= maxDepth)
+				return;
+
+			foreach (var property in properties)
+			{
+				string res = toCombine + "." + property.Name;
+				var subProps = property.PropertyType.GetProperties();
+
+				allPropertyFullNames.Add(res);
+
+				PropertyNameTree(res, subProps, currentDepth + 1, maxDepth, ref allPropertyFullNames);
+			}
+		}
+
+		/***************************************************/
+		/**** Private Fields                            ****/
+		/***************************************************/
+
+		private static Dictionary<Type, HashSet<string>> m_cachedPropertyFullNames = new Dictionary<System.Type, System.Collections.Generic.HashSet<string>>();
+
+	}
+}
+
+

--- a/Reflection_Engine/Query/IsAssignableFromIncludeGenerics.cs
+++ b/Reflection_Engine/Query/IsAssignableFromIncludeGenerics.cs
@@ -56,32 +56,6 @@ namespace BH.Engine.Reflection
         }
 
         /***************************************************/
-
-        [Description("Checks if a type is assignable from another type by first checking the system IsAssignableFrom." +
-            "\nIf this is false, checks if the assignable is generic and tests if it can be assigned as a generics version." +
-            "\nIf this is false, checks if the types are the same type, only a byRef version (&).")]
-        [Input("assignableTo", "The type to check if it can be assigned to.")]
-        [Input("assignableFrom", "The type to check if it can be assigned from.")]
-        [Output("result", "Returns true if 'assignableTo' is assignable from 'assignableFrom'.")]
-        public static bool IsAssignableFromIncludeGenericsAndRefTypes(this Type assignableTo, Type assignableFrom)
-        {
-            if (assignableTo == null || assignableFrom == null)
-            {
-                Compute.RecordError("Cannot assign to or from null types.");
-                return false;
-            }
-
-            if (IsAssignableFromIncludeGenerics(assignableTo, assignableFrom))
-                return true;
-
-            if (assignableTo.FullName.EndsWith("&") || assignableFrom.FullName.EndsWith("&"))
-            {
-                // Check for reference types
-                return assignableTo.Assembly == assignableFrom.Assembly && assignableTo.FullName.Except(assignableFrom.FullName).Count() <= 1;
-            }
-
-            return false;
-        }
     }
 }
 

--- a/Reflection_Engine/Query/IsAssignableFromIncludeGenerics.cs
+++ b/Reflection_Engine/Query/IsAssignableFromIncludeGenerics.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Reflection
         [Output("result", "Returns true if 'assignableTo' is assignable from 'assignableFrom'.")]
         public static bool IsAssignableFromIncludeGenerics(this Type assignableTo, Type assignableFrom)
         {
-            if(assignableTo == null || assignableFrom == null)
+            if (assignableTo == null || assignableFrom == null)
             {
                 Compute.RecordError("Cannot assign to or from null types.");
                 return false;
@@ -56,6 +56,32 @@ namespace BH.Engine.Reflection
         }
 
         /***************************************************/
+
+        [Description("Checks if a type is assignable from another type by first checking the system IsAssignableFrom." +
+            "\nIf this is false, checks if the assignable is generic and tests if it can be assigned as a generics version." +
+            "\nIf this is false, checks if the types are the same type, only a byRef version (&).")]
+        [Input("assignableTo", "The type to check if it can be assigned to.")]
+        [Input("assignableFrom", "The type to check if it can be assigned from.")]
+        [Output("result", "Returns true if 'assignableTo' is assignable from 'assignableFrom'.")]
+        public static bool IsAssignableFromIncludeGenericsAndRefTypes(this Type assignableTo, Type assignableFrom)
+        {
+            if (assignableTo == null || assignableFrom == null)
+            {
+                Compute.RecordError("Cannot assign to or from null types.");
+                return false;
+            }
+
+            if (IsAssignableFromIncludeGenerics(assignableTo, assignableFrom))
+                return true;
+
+            if (assignableTo.FullName.EndsWith("&") || assignableFrom.FullName.EndsWith("&"))
+            {
+                // Check for reference types
+                return assignableTo.Assembly == assignableFrom.Assembly && assignableTo.FullName.Except(assignableFrom.FullName).Count() <= 1;
+            }
+
+            return false;
+        }
     }
 }
 

--- a/Reflection_Engine/Query/IsAssignableFromIncludeGenerics.cs
+++ b/Reflection_Engine/Query/IsAssignableFromIncludeGenerics.cs
@@ -56,6 +56,32 @@ namespace BH.Engine.Reflection
         }
 
         /***************************************************/
+
+        [Description("Checks if a type is assignable from another type by first checking the system IsAssignableFrom." +
+            "\nIf this is false, checks if the assignable is generic and tests if it can be assigned as a generics version." +
+            "\nIf this is false, checks if the types are the same type, only a byRef version (&).")]
+        [Input("assignableTo", "The type to check if it can be assigned to.")]
+        [Input("assignableFrom", "The type to check if it can be assigned from.")]
+        [Output("result", "Returns true if 'assignableTo' is assignable from 'assignableFrom'.")]
+        public static bool IsAssignableFromIncludeGenericsAndRefTypes(this Type assignableTo, Type assignableFrom)
+        {
+            if (assignableTo == null || assignableFrom == null)
+            {
+                Compute.RecordError("Cannot assign to or from null types.");
+                return false;
+            }
+
+            if (IsAssignableFromIncludeGenerics(assignableTo, assignableFrom))
+                return true;
+
+            if (assignableTo.FullName.EndsWith("&") || assignableFrom.FullName.EndsWith("&"))
+            {
+                // Check for reference types
+                return assignableTo.Assembly == assignableFrom.Assembly && assignableTo.FullName.Except(assignableFrom.FullName).Count() <= 1;
+            }
+
+            return false;
+        }
     }
 }
 

--- a/Reflection_Engine/Query/IsAssignableFromIncludeGenericsAndRefTypes.cs
+++ b/Reflection_Engine/Query/IsAssignableFromIncludeGenericsAndRefTypes.cs
@@ -35,11 +35,13 @@ namespace BH.Engine.Reflection
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Checks if a type is assignable from another type by first checking the system IsAssignableFrom and, if this is false, checks if the assignable is generic and tests if it can be assigned as a generics version.")]
+        [Description("Checks if a type is assignable from another type by first checking the system IsAssignableFrom." +
+            "\nIf this is false, checks if the assignable is generic and tests if it can be assigned as a generics version." +
+            "\nIf this is false, checks if the types are the same type, only a byRef version (&).")]
         [Input("assignableTo", "The type to check if it can be assigned to.")]
         [Input("assignableFrom", "The type to check if it can be assigned from.")]
         [Output("result", "Returns true if 'assignableTo' is assignable from 'assignableFrom'.")]
-        public static bool IsAssignableFromIncludeGenerics(this Type assignableTo, Type assignableFrom)
+        public static bool IsAssignableFromIncludeGenericsAndRefTypes(this Type assignableTo, Type assignableFrom)
         {
             if (assignableTo == null || assignableFrom == null)
             {
@@ -47,15 +49,17 @@ namespace BH.Engine.Reflection
                 return false;
             }
 
-            //Check if standard IsAssignableFrom works.
-            if (assignableTo.IsAssignableFrom(assignableFrom))
+            if (IsAssignableFromIncludeGenerics(assignableTo, assignableFrom))
                 return true;
-            //If not, check if the argument is generic, and if so, use the IsAssignableToGenericType method to check if it can be assigned.
-            else
-                return assignableTo.IsGenericType && assignableFrom.IsAssignableToGenericType(assignableTo.GetGenericTypeDefinition());
-        }
 
-        /***************************************************/
+            if (assignableTo.FullName.EndsWith("&") || assignableFrom.FullName.EndsWith("&"))
+            {
+                // Check for reference types
+                return assignableTo.Assembly == assignableFrom.Assembly && assignableTo.FullName.Except(assignableFrom.FullName).Count() <= 1;
+            }
+
+            return false;
+        }
     }
 }
 

--- a/Reflection_Engine/Query/IsAssignableFromIncludeGenericsAndRefTypes.cs
+++ b/Reflection_Engine/Query/IsAssignableFromIncludeGenericsAndRefTypes.cs
@@ -35,9 +35,9 @@ namespace BH.Engine.Reflection
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Checks if a type is assignable from another type by first checking the system IsAssignableFrom." +
-            "\nIf this is false, checks if the assignable is generic and tests if it can be assigned as a generics version." +
-            "\nIf this is false, checks if the types are the same type, only a byRef version (&).")]
+        [Description("Checks if a type is assignable from another type by first checking the system IsAssignableFrom;" +
+            "\nif the previous is false, checks if the assignable is generic and tests if it can be assigned as a generics version;" +
+            "\nif the previous is false, lastly this checks if the types are a byRef version (&typeName) of the same type.")]
         [Input("assignableTo", "The type to check if it can be assigned to.")]
         [Input("assignableFrom", "The type to check if it can be assigned from.")]
         [Output("result", "Returns true if 'assignableTo' is assignable from 'assignableFrom'.")]

--- a/Reflection_Engine/Query/IsNumeric.cs
+++ b/Reflection_Engine/Query/IsNumeric.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
@@ -20,22 +20,37 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.oM.Base;
 using BH.oM.Reflection.Attributes;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 
-namespace BH.Engine.Base
+namespace BH.Engine.Reflection
 {
     public static partial class Query
     {
-        [Description("Extract the smallest (most precise) numeric tolerance from the ComparisonConfig," +
-            "which is the smallest value amongst all CustomTolerances (irrespective of the properties they were paired with) and the global numeric tolerance.")]
-        [Input("comparisonConfig", "Comparison Config from where tolerance information should be extracted.")]
-        public static double SmallestToleranceFromConfig(this BaseComparisonConfig comparisonConfig)
+        [Description("Determine whether a type is a numeric type.")]
+        [Input("type", "Type that we want to check if it is numeric type or not.")]
+        [Output("isNumeric", "True if the object is a numeric Type, false if not.")]
+        public static bool IsNumeric(this Type type)
         {
-            return ToleranceFromConfig(comparisonConfig, "", true); // the `propertyFullName` input is ignored when `getGlobalSmallest` is set to true.
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.UInt16:
+                case TypeCode.UInt32:
+                case TypeCode.UInt64:
+                case TypeCode.Int16:
+                case TypeCode.Int32:
+                case TypeCode.Int64:
+                case TypeCode.Decimal:
+                case TypeCode.Double:
+                case TypeCode.Single:
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1306/

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2651
Closes https://github.com/BHoM/BHoM_Engine/issues/2664
Closes #2684

<!-- Add short description of what has been fixed -->

#### 1) Toolkit-specific `*Diffing()` methods
Toolkit-specific Diffing now rely on TryRunExtensionMethod and a discovery of `*Diffing()` methods that can be defined in specific namespaces. The IDiffing calls those automatically. This replaces the previous temporary solution that used delegates.

#### 2) Toolkit-specific `ComparisonInclusion()` methods
When analysing object properties, Toolkit-specific `Query.ComparisonInclusion(SomeObject object)` methods are discovered and called by the Hash/Diffing functions. These methods evaluate if/how specific properties should be included in the comparison. Implementing a `Query.ComparisonInclusion(SomeObject object)` in your specific toolkit allows for options that are specific to your Toolkit. 

See https://github.com/BHoM/Revit_Toolkit/pull/1109 for [an example of this](https://github.com/BHoM/Revit_Toolkit/pull/1109/files#diff-a6a0b416b094c093ce1500364a67d5d5d5e779c495ff09f6ff2b1807d759af18). More details below.

<details>

A `Query.ComparisonInclusion()` function must have the following signature:

```cs 
ComparisonInclusion ComparisonInclusion(SomeObject object, string propertyFullName, BaseComparisonConfig comparisonConfig)
```

where: 
- `object`: the object whose difference/hash is being evaluated.
-  `propertyFullName`: the full name (path) of the object being evaluated.
- `comparisonConfig`: additional configurations.

It must return a `ComparisonInclusion` object populated with:
- `Include`: true if the property is to be included.
- `DisplayName`: if we want to display the name of the Difference found in this comparison with some custom name, this can be specified here. 

</details>

#### 3) Alignments to the new `Diff` object structure.
The new `Diff` object has a simplified structure for the `ModifiedPropertiesPerObject` property (no more `Dictionary<Dictionary<Tuple<etc>>>`) and therefore adjustments were made for that.


#### 4) Custom numeric tolerances per property
It is now possible to easily and correctly set custom numeric tolerances for specific properties, thanks to the new [PropertyNumericTolerance](https://github.com/BHoM/BHoM/pull/1306/files#diff-9705232b7aacebe130b7821b4215d892c2617481bdb8355963b1af4a802df4b6) object. 


### Conclusion

This set of PRs is the final wave of big changes done to the Diffing and related objects/functions (e.g. Hash) in this Beta, and I expect that it will more or less settle here.
Once these are approved (i.e. we like the solution), I will document the entire structure of the code, add a proper wiki, diagrams and many tutorial resources.


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/Revit_Toolkit/pull/1109

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Toolkit-specific Diffing now rely on TryRunExtensionMethod and a discovery of `*Diffing` methods that can be defined in specific namespaces.
- Toolkit-specific `Query.ComparisonInclusion(SomeObject object)` methods are discovered and called by the Hash/Diffing functions when analysing object properties. The `ComparisonInclusion` evaluates if/how specific properties should be included in the comparison; it can be implemented in specific Toolkits to allow for options that are specific to that Toolkit.
- Alignments to the new `Diff` object structure.
- Reworked the Custom numeric tolerances per property feature.
- General tidy up and quality of life improvements.
