### PR TITLE
BHoM_Engine: ThreadStatic attribute taken off the debug log and replaced by a lock

### DIFF
--- a/BHoM_Engine/Compute/ClearCurrentEvents.cs
+++ b/BHoM_Engine/Compute/ClearCurrentEvents.cs
@@ -38,9 +38,12 @@ namespace BH.Engine.Base
         [PreviousVersion("5.1", "BH.Engine.Reflection.Compute.ClearCurrentEvents()")]
         public static bool ClearCurrentEvents()
         {
-            Log log = Query.DebugLog();
-            log.CurrentEvents.Clear();
-            return true;
+            lock (Global.DebugLogLock)
+            {
+                Log log = Query.DebugLog();
+                log.CurrentEvents.Clear();
+                return true;
+            }
         }
 
         /***************************************************/

--- a/BHoM_Engine/Compute/ClearCurrentEvents.cs
+++ b/BHoM_Engine/Compute/ClearCurrentEvents.cs
@@ -25,6 +25,7 @@ using BH.oM.Base.Debugging;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Reflection;
 
 namespace BH.Engine.Base
@@ -36,6 +37,8 @@ namespace BH.Engine.Base
         /***************************************************/
 
         [PreviousVersion("5.1", "BH.Engine.Reflection.Compute.ClearCurrentEvents()")]
+        [Description("Clears the current event log buffer.")]
+        [Output("success", "True if the buffer is cleared successfully.")]
         public static bool ClearCurrentEvents()
         {
             lock (Global.DebugLogLock)

--- a/BHoM_Engine/Compute/RecordEvent.cs
+++ b/BHoM_Engine/Compute/RecordEvent.cs
@@ -52,11 +52,15 @@ namespace BH.Engine.Base
             string trace = System.Environment.StackTrace;
             newEvent.StackTrace = string.Join("\n", trace.Split('\n').Skip(4).ToArray());
 
-            Log log = Query.DebugLog();
-            log.AllEvents.Add(newEvent);
-            log.CurrentEvents.Add(newEvent);
-
-            return true;
+            lock (Global.DebugLogLock)
+            {
+                Log log = Query.DebugLog();
+                log.AllEvents.Add(newEvent);
+                log.CurrentEvents.Add(newEvent);
+                return true;
+            }
         }
+
+        /***************************************************/
     }
 }

--- a/BHoM_Engine/Compute/RecordEvent.cs
+++ b/BHoM_Engine/Compute/RecordEvent.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base.Debugging;
 using BH.oM.Base.Attributes;
 using System.Linq;
