### PR TITLE
Architecture_Engine: Geometry() query for BuildersWork.Opening refactored to return Point

### DIFF
--- a/Architecture_Engine/Query/Geometry.cs
+++ b/Architecture_Engine/Query/Geometry.cs
@@ -71,17 +71,11 @@ namespace BH.Engine.Architecture
         [Description("Extracts geometry of the given BuildersWork Opening.")]
         [Input("opening", "BuildersWork Opening to be queried for its geometry.")]
         [Output("Geometry of the input BuildersWork Opening.")]
-        public static PlanarSurface Geometry(this Opening opening)
+        public static Point Geometry(this Opening opening)
         {
             if (opening == null)
             {
                 BH.Engine.Reflection.Compute.RecordError("Cannot extract the geometry from a null opening.");
-                return null;
-            }
-
-            if (opening.Profile?.Edges == null || opening.Profile?.Edges.Count == 0)
-            {
-                BH.Engine.Reflection.Compute.RecordError("Cannot extract the geometry from an opening without profile edges.");
                 return null;
             }
 
@@ -91,7 +85,7 @@ namespace BH.Engine.Architecture
                 return null;
             }
 
-            return new PlanarSurface(new PolyCurve { Curves = opening.Profile.Edges.ToList() }, new List<ICurve>()).Orient(new Cartesian(), opening.CoordinateSystem);
+            return opening.CoordinateSystem.Origin;
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2704

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
It is a simple property return, so no tests should be needed.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
This is a breaking change (different return type compared to the original version of the method) - this cannot be avoided taken the nature of the bug (`Geometry()` _has to_ return `Point` for all types that implement `IElement0D` interface). Luckily, I do not think this type has been heavily used so far (if at all), taken it does not provide any interop features atm.

@IsakNaslundBh please shout if you are concerned about it and you have ideas how to lower the risk I introduce with this change.