### PR TITLE
Reflection_Engine: LoadAllAssemblies fixed to load assemblies with dot in name

### DIFF
--- a/Reflection_Engine/Compute/LoadAllAssemblies.cs
+++ b/Reflection_Engine/Compute/LoadAllAssemblies.cs
@@ -73,11 +73,12 @@ namespace BH.Engine.Reflection
                 SearchOption searchOption = parseSubfolders ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
                 foreach (string file in Directory.GetFiles(folder, "*.dll", searchOption))
                 {
-                    string[] parts = file.Split(new char[] { '.', '\\' });
+                    string[] parts = file.Split(new char[] { '\\' });
                     if (parts.Length < 2)
                         continue;
 
-                    string name = parts[parts.Length - 2];
+                    string name = parts[parts.Length - 1];
+                    name = name.Substring(0, name.Length - 4);
                     if (regex.IsMatch(name))
                     {
                         Assembly loaded = LoadAssembly(file);

--- a/Reflection_Engine/Compute/LoadAllAssemblies.cs
+++ b/Reflection_Engine/Compute/LoadAllAssemblies.cs
@@ -73,12 +73,7 @@ namespace BH.Engine.Reflection
                 SearchOption searchOption = parseSubfolders ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly;
                 foreach (string file in Directory.GetFiles(folder, "*.dll", searchOption))
                 {
-                    string[] parts = file.Split(new char[] { '\\' });
-                    if (parts.Length < 2)
-                        continue;
-
-                    string name = parts[parts.Length - 1];
-                    name = name.Substring(0, name.Length - 4);
+                    string name = Path.GetFileNameWithoutExtension(file);
                     if (regex.IsMatch(name))
                     {
                         Assembly loaded = LoadAssembly(file);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2712

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&isAscending=true&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FReflection%5FEngine%2F%232713%2DLoadAssembliesWithDots&sortField=LinkFilename&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
This bug should not affect the Beta release (it was found while working on https://github.com/BHoM/Revit_Toolkit/pull/1137), so I am not pushing it - up to the framework lead whether worth merging now or after the end of the milestone @FraserGreenroyd.