### PR TITLE
Facade_Engine: Improvements to Facade SolidVolume and MaterialComposition Methods

### DIFF
--- a/Facade_Engine/Query/MaterialComposition.cs
+++ b/Facade_Engine/Query/MaterialComposition.cs
@@ -55,7 +55,7 @@ namespace BH.Engine.Facade
         {
             if (curtainWall == null)
             {
-                BH.Engine.Base.Compute.RecordError("Cannot query the solid volume of a null curtain wall.");
+                BH.Engine.Base.Compute.RecordError("Cannot query the Material Composition of a null curtain wall.");
                 return null;
             }
 
@@ -144,7 +144,6 @@ namespace BH.Engine.Facade
 
             if (panel.Openings != null && panel.Openings.Count != 0)
             {
-
                 foreach (Opening opening in panel.Openings)
                 {
                     MaterialComposition matComp = opening.MaterialComposition();
@@ -155,12 +154,10 @@ namespace BH.Engine.Facade
                         volumes.Add(tempVolume);
                         volumes[0] -= tempVolume;
                     }
-                }
-
-                return Matter.Compute.AggregateMaterialComposition(matComps, volumes);
+                }  
             }
 
-            return pMat;
+            return Matter.Compute.AggregateMaterialComposition(matComps, volumes);
         }
 
 
@@ -179,9 +176,9 @@ namespace BH.Engine.Facade
 
             if (opening.OpeningConstruction == null || (opening.OpeningConstruction.IThickness() < oM.Geometry.Tolerance.Distance))
             {
-                if (opening.Edges == null || !opening.Edges.Any(x => x.FrameEdgeProperty != null))
+                if (opening.Edges == null || !opening.Edges.Any(x => x.FrameEdgeProperty != null) || !opening.Edges.Any(x=>x.FrameEdgeProperty.SectionProperties.Count() != 0))
                 {
-                    Engine.Base.Compute.RecordError("Opening " + opening.BHoM_Guid + " does not have any valid constructions assigned");
+                    Engine.Base.Compute.RecordWarning("Opening " + opening.BHoM_Guid + " does not have a frame edge property assigned to get material composition from.");
                     return null;
                 }
                 else
@@ -262,8 +259,8 @@ namespace BH.Engine.Facade
 
             if (frameEdge.FrameEdgeProperty == null || frameEdge.FrameEdgeProperty.SectionProperties.Count() == 0)
             {
-                Engine.Base.Compute.RecordWarning("FrameEdge " + frameEdge.BHoM_Guid + " does not have a frame edge property assigned to get material composition from, so the material composition returned is empty.");
-                return new MaterialComposition(new List<Material>() { new Material() }, new List<double> { 1 } ); ;
+                Engine.Base.Compute.RecordWarning("FrameEdge " + frameEdge.BHoM_Guid + " does not have a frame edge property assigned to get material composition from.");
+                return null;
             }
 
             if (frameEdge.FrameEdgeProperty.SectionProperties.Any(x => x.Material == null))

--- a/Facade_Engine/Query/SolidVolume.cs
+++ b/Facade_Engine/Query/SolidVolume.cs
@@ -111,17 +111,18 @@ namespace BH.Engine.Facade
             double glazedVolume = 0;
             double frameVolume = 0;
 
+            if (opening.Edges != null && opening.Edges.Count != 0)
+                foreach (FrameEdge edge in opening.Edges)
+                {
+                    frameVolume += edge.SolidVolume();
+                }
+
             if (opening.OpeningConstruction != null)
             {
-                if (opening.Edges != null && opening.Edges.Count != 0)
+                if (frameVolume>0)
                 {
                     double glazedArea = opening.ComponentAreas().Item1;
                     glazedVolume = glazedArea * opening.OpeningConstruction.IThickness();
-                    
-                    foreach (FrameEdge edge in opening.Edges)
-                    {
-                        frameVolume += edge.SolidVolume();
-                    }
                 }
                 else
                     glazedVolume = opening.Area() * opening.OpeningConstruction.IThickness();

--- a/Facade_Engine/Query/SolidVolume.cs
+++ b/Facade_Engine/Query/SolidVolume.cs
@@ -91,7 +91,7 @@ namespace BH.Engine.Facade
                 constructionThickness = panel.Construction.IThickness();
 
             double volume = panel.Area() * constructionThickness;
-            return volume + panel.Openings.Sum(x => x.SolidVolume());
+            return volume + panel.Openings.Sum(x => x.SolidVolume()) + panel.ExternalEdges.Sum(x => x.SolidVolume());
         }
 
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2848 

Errors and warnings have been improved, and the methods have been tweaked to improve quality of method outputs for various cases.


### Test files
[#2848 GH and Rhino test files](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Facade_Engine/%232848-VolumeAndCompositionAlignment?csf=1&web=1&e=WUsmvF)

To test, flip through the different dropdown options for FrameEdge, Opening, and Panel and constructions and confirm that the results / errors that result are as expected, and help inform the user what they need to provide to get the method to work accordingly.
