### PR TITLE
Structure_Engine - Adding tolerance to create panel methods

### DIFF
--- a/Structure_Engine/Create/Elements/Panel.cs
+++ b/Structure_Engine/Create/Elements/Panel.cs
@@ -97,7 +97,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [PreviousVersion("6.0", "BH.Engine.Structure.Create.Panel(System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
+        [PreviousVersion("6.1", "BH.Engine.Structure.Create.Panel(System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
         [Description("Creates a list of Panels based on a collection of outline curves. \n" +
                      "Method will distribute the outlines such that the outermost curve will be assumed to be an external outline of a panel, and any curve contained in this outline will be assumed as an opening of this Panel. \n" +
                      "Any outline curve inside an opening will again be assumed to be the outline of a new Panel.")]

--- a/Structure_Engine/Create/Elements/Panel.cs
+++ b/Structure_Engine/Create/Elements/Panel.cs
@@ -71,6 +71,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [PreviousVersion("6.0", "BH.Engine.Structure.Create.Panel(BH.oM.Geometry.ICurve, System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
         [Description("Creates a structural Panel from a closed curve defining the outline, and any number of closed curves defining openings.")]
         [Input("outline", "A closed Curve defining the outline of the Panel. The ExternalEdges of the Panel will be the subparts of this curve, where each edge will corespond to one curve segment.")]
         [Input("openings", "A collection of closed curves representing the openings of the Panel.")]
@@ -96,6 +97,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [PreviousVersion("6.0", "BH.Engine.Structure.Create.Panel(System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
         [Description("Creates a list of Panels based on a collection of outline curves. \n" +
                      "Method will distribute the outlines such that the outermost curve will be assumed to be an external outline of a panel, and any curve contained in this outline will be assumed as an opening of this Panel. \n" +
                      "Any outline curve inside an opening will again be assumed to be the outline of a new Panel.")]
@@ -138,6 +140,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [PreviousVersion("BH.Engine.Structure.Create.Panel(BH.oM.Geometry.PlanarSurface, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
         [Description("Creates a structural Panel from a PlanarSurface, creating external edges from the ExternalBoundary and openings from the InternalBoundaries of the PlanarSurface.")]
         [Input("surface", "A planar surface used to define the geometry of the panel, i.e. the external edges and the openings.")]
         [InputFromProperty("property")]

--- a/Structure_Engine/Create/Elements/Panel.cs
+++ b/Structure_Engine/Create/Elements/Panel.cs
@@ -33,6 +33,7 @@ using BH.Engine.Geometry;
 using BH.Engine.Base;
 using System.ComponentModel;
 using BH.Engine.Analytical;
+using BH.oM.Quantities.Attributes;
 
 namespace BH.Engine.Structure
 {
@@ -76,12 +77,13 @@ namespace BH.Engine.Structure
         [InputFromProperty("property")]
         [Input("localX", "Vector to set as local x of the Panel. Default value of null gives default orientation. If this vector is not in the plane of the Panel it will get projected. If the vector is parallel to the normal of the Panel the operation will fail and the Panel local orientation will be set to default.")]
         [Input("name", "The name of the created Panel.")]
+        [Input("tolerance", "Distance tolerance, used as a margin of error for checking that the outline is closed.", typeof(Length))]
         [Output("panel", "The created Panel.")]
-        public static Panel Panel(ICurve outline, List<ICurve> openings = null, ISurfaceProperty property = null, Vector localX = null, string name = "")
+        public static Panel Panel(ICurve outline, List<ICurve> openings = null, ISurfaceProperty property = null, Vector localX = null, string name = "", double tolerance = Tolerance.Distance)
         {
             if (outline.IsNull())
                 return null;
-            else if (!outline.IIsClosed())
+            else if (!outline.IIsClosed(tolerance))
             {
                 Base.Compute.RecordError("Outline is not closed. Could not create Panel.");
                 return null;
@@ -101,8 +103,9 @@ namespace BH.Engine.Structure
         [InputFromProperty("property")]
         [Input("localX", "Vector to set as local x of the Panel. Default value of null gives default orientation. If this vector is not in the plane of the Panel it will get projected. If the vector is parallel to the normal of the Panel the operation will fail and the Panel local orientation will be set to default.")]
         [Input("name", "The name of the created Panel(s).")]
+        [Input("tolerance", "Distance tolerance, used as a margin of error for comparing the outlines.", typeof(Length))]
         [Output("panel", "The created Panel(s).")]
-        public static List<Panel> Panel(List<ICurve> outlines, ISurfaceProperty property = null, Vector localX = null, string name = "")
+        public static List<Panel> Panel(List<ICurve> outlines, ISurfaceProperty property = null, Vector localX = null, string name = "", double tolerance = Tolerance.Distance)
         {
             if (outlines.IsNullOrEmpty() || outlines.Any(x => x.IsNull()))
                 return null;
@@ -110,7 +113,7 @@ namespace BH.Engine.Structure
             List<Panel> result = new List<Panel>();
             List<List<IElement1D>> outlineEdges = outlines.Select(x => x.ISubParts().Select(y => new Edge { Curve = y } as IElement1D).ToList()).ToList();
 
-            List<List<List<IElement1D>>> sortedOutlines = outlineEdges.DistributeOutlines(true);
+            List<List<List<IElement1D>>> sortedOutlines = outlineEdges.DistributeOutlines(true, tolerance);
             foreach (List<List<IElement1D>> panelOutlines in sortedOutlines)
             {
                 Panel panel = new Panel();
@@ -140,10 +143,11 @@ namespace BH.Engine.Structure
         [InputFromProperty("property")]
         [Input("localX", "Vector to set as local x of the Panel. Default value of null gives default orientation. If this vector is not in the plane of the Panel it will get projected. If the vector is parallel to the normal of the Panel the operation will fail and the Panel local orientation will be set to default.")]
         [Input("name", "The name of the created Panel.")]
+        [Input("tolerance", "Distance tolerance, used as a margin of error for checking that the outline is closed.", typeof(Length))]
         [Output("panel", "The created Panel.")]
-        public static Panel Panel(PlanarSurface surface, ISurfaceProperty property = null, Vector localX = null, string name = "")
+        public static Panel Panel(PlanarSurface surface, ISurfaceProperty property = null, Vector localX = null, string name = "", double tolerance = Tolerance.Distance)
         {
-            return surface.IsNull() ? null : Panel(surface.ExternalBoundary, surface.InternalBoundaries.ToList(), property, localX, name);
+            return surface.IsNull() ? null : Panel(surface.ExternalBoundary, surface.InternalBoundaries.ToList(), property, localX, name, tolerance);
         }
 
         /***************************************************/

--- a/Structure_Engine/Create/Elements/Panel.cs
+++ b/Structure_Engine/Create/Elements/Panel.cs
@@ -71,7 +71,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [PreviousVersion("6.0", "BH.Engine.Structure.Create.Panel(BH.oM.Geometry.ICurve, System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
+        [PreviousVersion("6.1", "BH.Engine.Structure.Create.Panel(BH.oM.Geometry.ICurve, System.Collections.Generic.List<BH.oM.Geometry.ICurve>, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
         [Description("Creates a structural Panel from a closed curve defining the outline, and any number of closed curves defining openings.")]
         [Input("outline", "A closed Curve defining the outline of the Panel. The ExternalEdges of the Panel will be the subparts of this curve, where each edge will corespond to one curve segment.")]
         [Input("openings", "A collection of closed curves representing the openings of the Panel.")]

--- a/Structure_Engine/Create/Elements/Panel.cs
+++ b/Structure_Engine/Create/Elements/Panel.cs
@@ -140,7 +140,7 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [PreviousVersion("BH.Engine.Structure.Create.Panel(BH.oM.Geometry.PlanarSurface, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
+        [PreviousVersion("6.1", "BH.Engine.Structure.Create.Panel(BH.oM.Geometry.PlanarSurface, BH.oM.Structure.SurfaceProperties.ISurfaceProperty, BH.oM.Geometry.Vector, System.String)")]
         [Description("Creates a structural Panel from a PlanarSurface, creating external edges from the ExternalBoundary and openings from the InternalBoundaries of the PlanarSurface.")]
         [Input("surface", "A planar surface used to define the geometry of the panel, i.e. the external edges and the openings.")]
         [InputFromProperty("property")]


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2961 

Adding tolerance the the Create.Panel methods in the Structural engine. At least for the ones where that makes sense. The other ones don't require any checks that involve the tolerance.



### Test files
[CreatePlanarCurveWithTolerance.zip](https://github.com/BHoM/BHoM_Engine/files/10699657/CreatePlanarCurveWithTolerance.zip)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->