### PR TITLE
BHoM_Engine: fix Hash() method not working with CustomObjects

### DIFF
--- a/BHoM_Engine/Query/Hash.cs
+++ b/BHoM_Engine/Query/Hash.cs
@@ -184,7 +184,22 @@ namespace BH.Engine.Base
                     {
                         string customDataKey = entry.Key.ToString();
 
-                        // Skip this custom data if the key belongs to the exceptions.
+                        bool isCustomObject = currentPropertyFullName.StartsWith("BH.oM.Base.CustomObject");
+
+                        if (isCustomObject)
+                        {
+                            // If the owner of this CustomData Dictionary is a CustomObject,
+                            // we want to consider its keys as if they were object properties for UX/UI consistency.
+                            cc.CustomdataKeysExceptions.AddRange(cc.PropertyExceptions);
+                            cc.CustomdataKeysToConsider.AddRange(cc.PropertiesToConsider);
+
+                            cc.CustomdataKeysExceptions = cc.CustomdataKeysExceptions.Distinct().ToList();
+                            cc.CustomdataKeysToConsider = cc.CustomdataKeysToConsider.Distinct().ToList();
+                        }
+
+                        // Get the custom data Key, so we can check if it belongs to the exceptions.
+
+                        // Skip this custom data if the key belongs to the CustomdataKeysExceptions.
                         if (cc.CustomdataKeysExceptions?.Any(cdKeyExcept => cdKeyExcept == customDataKey || customDataKey.WildcardMatch(cdKeyExcept)) ?? false)
                             continue;
 
@@ -232,18 +247,6 @@ namespace BH.Engine.Base
                     // Skip if the property is a BHoM_Guid.
                     if (propName == "BHoM_Guid")
                         continue;
-
-                    if (type == typeof(CustomObject))
-                    {
-                        // Get the custom data Key, so we can check if it belongs to the exceptions.
-                        int keyStart = propFullName.IndexOf('[') + 1;
-                        int keyEnd = propFullName.IndexOf(']');
-                        string customDataKey = propFullName.Substring(keyStart, keyEnd - keyStart);
-
-                        // Replace the property name as if this CustomData difference was actually a Property Difference.
-                        propName = customDataKey;
-                        propFullName = $"{currentPropertyFullName}.CustomData[{customDataKey}]";
-                    }
 
                     // Check the propertyExceptions/propertiesToConsider in the ComparisonConfig.
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2844

<!-- Add short description of what has been fixed -->
The issue was that there was an old piece of code in the Hash function that was supposed to grab the Key of the CustomData dictionary when the input object was a CustomObject, to then determine what to do with this key. This part was not implemented properly. It was not discovered earlier due to lack of usage of this workflow. This is now fixed by moving the code in the correct area of the algorithm. I also added tests in the DiffingTests prototypes to capture this usage, see below.

### Test files
<!-- Link to test files to validate the proposed changes -->
- See #2844 (simply try to compute the Hash of any CustomObject) and/or
- run the DiffingTests in https://github.com/BHoM/DiffingTests_Prototypes. There are two new tests that cover this workflow within the `HashTests` class: [`CustomObjects_EqualHash`](https://github.com/BHoM/DiffingTests_Prototypes/blob/aff8e4fdfb1db780698c86fdd9770bca583e9104/DiffingTests/HashTests.cs#L54-L65) and [`CustomObjects_CustomKeyException_DifferentObjs_EqualHash`](https://github.com/BHoM/DiffingTests_Prototypes/blob/aff8e4fdfb1db780698c86fdd9770bca583e9104/DiffingTests/HashTests.cs#L68-L97).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->