### PR TITLE
Environment_Engine: opening split bug fixed

### DIFF
--- a/Environment_Engine/Modify/SplitOpeningByGeometry.cs
+++ b/Environment_Engine/Modify/SplitOpeningByGeometry.cs
@@ -33,6 +33,7 @@ using System;
 using BH.oM.Geometry;
 
 using BH.Engine.Base;
+using BH.Engine.Geometry;
 
 namespace BH.Engine.Environment
 {
@@ -44,9 +45,17 @@ namespace BH.Engine.Environment
         [Output("openings", "A collection of Environment Openings split into the geometry parts provided")]
         public static List<Opening> SplitOpeningByGeometry(this Opening opening, List<Polyline> polylines)
         {
-            List<Opening> openings = new List<Opening>();
+            Polyline outline = opening.Polyline();
+            if (outline == null)
+            {
+                BH.Engine.Base.Compute.RecordError("The outline of the opening needs to be polylinear.");
+                return null;
+            }
 
-            foreach (Polyline p in polylines)
+            List<Line> cutting = polylines.SelectMany(x => x.SubParts()).ToList();
+
+            List<Opening> openings = new List<Opening>();
+            foreach (Polyline p in outline.Split(cutting))
             {
                 Opening pan = opening.ShallowClone();
                 pan.Edges = p.ToEdges();

--- a/Geometry_Engine/Compute/Split.cs
+++ b/Geometry_Engine/Compute/Split.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Geometry
         [Input("distanceTolerance", "Tolerance to use for distance measurment operations, default to BH.oM.Geometry.Tolerance.Distance.")]
         [Input("decimalPlaces", "All coordinates of the geometry will be rounded to the number of decimal places specified. Default 6.")]
         [Output("regions", "Closed polygon regions contained within the outer region cut by the cutting lines.")]
-        public static List<Polyline> Split(Polyline outerRegion, List<Line> cuttingLines, double distanceTolerance = BH.oM.Geometry.Tolerance.Distance, int decimalPlaces = 6)
+        public static List<Polyline> Split(this Polyline outerRegion, List<Line> cuttingLines, double distanceTolerance = BH.oM.Geometry.Tolerance.Distance, int decimalPlaces = 6)
         {
             //Preproc the cutting lines to take only the parts inside the outer region
             cuttingLines = cuttingLines.BooleanUnion(distanceTolerance);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2969

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FEnvironment%5FEngine%2F%233004%2DSplitOpeningFix&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->