+using System.ComponentModel;
 
 namespace BH.Engine.Base
 {
@@ -33,6 +34,10 @@ namespace BH.Engine.Base
         /***************************************************/
 
         [PreviousVersion("5.1", "BH.Engine.Reflection.Compute.RecordEvent(System.String, BH.oM.Base.Debugging.EventType)")]
+        [Description("Records an event in the BHoM event log.")]
+        [Input("message", "Message related to the event to be logged.")]
+        [Input("type", "Type of the event to be logged.")]
+        [Output("success", "True if the event is logged successfully.")]
         public static bool RecordEvent(string message, EventType type = EventType.Unknown)
         {
             return RecordEvent(new Event { Message = message, Type = type });
@@ -41,6 +46,9 @@ namespace BH.Engine.Base
         /***************************************************/
 
         [PreviousVersion("5.1", "BH.Engine.Reflection.Compute.RecordEvent(BH.oM.Base.Debugging.Event)")]
+        [Description("Records an event in the BHoM event log.")]
+        [Input("newEvent", "Event to be logged.")]
+        [Output("success", "True if the event is logged successfully.")]
         public static bool RecordEvent(Event newEvent)
         {
             if (newEvent == null)

--- a/BHoM_Engine/Compute/RemoveEvent.cs
+++ b/BHoM_Engine/Compute/RemoveEvent.cs
@@ -36,10 +36,13 @@ namespace BH.Engine.Base
         [PreviousVersion("5.1", "BH.Engine.Reflection.Compute.RemoveEvent(BH.oM.Base.Debugging.Event)")]
         public static bool RemoveEvent(Event newEvent)
         {
-            Log log = Query.DebugLog();
-            bool success = log.AllEvents.Remove(newEvent);
-            success &= log.CurrentEvents.Remove(newEvent);
-            return success;
+            lock (Global.DebugLogLock)
+            {
+                Log log = Query.DebugLog();
+                bool success = log.AllEvents.Remove(newEvent);
+                success &= log.CurrentEvents.Remove(newEvent);
+                return success;
+            }
         }
 
         /***************************************************/
@@ -47,15 +50,18 @@ namespace BH.Engine.Base
         [PreviousVersion("5.1", "BH.Engine.Reflection.Compute.RemoveEvents(System.Collections.Generic.List<BH.oM.Base.Debugging.Event>)")]
         public static bool RemoveEvents(List<Event> events)
         {
-            Log log = Query.DebugLog();
-            bool success = true;
-            foreach (Event e in events)
+            lock (Global.DebugLogLock)
             {
-                success &= log.AllEvents.Remove(e);
-                success &= log.CurrentEvents.Remove(e);
+                Log log = Query.DebugLog();
+                bool success = true;
+                foreach (Event e in events)
+                {
+                    success &= log.AllEvents.Remove(e);
+                    success &= log.CurrentEvents.Remove(e);
+                }
+
+                return success;
             }
-            
-            return success;
         }
 
         /***************************************************/

--- a/BHoM_Engine/Compute/RemoveEvent.cs
+++ b/BHoM_Engine/Compute/RemoveEvent.cs
@@ -24,6 +24,7 @@ using BH.oM.Base.Debugging;
 using System;
 using System.Collections.Generic;
 using BH.oM.Base.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Base
 {
@@ -34,6 +35,9 @@ namespace BH.Engine.Base
         /***************************************************/
 
         [PreviousVersion("5.1", "BH.Engine.Reflection.Compute.RemoveEvent(BH.oM.Base.Debugging.Event)")]
+        [Description("Removes an event from the BHoM event log.")]
+        [Input("newEvent", "Event to be removed.")]
+        [Output("success", "True if the event is removed successfully.")]
         public static bool RemoveEvent(Event newEvent)
         {
             lock (Global.DebugLogLock)
@@ -48,6 +52,9 @@ namespace BH.Engine.Base
         /***************************************************/
 
         [PreviousVersion("5.1", "BH.Engine.Reflection.Compute.RemoveEvents(System.Collections.Generic.List<BH.oM.Base.Debugging.Event>)")]
+        [Description("Removes a set of events from the BHoM event log.")]
+        [Input("events", "Events to be removed.")]
+        [Output("success", "True if the events are removed successfully.")]
         public static bool RemoveEvents(List<Event> events)
         {
             lock (Global.DebugLogLock)

--- a/BHoM_Engine/Objects/Global.cs
+++ b/BHoM_Engine/Objects/Global.cs
@@ -62,6 +62,8 @@ namespace BH.Engine.Base
 
         internal static object AssemblyReflectionLock { get; } = new object();
 
+        internal static object DebugLogLock { get; } = new object();
+
 
         /***************************************************/
         /****            Static constructor             ****/

--- a/BHoM_Engine/Query/DebugLog.cs
+++ b/BHoM_Engine/Query/DebugLog.cs
@@ -37,10 +37,13 @@ namespace BH.Engine.Base
         [PreviousVersion("5.1", "BH.Engine.Reflection.Query.DebugLog()")]
         internal static Log DebugLog()
         {
-            if (m_DebugLog == null)
-                m_DebugLog = new Log();
+            lock (Global.DebugLogLock)
+            {
+                if (m_DebugLog == null)
+                    m_DebugLog = new Log();
 
-            return m_DebugLog;
+                return m_DebugLog;
+            }
         }
 
 
@@ -48,9 +51,7 @@ namespace BH.Engine.Base
         /**** Private Fields                            ****/
         /***************************************************/
 
-        [ThreadStatic]
         private static Log m_DebugLog = new Log();
-
 
         /***************************************************/
     }

--- a/BHoM_Engine/Query/Events.cs
+++ b/BHoM_Engine/Query/Events.cs
@@ -38,8 +38,11 @@ namespace BH.Engine.Base
         [PreviousVersion("5.1", "BH.Engine.Reflection.Query.AllEvents()")]
         public static List<Event> AllEvents()
         {
-            Log log = DebugLog();
-            return log.AllEvents.ToList();
+            lock (Global.DebugLogLock)
+            {
+                Log log = DebugLog();
+                return log.AllEvents.ToList();
+            }
         }
 
 
@@ -48,8 +51,11 @@ namespace BH.Engine.Base
         [PreviousVersion("5.1", "BH.Engine.Reflection.Query.CurrentEvents()")]
         public static List<Event> CurrentEvents()
         {
-            Log log = DebugLog();
-            return log.CurrentEvents.ToList();
+            lock (Global.DebugLogLock)
+            {
+                Log log = DebugLog();
+                return log.CurrentEvents.ToList();
+            }
         }
 
 

--- a/BHoM_Engine/Query/Events.cs
+++ b/BHoM_Engine/Query/Events.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using BH.oM.Base.Attributes;
+using System.ComponentModel;
 
 namespace BH.Engine.Base
 {
@@ -36,6 +37,8 @@ namespace BH.Engine.Base
         /***************************************************/
 
         [PreviousVersion("5.1", "BH.Engine.Reflection.Query.AllEvents()")]
+        [Description("Gets all events stored in the lifetime of the BHoM event log (equal to lifetime of the process).")]
+        [Output("events", "All events stored in the lifetime of the BHoM event log.")]
         public static List<Event> AllEvents()
         {
             lock (Global.DebugLogLock)
@@ -49,6 +52,8 @@ namespace BH.Engine.Base
         /***************************************************/
 
         [PreviousVersion("5.1", "BH.Engine.Reflection.Query.CurrentEvents()")]
+        [Description("Gets the events from the BHoM event log that are related to the current action.")]
+        [Output("events", "Events from the BHoM event log that are related to the current action.")]
         public static List<Event> CurrentEvents()
         {
             lock (Global.DebugLogLock)

--- a/Data_Engine/Query/Children.cs
+++ b/Data_Engine/Query/Children.cs
@@ -54,16 +54,6 @@ namespace BH.Engine.Data
             return node?.Children ?? new List<DomainTree<T>>();
         }
 
-        /***************************************************/
-
-        //[Description("Gets the child nodes of this node.")]
-        //[Input("node", "The node to query for its children.")]
-        //[Output("nodes", "Child nodes of the input node.")]
-        public static List<Tree<T>> Children<T>(this Tree<T> node)
-        {
-            return node?.Children?.Values?.ToList() ?? new List<Tree<T>>();
-        }
-
 
         /***************************************************/
         /**** Private Methods                           ****/

--- a/Data_Engine/Query/Children.cs
+++ b/Data_Engine/Query/Children.cs
@@ -54,6 +54,16 @@ namespace BH.Engine.Data
             return node?.Children ?? new List<DomainTree<T>>();
         }
 
+        /***************************************************/
+
+        //[Description("Gets the child nodes of this node.")]
+        //[Input("node", "The node to query for its children.")]
+        //[Output("nodes", "Child nodes of the input node.")]
+        public static List<Tree<T>> Children<T>(this Tree<T> node)
+        {
+            return node?.Children?.Values?.ToList() ?? new List<Tree<T>>();
+        }
+
 
         /***************************************************/
         /**** Private Methods                           ****/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2009
Closes #2745

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Not sure how to test it meaningfully - the code still works as previously and does not show any signs of issues. I think that the best way of tasting can be simply merging the change and watching the logs carefully for the coming 2 sprint to make sure that this does not break anything.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
The approach taken has been discussed with @IsakNaslundBh: it seems to deliver best value for price:
- the log sits safely behind the lock
- the lock is `Global`, so it can be used across the entire project
- `Query.DebugLog` has already been `internal` so there is no risk of the collection being modified from the outside

An alternative that we discussed with @IsakNaslundBh was moving `BH.oM.Base.Debugging.Log` to the engine's `Objects` and encapsulating it properly. However, this would require more effort that does not seem to be justified for now.