### PR TITLE
MEP_Engine: Adding Create method for generating a Graph from a set of IFlowObejcts and fixtures

### DIFF
--- a/MEP_Engine/Create/Elements/Graph.cs
+++ b/MEP_Engine/Create/Elements/Graph.cs
@@ -1,0 +1,151 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using BH.oM.Analytical.Elements;
+using BH.oM.MEP.System;
+using BH.oM.MEP.System.Fittings;
+using BH.oM.Geometry;
+using BH.oM.Data.Collections;
+using BH.Engine.Data;
+using BH.Engine.Base;
+
+namespace BH.Engine.MEP
+{
+    public static partial class Create
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Creates a Graph from a series of IFlow and Fitting obejcts.")]
+        [Input("flows", "IFlow obejects to contruct the graph from.")]
+        [Input("fittings", "Optional Fitting obejcts to contruct the grph from.")]
+        [Input("snappingTolerance", "Tolerance, used to determine if two points are to be deemed to be the same.")]
+        [Output("graph", "Graph consisting of flows, fittings and nodes in between.")]
+        public static Graph Graph(IEnumerable<IFlow> flows, IEnumerable<Fitting> fittings = null, double snappingTolerance = Tolerance.MacroDistance)
+        {
+            if (flows == null)
+                return null;
+
+            fittings = fittings ?? new List<Fitting>();
+
+            List<IRelation> relations = new List<IRelation>();
+
+            PointMatrix<Node> matrix = Engine.Data.Create.PointMatrix<Node>(1);
+
+            Dictionary<Guid, IBHoMObject> entities = new Dictionary<Guid, IBHoMObject>();
+
+            foreach (IFlow flow in flows)
+            {
+                if (flow == null)
+                    continue;
+
+                entities[flow.BHoM_Guid] = flow;
+                Point stPt = flow.StartPoint;
+                Node stNode;
+                if (!matrix.FindOrAdd(stPt, out stNode, snappingTolerance))
+                {
+                    entities[stNode.BHoM_Guid] = stNode;
+                }
+                Point enPt = flow.EndPoint;
+                Node enNode;
+                if (!matrix.FindOrAdd(enPt, out enNode, snappingTolerance))
+                {
+                    entities[enNode.BHoM_Guid] = enNode;
+                }
+
+                Point mid = (stPt + enPt) / 2;
+                relations.Add(new Relation()
+                {
+                    Source = stNode.BHoM_Guid,
+                    Target = flow.BHoM_Guid,
+                    Curve = new Line() { Start = stPt, End = mid }
+                });
+
+                relations.Add(new Relation()
+                {
+                    Source = flow.BHoM_Guid,
+                    Target = enNode.BHoM_Guid,
+                    Curve = new Line() { Start = mid, End = enPt }
+                });
+            }
+
+            foreach (Fitting fitting in fittings)
+            {
+                if (fitting == null || fitting.ConnectionsLocation == null || fitting.ConnectionsLocation.Count == 0)
+                    continue;
+
+                foreach (Point point in fitting.ConnectionsLocation)
+                {
+                    Node node;
+                    if (!matrix.FindOrAdd(point, out node, snappingTolerance))
+                    {
+                        entities[node.BHoM_Guid] = node;
+                    }
+
+                    relations.Add(new Relation()
+                    {
+                        Source = node.BHoM_Guid,
+                        Target = fitting.BHoM_Guid,
+                        Curve = new Line() { Start = point, End = fitting.Location }
+                    });
+                }
+
+                entities[fitting.BHoM_Guid] = fitting;
+            }
+
+            return new Graph
+            {
+                Entities = entities,
+                Relations = relations
+            };
+        }
+
+        /***************************************************/
+        /**** Private Methods                           ****/
+        /***************************************************/
+
+        private static bool FindOrAdd(this PointMatrix<Node> pointMatrix, Point pos, out Node node, double tolerance)
+        {
+            LocalData<Node> closestData = pointMatrix.ClosestData(pos, tolerance);
+            if (closestData != null)
+            {
+                node = closestData.Data;
+                return true;
+            }
+            else
+            {
+                node = new Node { Position = pos };
+                pointMatrix.Add(node.Position, node);
+                return false;
+            }
+        }
+
+        /***************************************************/
+    }
+}

--- a/MEP_Engine/MEP_Engine.csproj
+++ b/MEP_Engine/MEP_Engine.csproj
@@ -44,7 +44,9 @@
       <SpecificVersion>false</SpecificVersion>
     </Reference>
     <Reference Include="Data_oM">
-      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <HintPath>C:\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Dimensional_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>

--- a/MEP_Engine/MEP_Engine.csproj
+++ b/MEP_Engine/MEP_Engine.csproj
@@ -18,7 +18,9 @@
   </Target>
 
   <ItemGroup>
+    <ProjectReference Include="..\Analytical_Engine\Analytical_Engine.csproj" />
     <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj" />
+    <ProjectReference Include="..\Data_Engine\Data_Engine.csproj" />
     <ProjectReference Include="..\Geometry_Engine\Geometry_Engine.csproj" />
     <ProjectReference Include="..\Matter_Engine\Matter_Engine.csproj" />
     <ProjectReference Include="..\Reflection_Engine\Reflection_Engine.csproj" />
@@ -40,6 +42,9 @@
       <HintPath>C:\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
       <Private>false</Private>
       <SpecificVersion>false</SpecificVersion>
+    </Reference>
+    <Reference Include="Data_oM">
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\Data_oM.dll</HintPath>
     </Reference>
     <Reference Include="Dimensional_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Dimensional_oM.dll</HintPath>


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2869

<!-- Add short description of what has been fixed -->

Raising this now, as I am about to go on leave for a few weeks, and while it is still fresh in my mind in case useful for further development discussed in planning call.

Adding a method for efficient creation of a analytical Graph from a set of `IFlow` objects as well as `Fixtures`.

Ideally we should be doing this in the Analytical_Engine, working on some interfaces such as the `ILink` etc, but as the `IFlow` objects currently do not implement that interface, added this as a temporary solution.

The graph currently assumes directionality from the `IFlow` objects, this is, from StartPoint to EndPoint. I suspect that this is not always correct, but could be handled by a second pass down the graph, once sources and exhausts etc are known.

Assume there are more point/node-based objects like HVAC units etc that will be required to form the full graph, but should hopefully be made easier by expanding the code in this PR.

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/EiieIrVtZwpJn5KUmwaPgb8BAWRcn9cFaq3w97GvvkE29Q?e=WiErl7

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

Ofc, not to be merged before 5.2 beta release.