### PR TITLE
Geometry_Engine: Added Query.FilterByNormal method

### DIFF
--- a/Geometry_Engine/Query/FilterByNormal.cs
+++ b/Geometry_Engine/Query/FilterByNormal.cs
@@ -38,15 +38,23 @@ namespace BH.Engine.Geometry
         [Description("Returns a list of PlanarSurfaces where each surface Normal is within the tolerance angle of the given vector.")]
         [Input("surfaces", "A list of PlanarSurfaces to filter by a given Normal vector.")]
         [Input("vector", "The Vector to filter by.")]
+        [Input("includeOpposite", "Set to True to include vectors that are equal, but opposite. Default is False.")]
         [Input("tolerance", "Angle tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Angle.")]
         [Output("matchingSurfaces", "A list of PlanarSurfaces where each surface Normal is within the tolerance angle of the given vector.")]
-        public static List<PlanarSurface> FilterByNormal(this List<PlanarSurface> surfaces, Vector vector, double tolerance = Tolerance.Angle)
+        public static List<PlanarSurface> FilterByNormal(this List<PlanarSurface> surfaces, Vector vector, bool includeOpposite = false, double tolerance = Tolerance.Angle)
         {
             List<PlanarSurface> matchingSurfaces = new List<PlanarSurface>();
             foreach (PlanarSurface srf in surfaces)
             {
-                if (Math.Abs(Query.Angle(vector, srf.Normal())) < tolerance)
+                int parallelism = vector.IsParallel(srf.Normal(), tolerance);
+                if (parallelism == 1)
+                {
                     matchingSurfaces.Add(srf);
+                }
+                else if (includeOpposite && parallelism == -1)
+                {
+                    matchingSurfaces.Add(srf);
+                }
             }
             return matchingSurfaces;
         }

--- a/Geometry_Engine/Query/FilterByNormal.cs
+++ b/Geometry_Engine/Query/FilterByNormal.cs
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2022, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Geometry;
+using System;
+using System.ComponentModel;
+
+using BH.oM.Base.Attributes;
+using System.Collections.Generic;
+
+namespace BH.Engine.Geometry
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Returns a list of PlanarSurfaces where each surface Normal is within the tolerance angle of the given vector.")]
+        [Input("surfaces", "A list of PlanarSurfaces to filter by a given Normal vector.")]
+        [Input("vector", "The Vector to filter by.")]
+        [Input("tolerance", "Angle tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Angle.")]
+        [Output("filtered_geom", "A list of PlanarSurfaces where each surface Normal is within the tolerance angle of the given vector.")]
+        public static List<PlanarSurface> FilterByNormal(this List<PlanarSurface> surfaces, Vector vector, double tolerance = Tolerance.Angle)
+        {
+            List<PlanarSurface> matchingSurfaces = new List<PlanarSurface>();
+            foreach (PlanarSurface srf in surfaces)
+            {
+
+                if (Math.Abs(Query.Angle(vector, srf.Normal())) < tolerance)
+                {
+                    matchingSurfaces.Add(srf);
+                }
+            }
+            return matchingSurfaces;
+        }
+    }
+}

--- a/Geometry_Engine/Query/FilterByNormal.cs
+++ b/Geometry_Engine/Query/FilterByNormal.cs
@@ -39,17 +39,14 @@ namespace BH.Engine.Geometry
         [Input("surfaces", "A list of PlanarSurfaces to filter by a given Normal vector.")]
         [Input("vector", "The Vector to filter by.")]
         [Input("tolerance", "Angle tolerance used in geometry processing, default set to BH.oM.Geometry.Tolerance.Angle.")]
-        [Output("filtered_geom", "A list of PlanarSurfaces where each surface Normal is within the tolerance angle of the given vector.")]
+        [Output("matchingSurfaces", "A list of PlanarSurfaces where each surface Normal is within the tolerance angle of the given vector.")]
         public static List<PlanarSurface> FilterByNormal(this List<PlanarSurface> surfaces, Vector vector, double tolerance = Tolerance.Angle)
         {
             List<PlanarSurface> matchingSurfaces = new List<PlanarSurface>();
             foreach (PlanarSurface srf in surfaces)
             {
-
                 if (Math.Abs(Query.Angle(vector, srf.Normal())) < tolerance)
-                {
                     matchingSurfaces.Add(srf);
-                }
             }
             return matchingSurfaces;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2876 

<!-- Add short description of what has been fixed -->
Added a method to filter a list of PlanarSurface objects by their surface normal, within a given tolerance.

### Test files
<!-- Link to test files to validate the proposed changes -->
[Geometry_Engine-#2876-AddFilterByNormal.zip](https://github.com/BHoM/BHoM_Engine/files/9008323/Geometry_Engine-.2876-AddFilterByNormal.zip)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- `Query.FilterByNormal()` Query method added in the `Geometry_Engine` for lists of PlanarSurface objects

### Additional comments
<!-- As required -->