### PR TITLE
Facade_Engine: Method to Modify Section Profile Depth within FrameEdgeProperty

### DIFF
--- a/Facade_Engine/Modify/ExtendMullion.cs
+++ b/Facade_Engine/Modify/ExtendMullion.cs
@@ -54,7 +54,7 @@ namespace BH.Engine.Facade
         public static FrameEdgeProperty ExtendMullion(this FrameEdgeProperty frameEdgeProp, double newDepth)
         {
             //Initial Checks
-            if (frameEdgeProp == null || frameEdgeProp.SectionProperties == null)
+            if (frameEdgeProp == null || frameEdgeProp.SectionProperties == null || newDepth == double.NaN)
                 return null;
 
             List<IFragment> extensionBoxes = frameEdgeProp.GetAllFragments(typeof(FrameExtensionBox));

--- a/Facade_Engine/Modify/ExtendMullion.cs
+++ b/Facade_Engine/Modify/ExtendMullion.cs
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Facade.Elements;
+using BH.oM.Base;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.Engine.Base;
+using BH.oM.Facade.Fragments;
+using BH.oM.Spatial.ShapeProfiles;
+using BH.oM.Facade.Results;
+using BH.oM.Facade.SectionProperties;
+using BH.oM.Physical.FramingProperties;
+
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Changes the depth of mullion represented as SectionProperties")]
+        [Input("FrameEdgeProperty", "FrameEdgeProperty with SectionProperties to modify and FrameExtensionBox fragment")]
+        [Input("MullionDepth", "New depth for mullion. Measured from interior face of glazing.")]
+        [Output("FrameEdgeProperty", "FrameEdgeProperty with modified SectionProperties depth")]
+        public static FrameEdgeProperty FrameEdgeProperty(this FrameEdgeProperty frameEdgeProp, double newDepth)
+        {
+            //Initial Checks
+            if (frameEdgeProp == null || frameEdgeProp.SectionProperties == null)
+                return null;
+
+            List<IFragment> extensionBoxes = frameEdgeProp.GetAllFragments(typeof(FrameExtensionBox));
+
+            if (extensionBoxes.Count <= 0)
+            {
+                BH.Engine.Base.Compute.RecordError($"FrameEdgeProperty {frameEdgeProp.BHoM_Guid} does not have FrameExtensionBox fragment applied.");
+                return null;
+            }
+
+            FrameExtensionBox extensionBox = extensionBoxes[0] as FrameExtensionBox;
+
+            Double currentDepth = frameEdgeProp.Depth();
+            if (currentDepth > newDepth)
+            {
+                BH.Engine.Base.Compute.RecordError($"New depth cannot be less than current mullion depth.");
+                return null;
+            }
+
+            ICurve extBox = extensionBox.BoundingBoxCurve;
+            foreach (ConstantFramingProperty prop in frameEdgeProp.SectionProperties)
+            {
+                if (prop.Profile != null)
+                {
+                    IProfile newProfile = ExtendProfile(prop.Profile, extBox, newDepth - currentDepth);
+                    prop.Profile = newProfile;
+                }
+            }
+            return frameEdgeProp;
+        }
+    }
+}
+
+
+
+

