### PR TITLE
Facade_Engine: MaterialComposition tweak to return valid empty value for valid empty frame edge

### DIFF
--- a/Facade_Engine/Query/MaterialComposition.cs
+++ b/Facade_Engine/Query/MaterialComposition.cs
@@ -260,7 +260,7 @@ namespace BH.Engine.Facade
             if (frameEdge.FrameEdgeProperty == null || frameEdge.FrameEdgeProperty.SectionProperties.Count() == 0)
             {
                 Engine.Base.Compute.RecordWarning("FrameEdge " + frameEdge.BHoM_Guid + " does not have a frame edge property assigned to get material composition from, so the material composition returned is empty.");
-                return new MaterialComposition(new List<Material>() { new Material() }, new List<double> { 1 }); ;
+                return new MaterialComposition(new List<Material>(), new List<double>()); ;
             }
 
             if (frameEdge.FrameEdgeProperty.SectionProperties.Any(x => x.Material == null))

--- a/Facade_Engine/Query/MaterialComposition.cs
+++ b/Facade_Engine/Query/MaterialComposition.cs
@@ -259,8 +259,8 @@ namespace BH.Engine.Facade
 
             if (frameEdge.FrameEdgeProperty == null || frameEdge.FrameEdgeProperty.SectionProperties.Count() == 0)
             {
-                Engine.Base.Compute.RecordWarning("FrameEdge " + frameEdge.BHoM_Guid + " does not have a frame edge property assigned to get material composition from.");
-                return null;
+                Engine.Base.Compute.RecordWarning("FrameEdge " + frameEdge.BHoM_Guid + " does not have a frame edge property assigned to get material composition from, so the material composition returned is empty.");
+                return new MaterialComposition(new List<Material>() { new Material() }, new List<double> { 1 }); ;
             }
 
             if (frameEdge.FrameEdgeProperty.SectionProperties.Any(x => x.Material == null))


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2864 

Made MaterialComposition return an empty MaterialComposition for a valid empty frame edge.


### Test files
[Facade_Engine Test File](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_Engine/Facade_Engine?csf=1&web=1&e=s1STNX)

