### PR TITLE
Results_Engine: Update DisplayMeshResults to work with simplified interface requirements

### DIFF
--- a/Results_Engine/Query/DisplayMeshResults.cs
+++ b/Results_Engine/Query/DisplayMeshResults.cs
@@ -216,9 +216,12 @@ namespace BH.Engine.Results
                 case MeshResultSmoothingType.ByFiniteElementCentres:
                 case MeshResultSmoothingType.BySelection:
                 default:
-                    Engine.Base.Compute.RecordError("Unsupported SmoothingType: " + Base.Query.PropertyValue(meshResult, "Smoothing").ToString() +
-                                                      " detected, meshResult for ObjectId: " + meshResult.ObjectId.ToString() +
-                                                      " and ResultCase: " + meshResult.ResultCase.ToString() + "will be returned empty.");
+                    string msg = $"Unsupported SmoothingType: {smoothingType} detected, meshResult for ObjectId: {meshResult.ObjectId}";
+                    if (meshResult is ICasedResult)
+                        msg += $" and ResultCase: {(meshResult as ICasedResult).ResultCase}";
+
+                    msg += " will be returned empty.";
+                    Engine.Base.Compute.RecordError(msg);
                     return new RenderMesh();
             }
 

--- a/Results_Engine/Query/DisplayMeshResults.cs
+++ b/Results_Engine/Query/DisplayMeshResults.cs
@@ -280,7 +280,7 @@ namespace BH.Engine.Results
             {
                 //If incorrect type, raise error message with suggestions of property types that works for the current MeshElementResult type
                 Base.Compute.RecordError($"Property {prop} is not a valid property for results of type {typeof(T).Name}." + 
-                    $"Try one of the following: {typeof(T).GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance).Where(x => x.PropertyType == typeof(double)).Select(x => x.Name).Aggregate((a, b) => a + " ," + b)}");
+                    $"Try one of the following: {typeof(T).GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance).Where(x => x.PropertyType == typeof(double)).Select(x => x.Name).Aggregate((a, b) => a + ", " + b)}");
                 return null;
             }
 

--- a/Results_Engine/Query/DisplayMeshResults.cs
+++ b/Results_Engine/Query/DisplayMeshResults.cs
@@ -228,7 +228,7 @@ namespace BH.Engine.Results
                         System.Drawing.Color colour = gradient.Color(faceValues[i], from, to);
                         //Store face indecies for newly added vertecies
                         List<int> faceIndecies = new List<int>();
-                        int vertsCount = verts.Count - 1;
+                        int vertsCount = verts.Count;
                         foreach (int nodeIndex in mesh.Faces[i].NodeListIndices)
                         {
                             verts.Add(new RenderPoint()

--- a/Results_Engine/Query/DisplayMeshResults.cs
+++ b/Results_Engine/Query/DisplayMeshResults.cs
@@ -25,6 +25,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Base;
 using System.Linq;
+using System.Reflection;
 using BH.oM.Geometry;
 using BH.oM.Structure.Results;
 using BH.oM.Graphics;
@@ -262,7 +263,8 @@ namespace BH.Engine.Results
 
             if (propInfo == null || propInfo.PropertyType != typeof(double))
             {
-                Base.Compute.RecordError($"Property {prop} is not a valid property for results of type {typeof(T).Name}. Try one of the following: {typeof(T).GetProperties().Where(x => x.PropertyType == typeof(double)).Select(x => x.Name).Aggregate((a, b) => a + " ," + b)}");
+                Base.Compute.RecordError($"Property {prop} is not a valid property for results of type {typeof(T).Name}." + 
+                    $"Try one of the following: {typeof(T).GetProperties(BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.Instance).Where(x => x.PropertyType == typeof(double)).Select(x => x.Name).Aggregate((a, b) => a + " ," + b)}");
                 return null;
             }
 

--- a/Results_Engine/Results_Engine.csproj
+++ b/Results_Engine/Results_Engine.csproj
@@ -23,7 +23,6 @@
     <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj" />
     <ProjectReference Include="..\Geometry_Engine\Geometry_Engine.csproj" />
     <ProjectReference Include="..\Graphics_Engine\Graphics_Engine.csproj" />
-    <ProjectReference Include="..\Reflection_Engine\Reflection_Engine.csproj" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
check if cased result for error message

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM/pull/1328
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Add short description of what has been fixed -->

Changing so that error message is only mentioning result case if the result is a cased result.

- Tweaking the way the result values are extracted to increase the performance.

### Test files
<!-- Link to test files to validate the proposed changes -->

Testing the MeshResultDisplay:

https://burohappold.sharepoint.com/:f:/s/BHoM/EmRmiGKVt5FFmQh7cOWCowQBR_MoUeNS5qPoemEjJmXrNw?e=sTvNF8

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->