### PR TITLE
Diffing_Engine: more null guarding against empty IEnumerables in the ComparisonConfig

### DIFF
--- a/Diffing_Engine/Compute/DiffWithCustomIds.cs
+++ b/Diffing_Engine/Compute/DiffWithCustomIds.cs
@@ -82,7 +82,7 @@ namespace BH.Engine.Diffing
             if (followingObjects == null) followingObjects = new List<object>();
             if (followingObjectsIds == null) followingObjectsIds = new List<string>();
             if (diffingConfig == null) diffingConfig = new DiffingConfig();
-            diffingConfig.ComparisonConfig.SetNewEmptyIEnumPropsIfNull();
+            diffingConfig.ComparisonConfig = diffingConfig.ComparisonConfig.SetNewEmptyIEnumPropsIfNull();
 
             // Check if we do not allow duplicate Ids
             // (we do not allow duplicate Ids by default – it may make sense in rare cases with Ids imported from some software that allows duplicates).

--- a/Diffing_Engine/Compute/DiffWithCustomIds.cs
+++ b/Diffing_Engine/Compute/DiffWithCustomIds.cs
@@ -36,6 +36,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using System.Collections;
 using BH.Engine.Base;
+using BH.Engine.Reflection;
 
 namespace BH.Engine.Diffing
 {
@@ -81,6 +82,7 @@ namespace BH.Engine.Diffing
             if (followingObjects == null) followingObjects = new List<object>();
             if (followingObjectsIds == null) followingObjectsIds = new List<string>();
             if (diffingConfig == null) diffingConfig = new DiffingConfig();
+            diffingConfig.ComparisonConfig.SetNewEmptyIEnumPropsIfNull();
 
             // Check if we do not allow duplicate Ids
             // (we do not allow duplicate Ids by default – it may make sense in rare cases with Ids imported from some software that allows duplicates).

--- a/Reflection_Engine/Modify/SetNewEmptyIEnumPropsIfNull.cs
+++ b/Reflection_Engine/Modify/SetNewEmptyIEnumPropsIfNull.cs
@@ -78,18 +78,5 @@ namespace BH.Engine.Reflection
 
             return deepClone;
         }
-
-        /***************************************************/
-
-        [Description("Returns a deepclone of the object, whose IEnumerable properties are replaced with new IEnumerables of the correct type if they are null." +
-            "\nThe method uses the default parameterless constructor of the property type's IEnumerable," +
-            "so if a property's IEnumerable type requires any input parameter, this method will not set that property.")]
-        [Input("obj", "Object whose properties that are null and whose type is a subtype of IEnumerable will be replaced with a new empty IEnumerable of the correct type.")]
-        [Input("warningForUnset", "(Optional, defaults to true) If false, the method does not return a warning when a certain property could not be set.")]
-        [Output("obj", "Object with the null IEnumerable properties replaced with empty IEnumerables of the correct type.")]
-        public static object SetNewEmptyIEnumPropsIfNull(this object obj, bool warningForUnset = true)
-        {
-            return SetNewEmptyIEnumPropsIfNull<object>(obj, warningForUnset);
-        }
     }
 }

--- a/Reflection_Engine/Modify/SetNewEmptyIEnumPropsIfNull.cs
+++ b/Reflection_Engine/Modify/SetNewEmptyIEnumPropsIfNull.cs
@@ -47,6 +47,9 @@ namespace BH.Engine.Reflection
         [Output("obj", "Object with the null IEnumerable properties replaced with empty IEnumerables of the correct type.")]
         public static T SetNewEmptyIEnumPropsIfNull<T>(this T obj, bool warningForUnset = true) where T : class
         {
+            if (obj == null)
+                return null;
+
             T deepClone = obj.DeepClone();
 
             var props = deepClone.GetType().GetProperties();

--- a/Reflection_Engine/Modify/SetNewEmptyIEnumPropsIfNull.cs
+++ b/Reflection_Engine/Modify/SetNewEmptyIEnumPropsIfNull.cs
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+using System.Collections;
+
+namespace BH.Engine.Reflection
+{
+    public static partial class Modify
+    {
+        [Description("Iterates the properties of an object; if the property type is a subtype of IEnumerable and it is null, " +
+            "this method replaces the null with a new empty IEnumerable of the correct type." +
+            "The method uses the default parameterless constructor of the property type's IEnumerable, so if the IEnumerable requires any input parameter, this method will return an error.")]
+        [Input("obj", "Object whose properties are examined. Any property that is null and whose type is a subtype of IEnumerable will have its value replaced with a new empty IEnumerable of the correct type.")]
+        [Output("obj", "Object with the null IEnumerable properties replaced with empty IEnumerables of the correct type.")]
+        public static void SetNewEmptyIEnumPropsIfNull(this object obj)
+        {
+            var props = obj.GetType().GetProperties();
+            foreach (var prop in props)
+            {
+                if (!prop.CanRead || prop.GetMethod.GetParameters().Count() > 0 || !prop.CanWrite)
+                    continue;
+
+                var value = prop.GetValue(obj, null);
+
+                if (value == null && typeof(IEnumerable).IsAssignableFrom(prop.PropertyType) && prop.PropertyType != typeof(string))
+                {
+                    try
+                    {
+                        object newEmptyIEnumerable = System.Activator.CreateInstance(prop.PropertyType);
+
+                        prop.SetValue(obj, newEmptyIEnumerable);
+                    }
+                    catch
+                    {
+                        BH.Engine.Base.Compute.RecordWarning($"Null property `{prop.Name}` of type `{prop.DeclaringType.FullName}` could not be set to a new empty `{prop.PropertyType.FullName}`.");
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2806

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Run [this test](https://github.com/BHoM/DiffingTests_Prototypes/commit/cfca2016d654603b39fd7cf6d8013a6779a9f58c) in the DiffingTests_Prototypes. If the test is run before compiling this PR, it will fail; otherwise, it will succeed.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->