### PR TITLE
SAM and CAM methods fixed and improved

### DIFF
--- a/Facade_Engine/Compute/UValueOpeningAW.cs
+++ b/Facade_Engine/Compute/UValueOpeningAW.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of opening calculated using the Area Weighting Method. Requires center of opening U-value, frame U-value and edge U-value as Opening fragments.")]
+        [Description("Returns effective U-Value of opening calculated using the Area Weighting Method. Requires center of opening U-value, frame U-value and edge U-value as OpeningConstruction and FrameEdgeProperty fragments.")]
         [Input("opening", "Opening to find U-value for.")]
         [Output("effectiveUValue", "Effective U-value result of opening calculated using area weighting.")]
         public static OverallUValue UValueOpeningAW(this Opening opening)
@@ -55,7 +55,7 @@ namespace BH.Engine.Facade
                 return null;
             }
 
-            List<IFragment> glassUValues = opening.GetAllFragments(typeof(UValueGlassCentre));
+            List<IFragment> glassUValues = opening.OpeningConstruction.GetAllFragments(typeof(UValueGlassCentre));
 
             if (glassUValues.Count <= 0)
             {
@@ -68,6 +68,19 @@ namespace BH.Engine.Facade
                 return null;
             }
             double glassUValue = (glassUValues[0] as UValueGlassCentre).UValue;
+
+            List<IFragment> glassEdgeUValues = opening.OpeningConstruction.GetAllFragments(typeof(UValueGlassEdge));
+            if (glassEdgeUValues.Count <= 0)
+            {
+                Base.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Glass edge U-value assigned.");
+                return null;
+            }
+            if (glassEdgeUValues.Count > 1)
+            {
+                Base.Compute.RecordError($"Opening {opening.BHoM_Guid} has more than one Glass edge U-value assigned.");
+                return null;
+            }
+            double glassEdgeUValue = (glassEdgeUValues[0] as UValueGlassEdge).UValue;
 
             List<FrameEdge> frameEdges = opening.Edges;
             List<double> frameAreas = new List<double>();
@@ -111,7 +124,7 @@ namespace BH.Engine.Facade
                 totEdgeArea += e_area;
                 totFrameArea += f_area;
 
-                List<IFragment> f_uValues = frameEdges[i].GetAllFragments(typeof(UValueFrame));
+                List<IFragment> f_uValues = frameEdges[i].FrameEdgeProperty.GetAllFragments(typeof(UValueFrame));
                 if (f_uValues.Count <= 0)
                 {
                     BH.Engine.Base.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Frame U-value assigned.");
@@ -124,20 +137,6 @@ namespace BH.Engine.Facade
                 }
                 double frameUValue = (f_uValues[0] as UValueFrame).UValue;
                 frameUValues.Add(frameUValue);
-
-                List<IFragment> e_uValues = frameEdges[i].GetAllFragments(typeof(UValueGlassEdge));
-                if (e_uValues.Count <= 0)
-                {
-                    BH.Engine.Base.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Frame U-value assigned.");
-                    return null;
-                }
-                if (e_uValues.Count > 1)
-                {
-                    BH.Engine.Base.Compute.RecordError($"Opening {opening.BHoM_Guid} has more than one Frame U-value assigned.");
-                    return null;
-                }
-                double edgeUValue = (e_uValues[0] as UValueGlassEdge).UValue;
-                edgeUValues.Add(edgeUValue);
             }
 
             double glassArea = opening.Area() - totEdgeArea - totFrameArea;
@@ -147,7 +146,7 @@ namespace BH.Engine.Facade
             for (int i = 0; i < frameUValues.Count; i++)
             {
                 FrameUValProduct += (frameUValues[i] * frameAreas[i]);
-                EdgeUValProduct += (edgeUValues[i] * edgeAreas[i]);
+                EdgeUValProduct += (glassEdgeUValue * edgeAreas[i]);
             }
 
             double totArea = opening.Area();

--- a/Facade_Engine/Compute/UValueOpeningCAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningCAM.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of opening calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Description("Returns effective U-Value of opening calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value and frame Psi-tj value as OpeningConstruction and FrameEdgeProperty fragments.")]
         [Input("opening", "Opening to find U-value for.")]
         [Output("effectiveUValue", "Effective U-value result of opening calculated using CAM.")]
         public static OverallUValue UValueOpeningCAM(this Opening opening)
@@ -57,10 +57,10 @@ namespace BH.Engine.Facade
             
             double glassArea = opening.ComponentAreas().Item1;
 
-            List<IFragment> glassUValues = opening.GetAllFragments(typeof(UValueGlassCentre));
+            List<IFragment> glassUValues = opening.OpeningConstruction.GetAllFragments(typeof(UValueGlassCentre));
             if (glassUValues.Count <= 0)
             {
-                BH.Engine.Base.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Glass U-value assigned.");
+                BH.Engine.Base.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have a Glass U-value assigned.");
                 return null;
             }
             if (glassUValues.Count > 1)
@@ -104,7 +104,7 @@ namespace BH.Engine.Facade
                 frameAreas.Add(area);
                 psigLengths.Add(innerLength);
 
