### PR TITLE
Diffing_Engine: alignments to changes to ComparisonConfig; minor bug fixes

### DIFF
--- a/BHoM_Engine/Query/Hash.cs
+++ b/BHoM_Engine/Query/Hash.cs
@@ -190,8 +190,8 @@ namespace BH.Engine.Base
                         if (cc.CustomdataKeysExceptions?.Any(cdKeyExcept => cdKeyExcept == customDataKey || customDataKey.WildcardMatch(cdKeyExcept)) ?? false)
                             continue;
 
-                        // If there are CustomdataKeysToInclude specified and this customDataKey is not among them, skip it.
-                        if ((cc.CustomdataKeysToInclude?.Any() ?? false) && !cc.CustomdataKeysToInclude.Any(cdkeyToInc => cdkeyToInc == customDataKey || customDataKey.WildcardMatch(cdkeyToInc)))
+                        // If there are CustomdataKeysToConsider specified and this customDataKey is not among them, skip it.
+                        if ((cc.CustomdataKeysToConsider?.Any() ?? false) && !cc.CustomdataKeysToConsider.Any(cdkeyToInc => cdkeyToInc == customDataKey || customDataKey.WildcardMatch(cdkeyToInc)))
                             continue;
                     }
 

--- a/Diffing_Engine/Compute/DiffWithHash.cs
+++ b/Diffing_Engine/Compute/DiffWithHash.cs
@@ -81,6 +81,8 @@ namespace BH.Engine.Diffing
 
         private static Diff DiffingWithHash(IEnumerable<object> pastObjects, IEnumerable<object> followingObjs, DiffingConfig diffingConfig = null, bool storeHash = false, bool retrieveStoredHash = false)
         {
+            DiffingConfig diffConfigCopy = diffingConfig ?? new DiffingConfig();
+
             Diff outputDiff = null;
             if (InputObjectsNullOrEmpty(pastObjects, followingObjs, out outputDiff, diffingConfig))
                 return outputDiff;
@@ -97,7 +99,7 @@ namespace BH.Engine.Diffing
             HashComparer<object> hashComparer = new HashComparer<object>(diffingConfig.ComparisonConfig, storeHash, retrieveStoredHash);
             VennDiagram<object> vd = Engine.Data.Create.VennDiagram(pastObjects, followingObjs, hashComparer);
 
-            return new Diff(vd.OnlySet2, vd.OnlySet1, null, diffingConfig, null, vd.Intersection);
+            return new Diff(vd.OnlySet2, vd.OnlySet1, null, diffingConfig, null, vd.Intersection.Select(i => i.Item2));
         }
 
         /***************************************************/

--- a/Diffing_Engine/Compute/IDiffing.cs
+++ b/Diffing_Engine/Compute/IDiffing.cs
@@ -91,8 +91,8 @@ namespace BH.Engine.Diffing
             List<object> remainder_following;
             Type commonPersistentId_past;
             Type commonPersistentId_following;