--- a/Facade_Engine/Modify/ExtendMullion.cs
+++ b/Facade_Engine/Modify/ExtendMullion.cs
@@ -47,11 +47,11 @@ namespace BH.Engine.Facade
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Changes the depth of mullion represented as SectionProperties")]
-        [Input("FrameEdgeProperty", "FrameEdgeProperty with SectionProperties to modify and FrameExtensionBox fragment")]
-        [Input("MullionDepth", "New depth for mullion. Measured from interior face of glazing.")]
-        [Output("FrameEdgeProperty", "FrameEdgeProperty with modified SectionProperties depth")]
-        public static FrameEdgeProperty FrameEdgeProperty(this FrameEdgeProperty frameEdgeProp, double newDepth)
+        [Description("Changes the depth of section profiles within a FrameEdgeProperty")]
+        [Input("FrameEdgeProperty", "FrameEdgeProperty with section profiles to modify and FrameExtensionBox fragment")]
+        [Input("MullionDepth", "New depth for mullion.")]
+        [Output("ExtendedFrameEdgeProperty", "FrameEdgeProperty with modified section profile depth")]
+        public static FrameEdgeProperty ExtendMullion(this FrameEdgeProperty frameEdgeProp, double newDepth)
         {
             //Initial Checks
             if (frameEdgeProp == null || frameEdgeProp.SectionProperties == null)
@@ -71,7 +71,7 @@ namespace BH.Engine.Facade
             if (currentDepth > newDepth)
             {
                 BH.Engine.Base.Compute.RecordError($"New depth cannot be less than current mullion depth.");
-                return null;
+                return frameEdgeProp;
             }
 
             ICurve extBox = extensionBox.BoundingBoxCurve;

--- a/Facade_Engine/Modify/ExtendMullion.cs
+++ b/Facade_Engine/Modify/ExtendMullion.cs
@@ -47,10 +47,10 @@ namespace BH.Engine.Facade
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Changes the depth of section profiles within a FrameEdgeProperty")]
-        [Input("FrameEdgeProperty", "FrameEdgeProperty with section profiles to modify and FrameExtensionBox fragment")]
-        [Input("MullionDepth", "New depth for mullion.")]
-        [Output("ExtendedFrameEdgeProperty", "FrameEdgeProperty with modified section profile depth")]
+        [Description("Changes the depth of section profiles within a FrameEdgeProperty.")]
+        [Input("frameEdgeProp", "FrameEdgeProperty with section profiles to modify and FrameExtensionBox fragment.")]
+        [Input("newDepth", "New depth for mullion.")]
+        [Output("frameEdgeProp", "FrameEdgeProperty with modified section profile depth.")]
         public static FrameEdgeProperty ExtendMullion(this FrameEdgeProperty frameEdgeProp, double newDepth)
         {
             //Initial Checks

--- a/Facade_Engine/Modify/ExtendProfile.cs
+++ b/Facade_Engine/Modify/ExtendProfile.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Facade
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Changes the depth of profile relative to a given profile extension box.")]
+        [Description("Changes the depth of profile relative to a given profile extension box, extending it in the +X direction.")]
         [Input("profile", "Profile to modify.")]
         [Input("extBox", "ICurve containing cross secton edges to extend.")]
         [Input("extDist", "Amount to extend the profile.")]
@@ -63,7 +63,7 @@ namespace BH.Engine.Facade
                 List<Point> intersectionPts = Geometry.Query.ICurveIntersections(crv, extBox);
                 ICurve newCrv = crv;
                 
-                if (Geometry.Query.IIsContaining(extBox, crv)) //Why isn't this running with ICurves like stated
+                if (Geometry.Query.IIsContaining(extBox, crv))
                 {
                     newCrv = Geometry.Modify.ITranslate(crv, vector);
                 }

--- a/Facade_Engine/Modify/ExtendProfile.cs
+++ b/Facade_Engine/Modify/ExtendProfile.cs
@@ -1,0 +1,94 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BH.oM.Facade.Elements;
+using BH.oM.Base;
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.oM.Spatial.ShapeProfiles;
+using BH.Engine.Base;
+using BH.oM.Facade.Fragments;
+using BH.oM.Facade.Results;
+using BH.oM.Facade.SectionProperties;
+using BH.oM.Physical.FramingProperties;
+
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Modify
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Changes the depth of mullion represented as SectionProperties")]
+        [Input("FrameEdgeProperty", "FrameEdgeProperty with SectionProperties to modify and FrameExtensionBox fragment")]
+        [Input("MullionDepth", "New depth for mullion. Measured from interior face of glazing.")]
+        [Output("FrameEdgeProperty", "FrameEdgeProperty with modified SectionProperties depth")] //UPDATE
+        public static IProfile ExtendProfile(this IProfile profile, ICurve extBox, double extDist)
+        {
+            List<ICurve> profileCrv = new List<ICurve>(profile.Edges);
+            Vector vector = BH.Engine.Geometry.Create.Vector(extDist, 0, 0);
+
+            foreach (ICurve crv in profileCrv)
+            {
+                List<Point> intersectionPts = Geometry.Query.ICurveIntersections(crv, extBox);
+
+                if(intersectionPts.Count >= 1)
+                {
+                    if (!Geometry.Query.IIsLinear(crv))
+                    {
+                        BH.Engine.Base.Compute.RecordError($"Extension cannot be performed on non-linear profile edge.");
+                        return profile;
+                    }
+                    Point endPt = Geometry.Query.IEndPoint(crv);
+                    Point strtPt = Geometry.Query.IStartPoint(crv);
+                    if(endPt.X >= strtPt.X)
+                    {
+                        Geometry.Modify.Translate(endPt, vector);
+                    }
+                    else
+                    {
+                        Geometry.Modify.Translate(strtPt, vector);
+                    }
+                }
+                else if (Geometry.Query.IIsContaining(extBox, crv)) //Why isn't this running with ICurves like stated
+                {
+                    Geometry.Modify.ITranslate(crv, vector);
+                }
+            }
+            IProfile newProfile = BH.Engine.Spatial.Create.FreeFormProfile(profileCrv,false);
+            return newProfile;
+        }
+    }
+}
+
+
+
+

