### PR TITLE
Humans_Engine: Align with making ViewQualityResults immutable

### DIFF
--- a/Humans_Engine/Query/CvalueAnalysis.cs
+++ b/Humans_Engine/Query/CvalueAnalysis.cs
@@ -140,21 +140,19 @@ namespace BH.Engine.Humans.ViewQuality
 
         private static Cvalue CvalueResult(Spectator current, Point focal, double cvalue)
         {
-            Cvalue result = new Cvalue();
-            result.ObjectId = current.BHoM_Guid;
             Vector d = current.Head.PairOfEyes.ReferenceLocation - focal;
 
-            result.AbsoluteDist = d.Length();
-            result.Focalpoint = focal;
-            result.HorizDist = Geometry.Create.Vector(d.X, d.Y, 0).Length();
-            result.HeightAbovePitch = current.Head.PairOfEyes.ReferenceLocation.Z - focal.Z;
+            double absoluteDist = d.Length();
+            double horizDist = Geometry.Create.Vector(d.X, d.Y, 0).Length();
+            double heightAbovePitch = current.Head.PairOfEyes.ReferenceLocation.Z - focal.Z;
 
+            double cValue;
             if (!m_CvalueExists)//
-                result.CValue = m_CvalueSettings.DefaultCValue;
+                cValue = m_CvalueSettings.DefaultCValue;
             else
-                result.CValue = cvalue;
+                cValue = cvalue;
 
-            return result;
+            return new Cvalue(current.BHoM_Guid, "", 0, cvalue, horizDist, heightAbovePitch, absoluteDist, focal);
 
         }
         /***************************************************/

--- a/Humans_Engine/Query/EvalueAnalysis.cs
+++ b/Humans_Engine/Query/EvalueAnalysis.cs
@@ -100,8 +100,6 @@ namespace BH.Engine.Humans.ViewQuality
 
         private static Evalue EvalueResult(Spectator s, Vector rowVector, Vector viewVect, Polyline playingArea, EvalueSettings settings)
         {
-            Evalue result = new Evalue();
-
             Vector viewY = Geometry.Query.CrossProduct(viewVect, rowVector);
             viewY = viewY.Normalise();
 
@@ -117,6 +115,9 @@ namespace BH.Engine.Humans.ViewQuality
             Point Vp0 = new Point();
             Point Vp1 = new Point();
             //loop to get widest horizontal and vertical angles and vectors
+
+            double horizViewAng = 0;
+            double vertViewAng = 0;
             for (int i = 0; i < playingArea.ControlPoints.Count; i++)
             {
                 Point controlPi = playingArea.ControlPoints[i];
@@ -133,34 +134,37 @@ namespace BH.Engine.Humans.ViewQuality
                         vtestAng = Geometry.Query.Angle(iComp, jComp, vertPln);
                         if (htestAng > Math.PI) htestAng = Math.PI * 2 - htestAng;
                         if (vtestAng > Math.PI) vtestAng = Math.PI * 2 - vtestAng;
-                        if (result.HorizViewAng < htestAng)
+                        if (horizViewAng < htestAng)
                         {
-                            result.HorizViewAng = htestAng;
+                            horizViewAng = htestAng;
                             Hp0 = playingArea.ControlPoints[i];
                             Hp1 = playingArea.ControlPoints[j];
                         }
-                        if (result.VertViewAng < vtestAng)
+                        if (vertViewAng < vtestAng)
                         {
-                            result.VertViewAng = vtestAng;
+                            vertViewAng = vtestAng;
                             Vp0 = playingArea.ControlPoints[i];
                             Vp1 = playingArea.ControlPoints[j];
                         }
                     }
                 }
             }
-            result.HorizViewAng = result.HorizViewAng * 57.2958;
-            result.VertViewAng = result.VertViewAng * 57.2958;
-            result.VertViewVectors[0] = (Vp0 - s.Head.PairOfEyes.ReferenceLocation).Normalise();
-            result.VertViewVectors[1] = (Vp1 - s.Head.PairOfEyes.ReferenceLocation).Normalise();
-            result.HorizViewVectors[0] = (Hp0 - s.Head.PairOfEyes.ReferenceLocation).Normalise();
-            result.HorizViewVectors[1] = (Hp1 - s.Head.PairOfEyes.ReferenceLocation).Normalise();
+            horizViewAng = horizViewAng * 57.2958;
+            vertViewAng = vertViewAng * 57.2958;
+            Vector[] vertViewVectors = new Vector[2];
+            vertViewVectors[0] = (Vp0 - s.Head.PairOfEyes.ReferenceLocation).Normalise();
+            vertViewVectors[1] = (Vp1 - s.Head.PairOfEyes.ReferenceLocation).Normalise();
+            Vector[] horizViewVectors = new Vector[2];
+            horizViewVectors[0] = (Hp0 - s.Head.PairOfEyes.ReferenceLocation).Normalise();
+            horizViewVectors[1] = (Hp1 - s.Head.PairOfEyes.ReferenceLocation).Normalise();
 
+            double torsion = 0;
             if (settings.ViewType == EvalueViewEnum.ToPoint)
             {
-                result.Torsion = Geometry.Query.Angle(s.Head.PairOfEyes.ViewDirection, viewVect) * 57.2958;
+                torsion = Geometry.Query.Angle(s.Head.PairOfEyes.ViewDirection, viewVect) * 57.2958;
             }
 
-            return result;
+            return new Evalue("", "", 0, torsion, horizViewAng, horizViewVectors, vertViewVectors, vertViewAng);
         }
 
         /***************************************************/


### PR DESCRIPTION
Aligns with https://github.com/BHoM/BHoM/pull/1358/commits/32809fc10519e474db31b0fddeafe41d247827ca

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM/pull/1358
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

align the engine with changes made for https://github.com/BHoM/BHoM/issues/1350

<!-- Add short description of what has been fixed -->

Methods generating ViewQualityResults made to call the added constructor.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->