### PR TITLE
Structure_Engine: Add null check for reinforcement in material composition

### DIFF
--- a/Structure_Engine/Query/MaterialComposition.cs
+++ b/Structure_Engine/Query/MaterialComposition.cs
@@ -110,27 +110,30 @@ namespace BH.Engine.Structure
             List<double> areas = new List<double>();
             List<Material> materials = new List<Material>();
 
-            //TODO: Resolve for stirups as well
-            foreach (LongitudinalReinforcement reinforcement in sectionProperty.RebarIntent.BarReinforcement.OfType<LongitudinalReinforcement>())
+            if (sectionProperty?.RebarIntent?.BarReinforcement != null)
             {
-                //Calculate reinforcement area for a section cut
-                double reinArea = reinforcement.Area();
+                //TODO: Resolve for stirups as well
+                foreach (LongitudinalReinforcement reinforcement in sectionProperty.RebarIntent.BarReinforcement.OfType<LongitudinalReinforcement>())
+                {
+                    //Calculate reinforcement area for a section cut
+                    double reinArea = reinforcement.Area();
 
-                //Scale area with distribution along the length
-                double factor = Math.Min(reinforcement.EndLocation - reinforcement.StartLocation, 1);
-                reinArea *= factor;
+                    //Scale area with distribution along the length
+                    double factor = Math.Min(reinforcement.EndLocation - reinforcement.StartLocation, 1);
+                    reinArea *= factor;
 
-                //Subtract reinforcement area from the section area
-                sectionArea -= reinArea;
-                areas.Add(reinArea);
-                Material reifMaterial;
+                    //Subtract reinforcement area from the section area
+                    sectionArea -= reinArea;
+                    areas.Add(reinArea);
+                    Material reifMaterial;
 
-                if (reinforcement.Material != null)
-                    reifMaterial = Physical.Create.Material(reinforcement.Material);
-                else
-                    reifMaterial = new Material();
+                    if (reinforcement.Material != null)
+                        reifMaterial = Physical.Create.Material(reinforcement.Material);
+                    else
+                        reifMaterial = new Material();
 
-                materials.Add(reifMaterial);
+                    materials.Add(reifMaterial);
+                }
             }
 
             if (materials.Count == 0)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2818 

<!-- Add short description of what has been fixed -->

Makes sure MaterialComposition works if no rebar is applied to concrete section

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/ErwwHG8L9P1Fk0W1tFnUujUBOVdXenAfUd1mCggfPl6N_A?e=v0Kb7r

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->