### PR TITLE
BHoM_Engine: fix for `Hash()` not dealing correctly with Enum types 

### DIFF
--- a/BHoM_Engine/Modify/PropertyNamesToFullNames.cs
+++ b/BHoM_Engine/Modify/PropertyNamesToFullNames.cs
@@ -138,7 +138,7 @@ namespace BH.Engine.Base
 
         [Description("Parse the ComparisonConfig's property-based configs (from the `PropertiesToConsider`, `PropertyExceptions`, etc.), and get them all as Full Names." +
             "This allows to make sure we collect all relevant properties, even if we are given partial names or wildcards (e.g. `StartNode.*.X`).")]
-                [Input("comparisonConfig", "ComparisonConfig object whose `PropertiesToConsider` and `PropertyExceptions` will be parsed." +
+        [Input("comparisonConfig", "ComparisonConfig object whose `PropertiesToConsider` and `PropertyExceptions` will be parsed." +
             "If they contain partial names or wildcards, they will be expanded with all the matching property FullNames found for the specified Type.")]
         [Input("obj", "Object whose properties will be collected and matched against the comparisonConfig's `PropertiesToConsider`, `PropertyExceptions`, and the other property-based configs.")]
         public static void PropertyNamesToFullNames(this BaseComparisonConfig comparisonConfig, object obj)
@@ -183,9 +183,11 @@ namespace BH.Engine.Base
             }
 
             // Add the results to the ComparisonConfig.
-            comparisonConfig.PropertiesToConsider.AddRange(propertiesToConsider_fullNames);
-            comparisonConfig.PropertyExceptions.AddRange(propertyExceptions_fullNames);
-            comparisonConfig.PropertyNumericTolerances.UnionWith(propertyNumericTolerances_fullNames);
+            comparisonConfig.PropertiesToConsider = comparisonConfig.PropertiesToConsider?.Concat(propertiesToConsider_fullNames).ToList() ?? propertiesToConsider_fullNames;
+            comparisonConfig.PropertyExceptions = comparisonConfig.PropertyExceptions?.Concat(propertyExceptions_fullNames).ToList() ?? propertyExceptions_fullNames;
+            comparisonConfig.PropertyNumericTolerances = comparisonConfig.PropertyNumericTolerances == null ?
+                new HashSet<NamedNumericTolerance>(comparisonConfig.PropertyNumericTolerances?.Union(propertyNumericTolerances_fullNames))
+                : propertyNumericTolerances_fullNames;
         }
 
         /***************************************************/

--- a/BHoM_Engine/Query/Hash.cs
+++ b/BHoM_Engine/Query/Hash.cs
@@ -144,7 +144,7 @@ namespace BH.Engine.Base
             {
                 return "";
             }
-            else if (type.IsNumeric())
+            else if (type.IsNumeric() && type.BaseType != typeof(System.Enum))
             {
                 // If we didn't specify any custom tolerance/significant figures, just return the input.
                 if (cc.NumericTolerance == double.MinValue && cc.SignificantFigures == int.MaxValue

--- a/BHoM_Engine/Query/Hash.cs
+++ b/BHoM_Engine/Query/Hash.cs
@@ -70,7 +70,6 @@ namespace BH.Engine.Base
 
             // Make sure we always have a config object. Clone for immutability.
             BaseComparisonConfig cc = comparisonConfig == null ? new ComparisonConfig() : comparisonConfig.DeepClone();
-            cc.TypeExceptions.Add(typeof(HashFragment));
 
             // Parse the ComparisonConfig's `PropertiesToConsider` and `PropertyExceptions` and get them all as Full Names.
             Modify.PropertyNamesToFullNames(cc, iObj);
@@ -136,8 +135,8 @@ namespace BH.Engine.Base
             // Compute the definingString depending on the object type. //
             // -------------------------------------------------------- // 
 
-
             if (type == null
+                || type == typeof(HashFragment)
                 || (cc.TypeExceptions != null && cc.TypeExceptions.Any(te => te.IsAssignableFrom(type)))
                 || (cc.NamespaceExceptions != null && cc.NamespaceExceptions.Where(ex => type.Namespace.Contains(ex)).Any())
                 || nestingLevel >= cc.MaxNesting)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2714

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
@FraserGreenroyd can you fill this in with your script?

Edit from @FraserGreenroyd :
@jamesramsden-bh and myself will be using the `XML_Toolkit_Push_Model.gh` file available [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBHoM%2FXML%5FToolkit&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b) in line with the test procedure [here](https://burohappold.sharepoint.com/:w:/r/sites/BHoM/01_Master%20File/09_QAQC/04%20-%20Testing%20Procedures/0005_Environment/0001_XML_Toolkit.docx?d=w05e62d00b2c74e24a778fbed2cf33771&csf=1&web=1&e=qRBtNJ).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->