### PR TITLE
Base_Engine: Making SetGeometry call TryRunExtensionMethod

### DIFF
--- a/BHoM_Engine/Modify/SetGeometry.cs
+++ b/BHoM_Engine/Modify/SetGeometry.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Base
         {
             if (obj == null)
             {
-                Compute.RecordError("Connat set geometry to a null object");
+                Compute.RecordError("Cannot set geometry to a null object.");
                 return null;
             }
             return SetGeometry(obj as dynamic, geometry);
@@ -60,7 +60,7 @@ namespace BH.Engine.Base
             else
             {
                 string geomType = geometry == null ? "null geometry" : $"geometry of type {geometry.GetType().Name}";
-                Compute.RecordError($"Cannot set {geomType} to a {obj.GetType().Name}");
+                Compute.RecordError($"Cannot set {geomType} to a {obj.GetType().Name}.");
             }
 
             return obj;

--- a/BHoM_Engine/Modify/SetGeometry.cs
+++ b/BHoM_Engine/Modify/SetGeometry.cs
@@ -22,6 +22,8 @@
 
 using BH.oM.Base;
 using BH.oM.Geometry;
+using System.ComponentModel;
+using BH.oM.Base.Attributes;
 
 namespace BH.Engine.Base
 {
@@ -31,8 +33,17 @@ namespace BH.Engine.Base
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Tries to set the geometry to the object. The type of geometry needs to be compatible with the object. If the method fails to set the geometry, it will return the incoming object without modification.")]
+        [Input("obj", "The object to set the geometry to.")]
+        [Input("geometry", "The geometry to set to the object. The type of geometry needs to be compatible with the object.")]
+        [Output("obj", "The object with updated geometry.")]
         public static IBHoMObject ISetGeometry(this IBHoMObject obj, IGeometry geometry)
         {
+            if (obj == null)
+            {
+                Compute.RecordError("Connat set geometry to a null object");
+                return null;
+            }
             return SetGeometry(obj as dynamic, geometry);
         }
 
@@ -43,6 +54,15 @@ namespace BH.Engine.Base
 
         private static IBHoMObject SetGeometry(this IBHoMObject obj, IGeometry geometry)
         {
+            object result;
+            if (Compute.TryRunExtensionMethod(obj, "SetGeometry", new object[] { geometry }, out result))
+                return result as IBHoMObject;
+            else
+            {
+                string geomType = geometry == null ? "null geometry" : $"geometry of type {geometry.GetType().Name}";
+                Compute.RecordError($"Cannot set {geomType} to a {obj.GetType().Name}");
+            }
+
             return obj;
         }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2777

<!-- Add short description of what has been fixed -->

This method was not doing anything before and not even raising any warnings/errors that that was the case. Made sure it it correctly tries to dispatch to a SetGeometry method compatible with the object type and geometry type provided, and if failing to do so, raises an error.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/BHoM_Engine/%232778-ISetGeometry-to-call-TryRunExtensionMethod?csf=1&web=1&e=aa36GG

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->