-            List<IBHoMObject> bHoMObjects_past_persistId = bHoMObjects_past.WithCommonPersistentAdapterId(out remainder_past, out commonPersistentId_past);
-            List<IBHoMObject> bHoMObjects_following_persistId = bHoMObjects_following.WithCommonPersistentAdapterId(out remainder_following, out commonPersistentId_following);
+            List<IBHoMObject> bHoMObjects_past_persistId = pastObjs.WithCommonPersistentAdapterId(out remainder_past, out commonPersistentId_past);
+            List<IBHoMObject> bHoMObjects_following_persistId = followingObjs.WithCommonPersistentAdapterId(out remainder_following, out commonPersistentId_following);
 
             // For the BHoMObjects having a common PersistentAdapterId in their fragments, we can compute the Diff by using it.
             if (commonPersistentId_past != null && commonPersistentId_past == commonPersistentId_following

--- a/Diffing_Engine/Query/ObjectDifferences.cs
+++ b/Diffing_Engine/Query/ObjectDifferences.cs
@@ -98,6 +98,9 @@ namespace BH.Engine.Diffing
                 string propertyFullName = objectFullName + "." + propertyName;
                 string propertyDisplayName = propertyName;
 
+                if ((cc.NamespaceExceptions?.Any() ?? false) && cc.NamespaceExceptions.Any(ne => propertyFullName.StartsWith(ne)))
+                    continue;
+
                 // Get the property path without indexes in square brackets.
                 // This is useful to check if it matches with any propertyExceptions/propertiesToConsider.
                 // E.g. Bar.Fragments[1].Parameters[5].Name becomes Bar.Fragments.Parameters.Name, so we can check that against exceptions like `Parameters.Name`.

--- a/Diffing_Engine/Query/ObjectDifferences.cs
+++ b/Diffing_Engine/Query/ObjectDifferences.cs
@@ -155,8 +155,8 @@ namespace BH.Engine.Diffing
                         if (cc.CustomdataKeysExceptions?.Any(cdKeyExcept => cdKeyExcept == customDataKey || customDataKey.WildcardMatch(cdKeyExcept)) ?? false)
                             continue;
 
-                        // If there are CustomdataKeysToInclude specified and this customDataKey is not among them, skip it.
-                        if ((cc.CustomdataKeysToInclude?.Any() ?? false) && !cc.CustomdataKeysToInclude.Any(cdkeyToInc => cdkeyToInc == customDataKey || customDataKey.WildcardMatch(cdkeyToInc)))
+                        // If there are CustomdataKeysToConsider specified and this customDataKey is not among them, skip it.
+                        if ((cc.CustomdataKeysToConsider?.Any() ?? false) && !cc.CustomdataKeysToConsider.Any(cdkeyToInc => cdkeyToInc == customDataKey || customDataKey.WildcardMatch(cdkeyToInc)))
                             continue;
                     }
                 }

--- a/Diffing_Engine/Query/ObjectDifferences.cs
+++ b/Diffing_Engine/Query/ObjectDifferences.cs
@@ -76,7 +76,7 @@ namespace BH.Engine.Diffing
             kellermanComparer.Config.TypesToIgnore.Add(typeof(RevisionFragment)); // Never include the changes in RevisionFragment.
             kellermanComparer.Config.TypesToIgnore.AddRange(cc.TypeExceptions);
             kellermanComparer.Config.MembersToIgnore = cc.PropertyExceptions;
-
+            
             // Kellerman configuration for tolerance.
             // Setting Custom Tolerance for specific properties is complex with Kellerman. 
             // So instead, we set the Kellerman precision to capture all variations, that is by using the value 0.
@@ -98,6 +98,15 @@ namespace BH.Engine.Diffing
                 string propertyFullName = objectFullName + "." + propertyName;
                 string propertyDisplayName = propertyName;
 
+                // Check Max Nesting level if specified.
+                if (cc.MaxNesting != int.MaxValue && cc.MaxNesting >= 0)
+                {
+                    int nestingLevel = propertyName.Count(c => c == '.');
+                    if (nestingLevel >= cc.MaxNesting)
+                        continue;
+                }
+
+                // Check namespace exceptions if specified.
                 if ((cc.NamespaceExceptions?.Any() ?? false) && cc.NamespaceExceptions.Any(ne => propertyFullName.StartsWith(ne)))
                     continue;
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1333
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2716 
Closes #2717 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Just run the following test file:
https://burohappold.sharepoint.com/:f:/s/BHoM/Epjl618V1IpNn0uEae_uFR0Bey9CYMXSDPNE-iUFuyYYoQ?e=bJt14l

and check that the panels correctly contains the objects as per text:
![image](https://user-images.githubusercontent.com/6352844/145453426-3ca13181-d0e5-4379-96c3-73ee5ba8ba6c.png)

The correct execution of this test file guarantees that all changes in this PR work correctly. Further testing is not needed, but more tests can be found in:
https://burohappold.sharepoint.com/:f:/s/BHoM/ElkWAuBU0CpNhyNhwF96LlEBqkxJgHX3AhBOGlnA4bBwag?e=Kr2FMc

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Aligned the Diffing_Engine and base BHoM_Engine to the renamed `ComparisonConfig.CustomDataToConsider`
- Bug fix in `ObjectDifferences()`: `ComparisonConfig.NameSpaceExceptions` now correctly used
- Bug fix in `ObjectDifferences()`: `ComparisonConfig.MaxNesting` now correctly used
- IDiffing: minor bug fix in incorrect dispatching object
- Minor bug fix in DiffingWithHash: null checks, result better display of result