### PR TITLE
Geometry_Engine: Fix only checking IsClockwise for closed curves

### DIFF
--- a/Geometry_Engine/Modify/SplitAtPoints.cs
+++ b/Geometry_Engine/Modify/SplitAtPoints.cs
@@ -274,8 +274,7 @@ namespace BH.Engine.Geometry
                 onCurvePoints.RemoveAt(0);
             }
 
-            bool isClosed = curve.IIsClosed(tolerance);
-            bool isClockwise = curve.IIsClockwise(curve.INormal(), tolerance);
+            bool isClosedAndAntiClockwise = curve.IIsClosed(tolerance) && !curve.IIsClockwise(curve.Normal(), tolerance);
 
             while (i <= onCurvePoints.Count)
             {
@@ -286,12 +285,12 @@ namespace BH.Engine.Geometry
                     subResultList.Add(tmpResult[j]);
                     if (i < onCurvePoints.Count)
                     {
-                        if (tmpResult[j].IEndPoint().IsEqual(onCurvePoints[i]) || (isClosed && !isClockwise && tmpResult[j].IStartPoint().IsEqual(onCurvePoints[i])))
+                        if (tmpResult[j].IEndPoint().IsEqual(onCurvePoints[i]) || (isClosedAndAntiClockwise && tmpResult[j].IStartPoint().IsEqual(onCurvePoints[i])))
                         {
                             j++;
                             break;
                         }
-                        else if (tmpResult[j].IEndPoint().IsEqual(curve.EndPoint()) || (isClosed && !isClockwise && tmpResult[j].IEndPoint().IsEqual(curve.StartPoint())))
+                        else if (tmpResult[j].IEndPoint().IsEqual(curve.EndPoint()) || (isClosedAndAntiClockwise && tmpResult[j].IEndPoint().IsEqual(curve.StartPoint())))
                         {
                             j++;
                             break;


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2860 

<!-- Add short description of what has been fixed -->

Method was crashing for open curves, due to trying to compute IsClockwise for all curves provided, due to the pre-computation performance improvement introduced in https://github.com/BHoM/BHoM_Engine/commit/15be19d351069eb9a4c1add175a0bd181a9edae3 .

Changing to storing only one boolean instead, that only is impacted by the IsClockwise method when it is known to be closed.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->