### PR TITLE
Serialiser_Engine: added null check in MethodBaseSerialiser

### DIFF
--- a/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
+++ b/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs
@@ -166,10 +166,14 @@ namespace BH.Engine.Serialiser.BsonSerializers
                     {
                         try
                         {
-                            if (methodName == ".ctor")
-                                method = type.GetConstructor(types.ToArray());
-                            else
-                                method = type.GetMethod(methodName, types.ToArray());
+                            Type[] typesArray = types.ToArray();
+                            if (typesArray != null)
+                            {
+                                if (methodName == ".ctor")
+                                    method = type.GetConstructor(typesArray);
+                                else
+                                    method = type.GetMethod(methodName, typesArray);
+                            }
                         }
                         catch { }
                     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2823

<!-- Add short description of what has been fixed -->
Added a null check in [MethodBaseSerializer](https://github.com/BHoM/BHoM_Engine/blob/ae5f832e75f8f8a4d4f3b994e6253c4485a5e829/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs) to avoid it throwing an exception during startup (plugin loading) as explained in #2823.

### Test files
<!-- Link to test files to validate the proposed changes -->
See #2823. I can provide an assembly that throws the error if deemed necessary.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added a null check in [MethodBaseSerializer](https://github.com/BHoM/BHoM_Engine/blob/ae5f832e75f8f8a4d4f3b994e6253c4485a5e829/Serialiser_Engine/Objects/BsonSerializers/MethodBaseSerializer.cs).
