### PR TITLE
Updated SAM and CAM methods and added AW for multiple openings

### DIFF
--- a/Facade_Engine/Compute/UValueOpeningCAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningCAM.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of opening calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Description("Returns effective U-Value of opening calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value and frame Psi-tj value as OpeningConstruction and FrameEdgeProperty fragments.")]
         [Input("opening", "Opening to find U-value for.")]
         [Output("effectiveUValue", "Effective U-value result of opening calculated using CAM.")]
         public static OverallUValue UValueOpeningCAM(this Opening opening)
@@ -57,10 +57,10 @@ namespace BH.Engine.Facade
             
             double glassArea = opening.ComponentAreas().Item1;
 
-            List<IFragment> glassUValues = opening.GetAllFragments(typeof(UValueGlassCentre));
+            List<IFragment> glassUValues = opening.OpeningConstruction.GetAllFragments(typeof(UValueGlassCentre));
             if (glassUValues.Count <= 0)
             {
-                BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Glass U-value assigned.");
+                BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have a Glass U-value assigned.");
                 return null;
             }
             if (glassUValues.Count > 1)
@@ -104,7 +104,7 @@ namespace BH.Engine.Facade
                 frameAreas.Add(area);
                 psigLengths.Add(innerLength);
 
-                List<IFragment> uValues = frameEdges[i].GetAllFragments(typeof(UValueFrame));
+                List<IFragment> uValues = frameEdges[i].FrameEdgeProperty.GetAllFragments(typeof(UValueFrame));
                 if (uValues.Count <= 0)
                 {
                     BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Frame U-value assigned.");
@@ -118,7 +118,7 @@ namespace BH.Engine.Facade
                 double frameUValue = (uValues[0] as UValueFrame).UValue;
                 frameUValues.Add(frameUValue);
                 
-                List<IFragment> psiGs = frameEdges[i].GetAllFragments(typeof(PsiGlassEdge));
+                List<IFragment> psiGs = frameEdges[i].FrameEdgeProperty.GetAllFragments(typeof(PsiGlassEdge));
                 if (psiGs.Count <= 0)
                 {
                     BH.Engine.Reflection.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} does not have PsiG value assigned.");

--- a/Facade_Engine/Compute/UValueOpeningSAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningSAM.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of opening calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Description("Returns effective U-Value of opening calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value and frame Psi-tj value as OpeningConstruction and FrameEdgeProperty fragments.")]
         [Input("opening", "Opening to find U-value for.")]
         [Output("effectiveUValue", "Effective U-value result of opening caclulated using SAM.")]
         public static OverallUValue UValueOpeningSAM(this Opening opening)
@@ -57,7 +57,7 @@ namespace BH.Engine.Facade
 
             double area = opening.Area();
 
-            List<IFragment> uValues = opening.GetAllFragments(typeof(UValueGlassCentre));
+            List<IFragment> uValues = opening.OpeningConstruction.GetAllFragments(typeof(UValueGlassCentre));
             if (uValues.Count <= 0)
             {
                 BH.Engine.Reflection.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have U-value assigned.");
@@ -76,7 +76,7 @@ namespace BH.Engine.Facade
 
             foreach (FrameEdge frameEdge in frameEdges)
             {
-                List<IFragment> psiJoints = frameEdge.GetAllFragments(typeof(PsiJoint));
+                List<IFragment> psiJoints = frameEdge.FrameEdgeProperty.GetAllFragments(typeof(PsiJoint));
                 if (psiJoints.Count <= 0)
                 {
                     BH.Engine.Reflection.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} does not have PsiJoint value assigned.");

--- a/Facade_Engine/Compute/UValueOpeningsAW.cs
+++ b/Facade_Engine/Compute/UValueOpeningsAW.cs
@@ -1,6 +1,6 @@
 ﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.

--- a/Facade_Engine/Compute/UValueOpeningsAW.cs
+++ b/Facade_Engine/Compute/UValueOpeningsAW.cs
@@ -1,6 +1,6 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
- * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ * Copyright (c) 2015 - 2021, the respective contributors. All rights reserved.
  *
  * Each contributor holds copyright over their respective contributions.
  * The project versioning (Git) records all such contribution source information.
@@ -43,18 +43,18 @@ namespace BH.Engine.Facade
         /***************************************************/
         /****          Public Methods                   ****/
         /***************************************************/
-
-        [Description("Returns effective U-Value of a collection of openings calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value and frame Psi-tj value as OpeningConstruction and FrameEdgeProperty fragments.")]
+        
+        [Description("Returns effective U-Value of a collection of openings calculated using the Area Weighting Method. Requires center of opening U-value, frame U-value and edge U-value as OpeningConstruction and FrameEdgeProperty fragments.")]
         [Input("openings", "Openings to find U-value for.")]
-        [Output("effectiveUValue", "Effective total U-value result of opening calculated using SAM.")]
-        public static OverallUValue UValueOpeningsSAM(this List<Opening> openings)
+        [Output("effectiveUValue", "Effective total U-value result of openings calculated using CAM.")]
+        public static OverallUValue UValueOpeningsAW(this List<Opening> openings)
         {
             double uValueProduct = 0;
             double totalArea = 0;
             foreach (Opening opening in openings)
             {
                 double area = opening.Area();
-                uValueProduct += opening.UValueOpeningSAM().UValue * area;
+                uValueProduct += opening.UValueOpeningAW().UValue * area;
                 totalArea += area;
             }
             if (totalArea == 0)
@@ -63,7 +63,7 @@ namespace BH.Engine.Facade
                 return null;
             }
 
-            double effectiveUValue =  uValueProduct / totalArea;
+            double effectiveUValue = uValueProduct / totalArea;
             OverallUValue result = new OverallUValue(effectiveUValue, openings.Select(x => x.BHoM_Guid as IComparable).ToList());
             return result;
         }

--- a/Facade_Engine/Compute/UValueOpeningsCAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningsCAM.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of a collection of openings calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Description("Returns effective U-Value of a collection of openings calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value and frame Psi-tj value as OpeningConstruction and FrameEdgeProperty fragments..")]
         [Input("openings", "Openings to find U-value for.")]
         [Output("effectiveUValue", "Effective total U-value result of openings calculated using CAM.")]
         public static OverallUValue UValueOpeningsCAM(this List<Opening> openings)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2662 

Fixed reliance on Psi/U Value fragments assigned to Construction properties rather than the element itself, and added multiple opening area weighted functionality.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Facade_Engine/%232662-SAMandCAMMethodUpdates?csf=1&web=1&e=HgP13D
