### PR TITLE
Physical_Engine: Make physical surfaces return material and volume of all content

### DIFF
--- a/Physical_Engine/Query/MaterialComposition.cs
+++ b/Physical_Engine/Query/MaterialComposition.cs
@@ -31,6 +31,7 @@ using BH.oM.Physical.Materials;
 using BH.oM.Physical.FramingProperties;
 using BH.oM.Physical.Constructions;
 using BH.oM.Quantities.Attributes;
+using BH.Engine.Matter;
 
 namespace BH.Engine.Physical
 {
@@ -67,19 +68,11 @@ namespace BH.Engine.Physical
         [Output("materialComposition", "The kind of matter the ISurface is composed of and in which ratios.")]
         public static MaterialComposition MaterialComposition(this ISurface surface)
         {
-            if (surface == null)
-            {
-                BH.Engine.Base.Compute.RecordError("Cannot query the material composition of a null surface.");
+            VolumetricMaterialTakeoff takeoff = surface.IVolumetricMaterialTakeoff();
+            if (takeoff == null)
                 return null;
-            }
 
-            if (surface.Construction == null)
-            {
-                Engine.Base.Compute.RecordError("The MaterialComposition could not be queried as no IConstruction has been assigned to the ISurface.");
-                return null;
-            }
-
-            return surface.Construction.IMaterialComposition();
+            return Matter.Create.MaterialComposition(takeoff);
         }
 
         /***************************************************/
@@ -89,36 +82,11 @@ namespace BH.Engine.Physical
         [Output("materialComposition", "The kind of matter the IOpening is composed of and in which ratios.")]
         public static MaterialComposition MaterialComposition(this IOpening opening)
         {
-            MaterialComposition materialComposition = null;
-            if (opening is Window)
-            {
-                if ((opening as Window).Construction == null)
-                {
-                    Engine.Base.Compute.RecordError("The IOpening MaterialComposition could not be calculated as no IConstruction has been assigned.");
-                    return null;
-                }
-
-                materialComposition = (opening as Window).Construction.IMaterialComposition();
-            }
-
-            if (opening is Door)
-            {
-                if ((opening as Door).Construction == null)
-                {
-                    Engine.Base.Compute.RecordError("The IOpening MaterialComposition could not be calculated as no IConstruction has been assigned.");
-                    return null;
-                }
-
-                materialComposition = (opening as Door).Construction.IMaterialComposition();
-            }
-
-            if (opening is BH.oM.Physical.Elements.Void)
-            {
-                Engine.Base.Compute.RecordError("Void's do not support constructions and therefore, contain no material composition. Returning null.");
+            VolumetricMaterialTakeoff takeoff = opening.IVolumetricMaterialTakeoff();
+            if (takeoff == null)
                 return null;
-            }
 
-            return materialComposition;
+            return Matter.Create.MaterialComposition(takeoff);
         }
 
         /***************************************************/
@@ -201,7 +169,7 @@ namespace BH.Engine.Physical
         {
             if (prop == null)
             {
-                Compute.RecordError("Cannot evaluate MaterialComposition because the Construction was null.");
+                Base.Compute.RecordError("Cannot evaluate MaterialComposition because the Construction was null.");
                 return null;
             }
 
@@ -210,13 +178,13 @@ namespace BH.Engine.Physical
 
             if (prop.Layers.All(x => x.Material == null))
             {
-                Compute.RecordError("Cannote evaluate MaterialComposition because all of the materials are null.");
+                Base.Compute.RecordError("Cannote evaluate MaterialComposition because all of the materials are null.");
                 return null;
             }
 
             if (prop.Layers.Any(x => x.Material == null))
             {
-                Compute.RecordWarning("At least one Material in a Layered surface property was null. MaterialConstruction excludes this layer, assuming it is void space.");
+                Base.Compute.RecordWarning("At least one Material in a Layered surface property was null. MaterialConstruction excludes this layer, assuming it is void space.");
             }
 
             IEnumerable<Layer> layers = prop.Layers.Where(x => x.Material != null);

--- a/Physical_Engine/Query/MaterialComposition.cs
+++ b/Physical_Engine/Query/MaterialComposition.cs
@@ -173,8 +173,17 @@ namespace BH.Engine.Physical
                 return null;
             }
 
-            if (prop.Layers.IsNullOrEmpty()) //.IsNullOrEmpty raises it's own error
+            if (prop.Layers == null) //.IsNullOrEmpty raises it's own error
+            {
+                Base.Compute.RecordError("Cannote evaluate MaterialComposition because the layers are null.");
                 return null;
+            }
+
+            if (prop.Layers.Count == 0)
+            {
+                Base.Compute.RecordWarning($"Construction {(string.IsNullOrEmpty(prop.Name) ? "NoName" : prop.Name)} does not conatin any layers. An empty MaterialComposition is returned in its place.");
+                return new MaterialComposition(new List<Material>(), new List<double>());
+            }
 
             if (prop.Layers.All(x => x.Material == null))
             {

--- a/Physical_Engine/Query/VolumetricMaterialTakeoff.cs
+++ b/Physical_Engine/Query/VolumetricMaterialTakeoff.cs
@@ -167,6 +167,11 @@ namespace BH.Engine.Physical
 
         private static VolumetricMaterialTakeoff TakeOff(double area, IConstruction construction)
         {
+            MaterialComposition comp = construction.IMaterialComposition();
+            if (comp == null)
+                return null;
+            if(comp.Materials.Count == 0)
+                return new VolumetricMaterialTakeoff(new List<Material>(), new List<double>());
             return Matter.Create.VolumetricMaterialTakeoff(construction.IMaterialComposition(), construction.IThickness() * area);
         }
 

--- a/Physical_Engine/Query/VolumetricMaterialTakeoff.cs
+++ b/Physical_Engine/Query/VolumetricMaterialTakeoff.cs
@@ -1,0 +1,175 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Physical.Constructions;
+using BH.oM.Physical.Elements;
+using BH.oM.Physical.Materials;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace BH.Engine.Physical
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Gets the volumetric material takeoff from the ISurface object. The takeoff will contain materials and volumes from the surface itself, as well as takeoffs from any openings, such as doors and windows.")]
+        [Input("surface", "The physical surface object to extract the volumetric material takeoff from.")]
+        [Output("volTakeoff", "The volumetric material takeoff based on buildup of the surface object as well as any of its inner objects, such as doors and windows.")]
+        public static VolumetricMaterialTakeoff VolumetricMaterialTakeoff(this ISurface surface)
+        {
+            if (surface == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(VolumetricMaterialTakeoff)} of a null {nameof(ISurface)}.");
+                return null;
+            }
+
+            if (surface.Location == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(VolumetricMaterialTakeoff)} of a {nameof(ISurface)} with null geometry.");
+                return null;
+            }
+
+            if (surface.Construction == null)
+            {
+                Engine.Base.Compute.RecordError($"The {nameof(VolumetricMaterialTakeoff)} could not be queried as no {nameof(IConstruction)} has been assigned to the {nameof(ISurface)}.");
+                return null;
+            }
+
+            double openingAreas = 0;
+
+            List<VolumetricMaterialTakeoff> takeoffs = new List<VolumetricMaterialTakeoff>();
+
+            foreach (IOpening opening in surface.Openings)
+            {
+                VolumetricMaterialTakeoff opeingTakeoff = opening.IVolumetricMaterialTakeoff();
+                if (opeingTakeoff == null)
+                    return null;
+
+                takeoffs.Add(opeingTakeoff);
+                openingAreas += opening.Area();
+
+            }
+            takeoffs.Add(TakeOff(surface.Location.IArea() - openingAreas, surface.Construction));
+
+            return Matter.Compute.AggregateVolumetricMaterialTakeoff(takeoffs);
+        }
+
+        /***************************************************/
+
+        [Description("Gets the volumetric material takeoff from the Void object. This will always return an empty takeoff as a void represent an area of no materiality.")]
+        [Input("surface", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Output("volTakeoff", "The volumetric material takeoff for the opening. For a void this will alwys be an empty Material Takeoff.")]
+        public static VolumetricMaterialTakeoff VolumetricMaterialTakeoff(this BH.oM.Physical.Elements.Void opening)
+        {
+            //Voids represent empty space, hence returning a completely empty composition
+            return new VolumetricMaterialTakeoff(new List<Material>(), new List<double>());
+        }
+
+        /***************************************************/
+
+        [Description("Gets the volumetric material takeoff from the Window.")]
+        [Input("surface", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Output("volTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
+        public static VolumetricMaterialTakeoff VolumetricMaterialTakeoff(this Window opening)
+        {
+            if (opening == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(VolumetricMaterialTakeoff)} of a null {nameof(Window)}.");
+                return null;
+            }
+
+            if (opening.Location == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(VolumetricMaterialTakeoff)} of a {nameof(Window)} with null geometry.");
+                return null;
+            }
+
+            if (opening.Construction == null)
+            {
+                Engine.Base.Compute.RecordError($"The {nameof(VolumetricMaterialTakeoff)} could not be queried as no {nameof(IConstruction)} has been assigned to the {nameof(Window)}.");
+                return null;
+            }
+
+            return TakeOff(opening.Location.IArea(), opening.Construction);
+        }
+
+        /***************************************************/
+
+        [Description("Gets the volumetric material takeoff from the Door.")]
+        [Input("surface", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Output("volTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
+        public static VolumetricMaterialTakeoff VolumetricMaterialTakeoff(this Door opening)
+        {
+            if (opening == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(VolumetricMaterialTakeoff)} of a null {nameof(Door)}.");
+                return null;
+            }
+
+            if (opening.Location == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(VolumetricMaterialTakeoff)} of a {nameof(Door)} with null geometry.");
+                return null;
+            }
+
+            if (opening.Construction == null)
+            {
+                Engine.Base.Compute.RecordError($"The {nameof(VolumetricMaterialTakeoff)} could not be queried as no {nameof(IConstruction)} has been assigned to the {nameof(Door)}.");
+                return null;
+            }
+
+            return TakeOff(opening.Location.IArea(), opening.Construction);
+        }
+
+        /***************************************************/
+        /**** Public Methods - Interface                ****/
+        /***************************************************/
+
+        [Description("Gets the volumetric material takeoff from the IOpening.")]
+        [Input("surface", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Output("volTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
+        public static VolumetricMaterialTakeoff IVolumetricMaterialTakeoff(this IOpening opening)
+        {
+            return VolumetricMaterialTakeoff(opening as dynamic);
+        }
+
+        /***************************************************/
+        /**** private Methods                           ****/
+        /***************************************************/
+
+        private static VolumetricMaterialTakeoff TakeOff(double area, IConstruction construction)
+        {
+            return Matter.Create.VolumetricMaterialTakeoff(construction.IMaterialComposition(), construction.IThickness() * area);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Physical_Engine/Query/VolumetricMaterialTakeoff.cs
+++ b/Physical_Engine/Query/VolumetricMaterialTakeoff.cs
@@ -85,7 +85,7 @@ namespace BH.Engine.Physical
         /***************************************************/
 
         [Description("Gets the volumetric material takeoff from the Void object. This will always return an empty takeoff as a void represent an area of no materiality.")]
-        [Input("surface", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Input("opening", "The physical opening object to extract the volumetric material takeoff from.")]
         [Output("volTakeoff", "The volumetric material takeoff for the opening. For a void this will alwys be an empty Material Takeoff.")]
         public static VolumetricMaterialTakeoff VolumetricMaterialTakeoff(this BH.oM.Physical.Elements.Void opening)
         {
@@ -96,7 +96,7 @@ namespace BH.Engine.Physical
         /***************************************************/
 
         [Description("Gets the volumetric material takeoff from the Window.")]
-        [Input("surface", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Input("opening", "The physical opening object to extract the volumetric material takeoff from.")]
         [Output("volTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
         public static VolumetricMaterialTakeoff VolumetricMaterialTakeoff(this Window opening)
         {
@@ -124,7 +124,7 @@ namespace BH.Engine.Physical
         /***************************************************/
 
         [Description("Gets the volumetric material takeoff from the Door.")]
-        [Input("surface", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Input("opening", "The physical opening object to extract the volumetric material takeoff from.")]
         [Output("volTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
         public static VolumetricMaterialTakeoff VolumetricMaterialTakeoff(this Door opening)
         {
@@ -154,7 +154,7 @@ namespace BH.Engine.Physical
         /***************************************************/
 
         [Description("Gets the volumetric material takeoff from the IOpening.")]
-        [Input("surface", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Input("opening", "The physical opening object to extract the volumetric material takeoff from.")]
         [Output("volTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
         public static VolumetricMaterialTakeoff IVolumetricMaterialTakeoff(this IOpening opening)
         {


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2895

<!-- Add short description of what has been fixed -->

Updates so that Physical ISurface objects account for inner opening type objects, such as doors and walls, for computation of SolidVolume as well as MaterialComposition.

- Add method for VolumetricMaterialTakeoff
- Make MaterialComposition method rely on new method
- Make SolidVolume rely on the new method

Important that this _is_ changing behaviour, and would impact workflows like LCA, but should be to the better. Important that people using the tools are aware of this. @enarhi when review/merged would you be able to help spread this?

Also, smaller change, is I removed all errors/warnings regarding Void type openings, as imo, it is safe to simply return 0 volume/empty material composition for this type of object, given it by definition is meant to model nothingness.



### Test files
<!-- Link to test files to validate the proposed changes -->

Testfile from issue:

[Test File](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Issue/BHoM/BHoM_Engine/Physical_Engine/%232895%20-%20Volume%20and%20MatComp%20including%20Nested%20Elems?csf=1&web=1&e=bmsy3m)

Also good ofc if this can be tested through a few cases.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->