### PR TITLE
Add DisplayText support on enums

### DIFF
--- a/BHoM_Engine/Compute/ParseEnum.cs
+++ b/BHoM_Engine/Compute/ParseEnum.cs
@@ -64,9 +64,11 @@ namespace BH.Engine.Base
                 return Enum.GetValues(enumType).OfType<Enum>()
                     .FirstOrDefault(x => {
                         FieldInfo fi = enumType.GetField(x.ToString());
-                        DescriptionAttribute[] attributes = fi.GetCustomAttributes(typeof(DescriptionAttribute), false) as DescriptionAttribute[];
+                        DisplayTextAttribute[] displayTexts = fi.GetCustomAttributes(typeof(DisplayTextAttribute), false) as DisplayTextAttribute[];
+                        DescriptionAttribute[] descriptions = fi.GetCustomAttributes(typeof(DescriptionAttribute), false) as DescriptionAttribute[];
 
-                        return attributes != null && attributes.Count() > 0 && attributes.First().Description == value;
+                        return (displayTexts != null && displayTexts.Count() > 0 && displayTexts.First().Text == value)
+                            || (descriptions != null && descriptions.Count() > 0 && descriptions.First().Description == value);
                     });
             }
         }

--- a/BHoM_Engine/Convert/ToText.cs
+++ b/BHoM_Engine/Convert/ToText.cs
@@ -161,7 +161,7 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
-        public static string ToText(Enum item, bool includePath = false)
+        public static string ToText(this Enum item, bool includePath = false)
         {
             if (item == null)
                 return "null";

--- a/BHoM_Engine/Convert/ToText.cs
+++ b/BHoM_Engine/Convert/ToText.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -158,7 +159,29 @@ namespace BH.Engine.Base
             }
         }
 
+        /***************************************************/
 
+        public static string ToText(Enum item, bool includePath = false)
+        {
+            if (item == null)
+                return "null";
+
+            if (includePath)
+            {
+                Type type = item.GetType();
+                return type.Path() + "." + type.Name + "." + item.ToString();
+            }
+            else
+            {
+                FieldInfo fi = item.GetType().GetField(item.ToString());
+                DisplayTextAttribute[] attributes = fi.GetCustomAttributes(typeof(DisplayTextAttribute), false) as DisplayTextAttribute[];
+
+                if (attributes != null && attributes.Count() > 0)
+                    return attributes.First().Text;
+                else
+                    return item.ToString();
+            }
+        }
 
         /***************************************************/
         /**** Fallback Methods                          ****/
@@ -168,7 +191,7 @@ namespace BH.Engine.Base
         {
             if (item == null)
                 return "null";
-            else if (item is string || item.GetType().IsEnum)
+            else if (item is string)
                 return item.ToString();
             else
                 return item.GetType().ToString();

--- a/BHoM_Engine/Convert/ToText.cs
+++ b/BHoM_Engine/Convert/ToText.cs
@@ -37,6 +37,10 @@ namespace BH.Engine.Base
         /**** Interface Methods                         ****/
         /***************************************************/
 
+        [Description("Provides a human-friendly text representation of the provided object.")]
+        [Input("member", "object to convert to text.")]
+        [Input("includePath", "If true, the path/namespace will be provided.")]
+        [Output("Text representation.")]
         public static string IToText(this object member, bool includePath = false)
         {
             if (member == null)
@@ -50,6 +54,10 @@ namespace BH.Engine.Base
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Provides a human-friendly text representation of a member of a class.")]
+        [Input("member", "member to convert to text.")]
+        [Input("includePath", "If true, the path/namespace will be provided.")]
+        [Output("Text representation.")]
         public static string ToText(this MemberInfo member, bool includePath = false)
         {
             if (member == null)
@@ -65,6 +73,18 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
+        [Description("Provides a human-friendly text representation of a method.")]
+        [Input("method", "method to convert to text.")]
+        [Input("includePath", "If true, the path/namespace will be provided.")]
+        [Input("paramStart", "Start symbol used for the beginning of the method parameters. Usually, '('.")]
+        [Input("paramSeparator", "Symbol used to separate the parameters. Usually, ','.")]
+        [Input("paramEnd", "Start symbol used for the end of the method parameters. Usually, ')'.")]
+        [Input("removeIForInterface", "If true, the 'I' in front of the interface method will not show.")]
+        [Input("includeParamNames", "If true, the name of the parameters will be written. Otherwise, only their types will show.")]
+        [Input("maxParams", "Maximum number of parameter to write. Any remaining will be represented with '...'.")]
+        [Input("maxChars", "Maximum number of characters to use. Any remaining will be represented with '...'.")]
+        [Input("includeParamPaths", "If true, the path/namespace will be provided.")]
+        [Output("Text representation.")]
         public static string ToText(this MethodBase method, bool includePath = false, string paramStart = "(", string paramSeparator = ", ", string paramEnd = ")", bool removeIForInterface = true, bool includeParamNames = true, int maxParams = 5, int maxChars = 40, bool includeParamPaths = false)
         {
             if (method == null)
@@ -124,6 +144,13 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
+        [Description("Provides a human-friendly text representation of a type.")]
+        [Input("type", "type to convert to text.")]
+        [Input("includePath", "If true, the path/namespace will be provided.")]
+        [Input("genericStart", "Start symbol used for the beginning of the generic parameters, if any. Usually, '<'.")]
+        [Input("genericSeparator", "Symbol used to separate the generic parameters. Usually, ','.")]
+        [Input("genericEnd", "Start symbol used for the end of the generic parameters, if any. Usually, '>'.")]
+        [Output("Text representation.")]
         public static string ToText(this Type type, bool includePath = false, bool replaceGeneric = false, string genericStart = "<", string genericSeparator = ", ", string genericEnd = ">")
         {
             if (type == null)
@@ -161,6 +188,10 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
+        [Description("Provides a human-friendly text representation of an enum.")]
+        [Input("item", "enum to convert to text.")]
+        [Input("includePath", "If true, the path/namespace will be provided.")]
+        [Output("Text representation.")]
         public static string ToText(this Enum item, bool includePath = false)
         {
             if (item == null)


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
https://github.com/BHoM/BHoM/pull/1441

   
### Issues addressed by this PR
See https://github.com/BHoM/BHoM/issues/1440


### Test files
Not a file per se since there isn't obviously a case of `DisplayText` usage in the BHoM yet. But here's a working example:

![image](https://user-images.githubusercontent.com/16853390/196959357-22948af0-d6ba-4d5b-b33f-af28974e6167.png)

![image](https://user-images.githubusercontent.com/16853390/196959276-5a455ea3-790f-4f1b-97b7-18d30206bc04.png)

Best is to add the attribute yourself to a random enum and test that it is well supported. Happy to jump to a call if it is easier for the review though.

