### PR TITLE
Serialiser_Engine: Fix serialisation in Blazor web assemblies

### DIFF
--- a/BHoM_Engine/Compute/ExtractAssembly.cs
+++ b/BHoM_Engine/Compute/ExtractAssembly.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Base
         [Input("assembly", "Assembly to be reflected.")]
         public static void ExtractAssembly(Assembly assembly)
         {
-            if (assembly == null || assembly.IsDynamic || assembly.ReflectionOnly)
+            if (assembly == null || assembly.IsDynamic || assembly.ReflectionOnly) // Dynamically compiled assemblies throw an exception on reading the ReflectionOnly property (ex. of dynamic assembly can be found in Blazor apps) 
                 return;
 
             lock (Global.AssemblyReflectionLock)

--- a/BHoM_Engine/Compute/ExtractAssembly.cs
+++ b/BHoM_Engine/Compute/ExtractAssembly.cs
@@ -41,7 +41,7 @@ namespace BH.Engine.Base
         [Input("assembly", "Assembly to be reflected.")]
         public static void ExtractAssembly(Assembly assembly)
         {
-            if (assembly == null || assembly.ReflectionOnly)
+            if (assembly == null || assembly.IsDynamic || assembly.ReflectionOnly)
                 return;
 
             lock (Global.AssemblyReflectionLock)

--- a/Versioning_Engine/Query/UpgraderVersions.cs
+++ b/Versioning_Engine/Query/UpgraderVersions.cs
@@ -50,6 +50,8 @@ namespace BH.Engine.Versioning
                 return m_UpgraderVersions;
 
             string upgraderFolder = Path.Combine(Base.Query.BHoMFolder(), "..", "Upgrades");
+            if (!Directory.Exists(upgraderFolder))
+                return new List<string>();
 
             m_UpgraderVersions = Directory.GetDirectories(upgraderFolder, "BHoMUpgrader*", SearchOption.TopDirectoryOnly).Select(folder =>
             {


### PR DESCRIPTION


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2953 

Two things are being fixed: 
 - Check that the `C:\ProgramData\BHoM\Upgrades` folder exists before collecting Versioning upgraders to prevent errors in web apps.
 - Filter out dynamic assemblies when extracting types as the call to the `ReflectionOnly` property is throwing an exception for them.


### Test files
Test of the fix ran in a live session with @FraserGreenroyd as it requires testing the fix within a Blazor application.

