### PR TITLE
Environment_Engine: Hard coded default acceptOnEdges to true

### DIFF
--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -109,7 +109,7 @@ namespace BH.Engine.Environment
             List<Point> ctrPoints = panels.SelectMany(x => x.Polyline().IControlPoints()).ToList();
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
-            if (!BH.Engine.Geometry.Query.IsContaining(boundingBox, point, acceptOnEdges, tolerance))
+            if (!BH.Engine.Geometry.Query.IsContaining(boundingBox, point, true, tolerance))
                 return false;
 
             //We need to check one line that starts in the point and end outside the bounding box


### PR DESCRIPTION


Closes #2871 

Turns out that the two bugs were related - fixing one fixed the other. 



### Test files
Test via sections 1 and 3 of the Environment_Engine test procedure. 