--- a/Facade_Engine/Modify/ExtendProfile.cs
+++ b/Facade_Engine/Modify/ExtendProfile.cs
@@ -50,7 +50,7 @@ namespace BH.Engine.Facade
         [Description("Changes the depth of profile relative to a given profile extension box.")]
         [Input("profile", "Profile to modify.")]
         [Input("extBox", "ICurve containing cross secton edges to extend.")]
-        [Input("newDepth", "New depth for mullion. Measured from interior face of glazing.")]
+        [Input("extDist", "Amount to extend the profile.")]
         [Output("profile", "Profile with extended edge curves.")]
         public static IProfile ExtendProfile(this IProfile profile, ICurve extBox, double extDist)
         {

--- a/Facade_Engine/Modify/ExtendProfile.cs
+++ b/Facade_Engine/Modify/ExtendProfile.cs
@@ -54,6 +54,10 @@ namespace BH.Engine.Facade
         [Output("profile", "Profile with extended edge curves.")]
         public static IProfile ExtendProfile(this IProfile profile, ICurve extBox, double extDist)
         {
+            //Initial Checks
+            if (profile == null || extBox == null || extDist == double.NaN)
+                return null; 
+            
             List<ICurve> profileCrvs = new List<ICurve>(profile.Edges);
             Vector vector = BH.Engine.Geometry.Create.Vector(extDist, 0, 0);
             List<ICurve> newProfCrvs = new List<ICurve>();

--- a/Facade_Engine/Modify/ExtendProfile.cs
+++ b/Facade_Engine/Modify/ExtendProfile.cs
@@ -47,11 +47,11 @@ namespace BH.Engine.Facade
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Changes the depth of profile relative to a given profile extension box")]
-        [Input("Profile", "Profile to modify")]
-        [Input("ExtensionBox", "ICurve containing cross secton edges to extend.")]
-        [Input("NewProfileDepth", "New depth for mullion. Measured from interior face of glazing.")]
-        [Output("ExtendedProfile", "Profile with extended edge curves")] //UPDATE
+        [Description("Changes the depth of profile relative to a given profile extension box.")]
+        [Input("profile", "Profile to modify.")]
+        [Input("extBox", "ICurve containing cross secton edges to extend.")]
+        [Input("newDepth", "New depth for mullion. Measured from interior face of glazing.")]
+        [Output("profile", "Profile with extended edge curves.")]
         public static IProfile ExtendProfile(this IProfile profile, ICurve extBox, double extDist)
         {
             List<ICurve> profileCrvs = new List<ICurve>(profile.Edges);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2770 

<!-- Add short description of what has been fixed -->
Adds two new methods. ExtendProfile extends profile edge curves relative to a provided extension box curve. ExtendMullion modifies a FrameEdgeProperty by extending profile curves relative to an extensionbox fragment assigned to the FrameEdgeProperty.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Facade_Engine/%232770-ModifyMullionDepth?csf=1&web=1&e=LtFp75
