### PR TITLE
Environment_Engine: Add tolerance param to Opening

### DIFF
--- a/Environment_Engine/Create/Opening.cs
+++ b/Environment_Engine/Create/Opening.cs
@@ -43,7 +43,8 @@ namespace BH.Engine.Environment
         [Input("configurationOption", "The Configuration Options the Opening should be generated against that define the height, width, and sill height of the Opening.")]
         [Input("panels", "A collection of Environment Panels which will be used to identify the host panel for the opening from the provided location point.")]
         [Output("opening", "An Opening generated with the provided Configuration Options.")]
-        public static Opening Opening(Point location, OpeningOption configurationOption, List<Panel> panels)
+        [PreviousVersion("5.2", "BH.Engine.Environment.Create.Opening(BH.oM.Geometry.Point, BH.oM.Environment.Configuration.OpeningOption, System.Collections.Generic.List<BH.oM.Environment.Elements.Panel>)")]
+        public static Opening Opening(Point location, OpeningOption configurationOption, List<Panel> panels, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
             if(location == null)
             {
@@ -67,7 +68,7 @@ namespace BH.Engine.Environment
             searchPoint.Z += configurationOption.SillHeight;
             searchPoint.Z += configurationOption.Height / 2;
 
-            Panel hostPanel = panels.Where(x => x.IsContaining(searchPoint)).FirstOrDefault();
+            Panel hostPanel = panels.Where(x => x.IsContaining(searchPoint, tolerance: tolerance)).FirstOrDefault();
             if (hostPanel == null)
                 return null; //Error
 


### PR DESCRIPTION
Tolerance added to Opening, as per linked issue. 

Closes #2816

<!-- Add short description of what has been fixed -->


### Test files
To test, create a Panel object, and place a point as the location along the bottom edge of the panel. Attempt to create a doorway. Then, move the point a tiny distance away (e.g. 0.001m). Then, adjust the tolerance value, and ensure the door is created successfully only when the tolerance is greater than this distance. 