### PR TITLE
Diffing_Engine: fix `NumericalDifferenceInclusion()` that did not trigger check on `IsNumerical()` correctly

### DIFF
--- a/Diffing_Engine/Query/NumericalDifferenceInclusion.cs
+++ b/Diffing_Engine/Query/NumericalDifferenceInclusion.cs
@@ -71,8 +71,8 @@ namespace BH.Engine.Diffing
             int globalSignificantFigures = int.MaxValue)
         {
             // Check if we specified CustomTolerances and if this difference is a number difference.
-            if (globalNumericTolerance != double.MinValue || globalSignificantFigures != int.MaxValue
-                || (namedNumericTolerances?.Any() ?? false) || (namedSignificantFigures?.Any() ?? false)
+            if ((globalNumericTolerance != double.MinValue || globalSignificantFigures != int.MaxValue
+                || (namedNumericTolerances?.Any() ?? false) || (namedSignificantFigures?.Any() ?? false))
                 && (number1?.GetType().IsNumeric() ?? false) && (number2?.GetType().IsNumeric() ?? false)) // GetType() is slow; call only after checking that any custom tolerance is present.
             {
                 // We have specified some custom tolerance in the ComparisonConfig AND this property difference is numeric.


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2807

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Run [DiffingTests_Prototypes](https://github.com/BHoM/DiffingTests_Prototypes). The tests on RevitParameters should work (with the latest commit https://github.com/BHoM/DiffingTests_Prototypes/commit/74934df94a913c053d5c5393c74f6f9d4a766aa6, all tests should work).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->