### PR TITLE
Results_Engine: Checking ToString properties instead of IComparable for ResultFiltering

### DIFF
--- a/Results_Engine/Query/FilterResults.cs
+++ b/Results_Engine/Query/FilterResults.cs
@@ -53,19 +53,19 @@ namespace BH.Engine.Results
             IEnumerable<T> filteredRes = results;
 
             if (filter.ResultCaseFilters != null && filter.ResultCaseFilters.Count > 0)
-                filteredRes = results.OfType<ICasedResult>().Where(x => filter.ResultCaseFilters.Contains(x.ResultCase.ToString())).OfType<T>();
+                filteredRes = results.OfType<ICasedResult>().Where(x => filter.ResultCaseFilters.Contains(x.ResultCase?.ToString())).OfType<T>();
 
             if (filter.TimeStepFilters != null && filter.TimeStepFilters.Count > 0)
                 filteredRes = results.OfType<ITimeStepResult>().Where(x => filter.TimeStepFilters.Contains(x.TimeStep)).OfType<T>();
 
             if (filter.ObjectIDFilters != null && filter.ObjectIDFilters.Count > 0)
-                filteredRes = results.OfType<IObjectIdResult>().Where(x => filter.ObjectIDFilters.Contains(x.ObjectId.ToString())).OfType<T>();
+                filteredRes = results.OfType<IObjectIdResult>().Where(x => filter.ObjectIDFilters.Contains(x.ObjectId?.ToString())).OfType<T>();
 
             if (filter.NodeIDFilters != null && filter.NodeIDFilters.Count > 0)
-                filteredRes = results.OfType<IMeshElementResult>().Where(x => filter.NodeIDFilters.Contains(x.NodeId.ToString())).OfType<T>();
+                filteredRes = results.OfType<IMeshElementResult>().Where(x => filter.NodeIDFilters.Contains(x.NodeId?.ToString())).OfType<T>();
 
             if (filter.MeshFaceIDFilters != null && filter.MeshFaceIDFilters.Count > 0)
-                filteredRes = results.OfType<IMeshElementResult>().Where(x => filter.MeshFaceIDFilters.Contains(x.MeshFaceId.ToString())).OfType<T>();
+                filteredRes = results.OfType<IMeshElementResult>().Where(x => filter.MeshFaceIDFilters.Contains(x.MeshFaceId?.ToString())).OfType<T>();
 
 
             return filteredRes;

--- a/Results_Engine/Query/FilterResults.cs
+++ b/Results_Engine/Query/FilterResults.cs
@@ -53,19 +53,19 @@ namespace BH.Engine.Results
             IEnumerable<T> filteredRes = results;
 
             if (filter.ResultCaseFilters != null && filter.ResultCaseFilters.Count > 0)
-                filteredRes = results.OfType<ICasedResult>().Where(x => filter.ResultCaseFilters.Contains(x.ResultCase)).OfType<T>();
+                filteredRes = results.OfType<ICasedResult>().Where(x => filter.ResultCaseFilters.Contains(x.ResultCase.ToString())).OfType<T>();
 
             if (filter.TimeStepFilters != null && filter.TimeStepFilters.Count > 0)
                 filteredRes = results.OfType<ITimeStepResult>().Where(x => filter.TimeStepFilters.Contains(x.TimeStep)).OfType<T>();
 
             if (filter.ObjectIDFilters != null && filter.ObjectIDFilters.Count > 0)
-                filteredRes = results.OfType<IObjectIdResult>().Where(x => filter.ObjectIDFilters.Contains(x.ObjectId)).OfType<T>();
+                filteredRes = results.OfType<IObjectIdResult>().Where(x => filter.ObjectIDFilters.Contains(x.ObjectId.ToString())).OfType<T>();
 
             if (filter.NodeIDFilters != null && filter.NodeIDFilters.Count > 0)
-                filteredRes = results.OfType<IMeshElementResult>().Where(x => filter.NodeIDFilters.Contains(x.NodeId)).OfType<T>();
+                filteredRes = results.OfType<IMeshElementResult>().Where(x => filter.NodeIDFilters.Contains(x.NodeId.ToString())).OfType<T>();
 
             if (filter.MeshFaceIDFilters != null && filter.MeshFaceIDFilters.Count > 0)
-                filteredRes = results.OfType<IMeshElementResult>().Where(x => filter.MeshFaceIDFilters.Contains(x.MeshFaceId)).OfType<T>();
+                filteredRes = results.OfType<IMeshElementResult>().Where(x => filter.MeshFaceIDFilters.Contains(x.MeshFaceId.ToString())).OfType<T>();
 
 
             return filteredRes;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->
https://github.com/BHoM/BHoM/pull/1376
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Add short description of what has been fixed -->

Filtering strings rather than by IComparable to improve UX.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Analytical_oM/%231376-ChangeResultFiltersToStringHashSets?csf=1&web=1&e=ZxWpLB

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->