-                List<IFragment> uValues = frameEdges[i].GetAllFragments(typeof(UValueFrame));
+                List<IFragment> uValues = frameEdges[i].FrameEdgeProperty.GetAllFragments(typeof(UValueFrame));
                 if (uValues.Count <= 0)
                 {
                     BH.Engine.Base.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have Frame U-value assigned.");
@@ -118,7 +118,7 @@ namespace BH.Engine.Facade
                 double frameUValue = (uValues[0] as UValueFrame).UValue;
                 frameUValues.Add(frameUValue);
                 
-                List<IFragment> psiGs = frameEdges[i].GetAllFragments(typeof(PsiGlassEdge));
+                List<IFragment> psiGs = frameEdges[i].FrameEdgeProperty.GetAllFragments(typeof(PsiGlassEdge));
                 if (psiGs.Count <= 0)
                 {
                     BH.Engine.Base.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} does not have PsiG value assigned.");

--- a/Facade_Engine/Compute/UValueOpeningSAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningSAM.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of opening calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Description("Returns effective U-Value of opening calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value and frame Psi-tj value as OpeningConstruction and FrameEdgeProperty fragments.")]
         [Input("opening", "Opening to find U-value for.")]
         [Output("effectiveUValue", "Effective U-value result of opening caclulated using SAM.")]
         public static OverallUValue UValueOpeningSAM(this Opening opening)
@@ -57,7 +57,7 @@ namespace BH.Engine.Facade
 
             double area = opening.Area();
 
-            List<IFragment> uValues = opening.GetAllFragments(typeof(UValueGlassCentre));
+            List<IFragment> uValues = opening.OpeningConstruction.GetAllFragments(typeof(UValueGlassCentre));
             if (uValues.Count <= 0)
             {
                 BH.Engine.Base.Compute.RecordError($"Opening {opening.BHoM_Guid} does not have U-value assigned.");
@@ -76,7 +76,7 @@ namespace BH.Engine.Facade
 
             foreach (FrameEdge frameEdge in frameEdges)
             {
-                List<IFragment> psiJoints = frameEdge.GetAllFragments(typeof(PsiJoint));
+                List<IFragment> psiJoints = frameEdge.FrameEdgeProperty.GetAllFragments(typeof(PsiJoint));
                 if (psiJoints.Count <= 0)
                 {
                     BH.Engine.Base.Compute.RecordError($"One or more FrameEdges belonging to {opening.BHoM_Guid} does not have PsiJoint value assigned.");

--- a/Facade_Engine/Compute/UValueOpeningsAW.cs
+++ b/Facade_Engine/Compute/UValueOpeningsAW.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * This file is part of the Buildings and Habitats object Model (BHoM)
  * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
  *
@@ -31,9 +31,9 @@ using BH.Engine.Geometry;
 using BH.Engine.Spatial;
 using BH.Engine.Base;
 using BH.oM.Facade.Fragments;
-using BH.oM.Facade.Results;
- 
+
 using BH.oM.Base.Attributes;
+using BH.oM.Facade.Results;
 using System.ComponentModel;
 
 namespace BH.Engine.Facade
@@ -43,27 +43,27 @@ namespace BH.Engine.Facade
         /***************************************************/
         /****          Public Methods                   ****/
         /***************************************************/
-
-        [Description("Returns effective U-Value of a collection of openings calculated using the Single Assessment Method (Using Psi-tj). Requires center of opening U-value and frame Psi-tj value as OpeningConstruction and FrameEdgeProperty fragments.")]
+        
+        [Description("Returns effective U-Value of a collection of openings calculated using the Area Weighting Method. Requires center of opening U-value, frame U-value and edge U-value as OpeningConstruction and FrameEdgeProperty fragments.")]
         [Input("openings", "Openings to find U-value for.")]
-        [Output("effectiveUValue", "Effective total U-value result of opening calculated using SAM.")]
-        public static OverallUValue UValueOpeningsSAM(this List<Opening> openings)
+        [Output("effectiveUValue", "Effective total U-value result of openings calculated using CAM.")]
+        public static OverallUValue UValueOpeningsAW(this List<Opening> openings)
         {
             double uValueProduct = 0;
             double totalArea = 0;
             foreach (Opening opening in openings)
             {
                 double area = opening.Area();
-                uValueProduct += opening.UValueOpeningSAM().UValue * area;
+                uValueProduct += opening.UValueOpeningAW().UValue * area;
                 totalArea += area;
             }
             if (totalArea == 0)
             {
-                BH.Engine.Base.Compute.RecordError("Openings have a total calculated area of 0. Ensure Openings are valid with associated edges defining their geometry and try again.");
+                Base.Compute.RecordError("Openings have a total calculated area of 0. Ensure Openings are valid with associated edges defining their geometry and try again.");
                 return null;
             }
 
-            double effectiveUValue =  uValueProduct / totalArea;
+            double effectiveUValue = uValueProduct / totalArea;
             OverallUValue result = new OverallUValue(effectiveUValue, openings.Select(x => x.BHoM_Guid as IComparable).ToList());
             return result;
         }

--- a/Facade_Engine/Compute/UValueOpeningsCAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningsCAM.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Facade
         /****          Public Methods                   ****/
         /***************************************************/
 
-        [Description("Returns effective U-Value of a collection of openings calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value as Opening fragment and frame Psi-tj value as list of Edge fragments.")]
+        [Description("Returns effective U-Value of a collection of openings calculated using the Component Assessment Method (Using Psi-g). Requires center of opening U-value and frame Psi-tj value as OpeningConstruction and FrameEdgeProperty fragments..")]
         [Input("openings", "Openings to find U-value for.")]
         [Output("effectiveUValue", "Effective total U-value result of openings calculated using CAM.")]
         public static OverallUValue UValueOpeningsCAM(this List<Opening> openings)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2662 

Fixed reliance on Psi/U Value fragments assigned to Construction properties rather than the element itself, and added multiple opening area weighted functionality.


### Test files
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Facade_Engine/%232662-SAMandCAMMethodUpdates?csf=1&web=1&e=HgP13D
