### PR TITLE
BHoM_Engine: `IsNumeric()` to be explicit about whether enum types should be considered numeric

### DIFF
--- a/.ci/unit-tests/Base_Engine_Tests/Query/IsNumeric.cs
+++ b/.ci/unit-tests/Base_Engine_Tests/Query/IsNumeric.cs
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using BH.Engine.Base;
+using BH.Tests.Engine.Base.Query.Objects;
+using NUnit.Framework;
+using AutoBogus;
+using Shouldly;
+using BH.oM.Structure.Constraints;
+
+namespace BH.Tests.Engine.Base.Query
+{
+    public class IsNumericTests
+    {
+        [Test]
+        public void IsNumericForEnum()
+        {
+            BH.Engine.Base.Query.IsNumeric(typeof(DOFType)).ShouldBe(false);
+        }
+    }
+}

--- a/.ci/unit-tests/Base_Engine_Tests/Query/IsNumericIntegralType.cs
+++ b/.ci/unit-tests/Base_Engine_Tests/Query/IsNumericIntegralType.cs
@@ -30,19 +30,19 @@ using BH.oM.Structure.Constraints;
 
 namespace BH.Tests.Engine.Base.Query
 {
-    public class IsNumericTests
+    public class IsNumericIntegralTypeTests
     {
         [Test]
-        public void AreEnumsNumeric()
+        public void AreEnumsIntegral()
         {
-            BH.Engine.Base.Query.IsNumeric(typeof(DOFType), false).ShouldBe(false);
-            BH.Engine.Base.Query.IsNumeric(typeof(DOFType), true).ShouldBe(true);
+            BH.Engine.Base.Query.IsNumericIntegralType(typeof(DOFType), false).ShouldBe(false);
+            BH.Engine.Base.Query.IsNumericIntegralType(typeof(DOFType), true).ShouldBe(true);
 
-            BH.Engine.Base.Query.IsNumeric(typeof(DOFType)).ShouldBe(true, "By default, IsNumeric() considers enums as a numeric type.");
+            BH.Engine.Base.Query.IsNumeric(typeof(DOFType)).ShouldBe(true, "By default, IsNumericIntegralType() considers enums as a numeric integral type.");
         }
 
         [Test]
-        public void AreIntegersNumeric()
+        public void AreIntsIntegral()
         {
             BH.Engine.Base.Query.IsNumeric(10.GetType(), true).ShouldBe(true);
             BH.Engine.Base.Query.IsNumeric(10.GetType(), false).ShouldBe(true);

--- a/BHoM_Engine/Query/IsNumeric.cs
+++ b/BHoM_Engine/Query/IsNumeric.cs
@@ -29,6 +29,7 @@ namespace BH.Engine.Base
 {
     public static partial class Query
     {
+        [PreviousVersion("6.1", "BH.Engine.Base.Query.IsNumeric(System.Type)")]
         [Description("Determine whether a type is a numeric type.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]
         [Input("enumsAsNumbers", "(Optional, defaults to true) Whether `enum` types should be considered to be numeric.")]

--- a/BHoM_Engine/Query/IsNumeric.cs
+++ b/BHoM_Engine/Query/IsNumeric.cs
@@ -31,8 +31,9 @@ namespace BH.Engine.Base
     {
         [Description("Determine whether a type is a numeric type.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]
+        [Input("enumsAreNumbers", "(Optional, defaults to false) Whether `enum` types should be considered to be numeric.")]
         [Output("isNumeric", "True if the object is a numeric Type, false if not.")]
-        public static bool IsNumeric(this Type type)
+        public static bool IsNumeric(this Type type, bool enumsAreNumbers = false)
         {
             switch (Type.GetTypeCode(type))
             {
@@ -95,6 +96,7 @@ namespace BH.Engine.Base
                 case TypeCode.Int32:
                 case TypeCode.Int64:
                     return true;
+                    return !type.IsEnum || enumsAreNumbers;
                 default:
                     return false;
             }

--- a/BHoM_Engine/Query/IsNumeric.cs
+++ b/BHoM_Engine/Query/IsNumeric.cs
@@ -31,9 +31,9 @@ namespace BH.Engine.Base
     {
         [Description("Determine whether a type is a numeric type.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]
-        [Input("enumsAreNumbers", "(Optional, defaults to false) Whether `enum` types should be considered to be numeric.")]
+        [Input("enumsAreNumbers", "(Optional, defaults to true) Whether `enum` types should be considered to be numeric.")]
         [Output("isNumeric", "True if the object is a numeric Type, false if not.")]
-        public static bool IsNumeric(this Type type, bool enumsAreNumbers = false)
+        public static bool IsNumeric(this Type type, bool enumsAreNumbers = true)
         {
             switch (Type.GetTypeCode(type))
             {

--- a/BHoM_Engine/Query/IsNumeric.cs
+++ b/BHoM_Engine/Query/IsNumeric.cs
@@ -31,9 +31,9 @@ namespace BH.Engine.Base
     {
         [Description("Determine whether a type is a numeric type.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]
-        [Input("enumsAreNumbers", "(Optional, defaults to true) Whether `enum` types should be considered to be numeric.")]
+        [Input("enumsAsNumbers", "(Optional, defaults to true) Whether `enum` types should be considered to be numeric.")]
         [Output("isNumeric", "True if the object is a numeric Type, false if not.")]
-        public static bool IsNumeric(this Type type, bool enumsAreNumbers = true)
+        public static bool IsNumeric(this Type type, bool enumsAsNumbers = true)
         {
             switch (Type.GetTypeCode(type))
             {
@@ -45,10 +45,11 @@ namespace BH.Engine.Base
                 case TypeCode.Int16:
                 case TypeCode.Int32:
                 case TypeCode.Int64:
+                    return !type.IsEnum || enumsAsNumbers;
                 case TypeCode.Decimal:
                 case TypeCode.Double:
                 case TypeCode.Single:
-                    return !type.IsEnum || enumsAreNumbers;
+                    return true;
                 default:
                     return false;
             }

--- a/BHoM_Engine/Query/IsNumericFloatingPointType.cs
+++ b/BHoM_Engine/Query/IsNumericFloatingPointType.cs
@@ -29,26 +29,20 @@ namespace BH.Engine.Base
 {
     public static partial class Query
     {
-        [Description("Determine whether a type is a numeric type.")]
+        [Description("Determine whether a type is a floating-point numeric type." +
+            "\nSee https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types for more information.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]
-        [Input("enumsAreNumbers", "(Optional, defaults to false) Whether `enum` types should be considered to be numeric.")]
         [Output("isNumeric", "True if the object is a numeric Type, false if not.")]
-        public static bool IsNumeric(this Type type, bool enumsAreNumbers = false)
+        public static bool IsNumericFloatingPointType(this Type type)
         {
+            // As per https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types
+
             switch (Type.GetTypeCode(type))
             {
-                case TypeCode.Byte:
-                case TypeCode.SByte:
-                case TypeCode.UInt16:
-                case TypeCode.UInt32:
-                case TypeCode.UInt64:
-                case TypeCode.Int16:
-                case TypeCode.Int32:
-                case TypeCode.Int64:
                 case TypeCode.Decimal:
                 case TypeCode.Double:
                 case TypeCode.Single:
-                    return !type.IsEnum || enumsAreNumbers;
+                    return true;
                 default:
                     return false;
             }

--- a/BHoM_Engine/Query/IsNumericIntegralType.cs
+++ b/BHoM_Engine/Query/IsNumericIntegralType.cs
@@ -32,9 +32,9 @@ namespace BH.Engine.Base
         [Description("Determine whether a type is a integral numeric type (an integer)." +
             "\nSee https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types for more information.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]
-        [Input("enumsAreNumbers", "(Optional, defaults to true) Whether `enum` types should be considered to be numeric.")]
+        [Input("enumsAsNumbers", "(Optional, defaults to true) Whether `enum` types should be considered to be numeric.")]
         [Output("isNumeric", "True if the object is a numeric Type, false if not.")]
-        public static bool IsNumericIntegralType(this Type type, bool enumsAreNumbers = true)
+        public static bool IsNumericIntegralType(this Type type, bool enumsAsNumbers = true)
         {
             // As per https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types
 
@@ -48,7 +48,7 @@ namespace BH.Engine.Base
                 case TypeCode.Int16:
                 case TypeCode.Int32:
                 case TypeCode.Int64:
-                    return !type.IsEnum || enumsAreNumbers;
+                    return !type.IsEnum || enumsAsNumbers;
                 default:
                     return false;
             }

--- a/BHoM_Engine/Query/IsNumericIntegralType.cs
+++ b/BHoM_Engine/Query/IsNumericIntegralType.cs
@@ -32,9 +32,9 @@ namespace BH.Engine.Base
         [Description("Determine whether a type is a integral numeric type (an integer)." +
             "\nSee https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types for more information.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]
-        [Input("enumsAreNumbers", "(Optional, defaults to false) Whether `enum` types should be considered to be numeric.")]
+        [Input("enumsAreNumbers", "(Optional, defaults to true) Whether `enum` types should be considered to be numeric.")]
         [Output("isNumeric", "True if the object is a numeric Type, false if not.")]
-        public static bool IsNumericIntegralType(this Type type, bool enumsAreNumbers = false)
+        public static bool IsNumericIntegralType(this Type type, bool enumsAreNumbers = true)
         {
             // As per https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types
 

--- a/BHoM_Engine/Query/IsNumericIntegralType.cs
+++ b/BHoM_Engine/Query/IsNumericIntegralType.cs
@@ -29,12 +29,15 @@ namespace BH.Engine.Base
 {
     public static partial class Query
     {
-        [Description("Determine whether a type is a numeric type.")]
+        [Description("Determine whether a type is a integral numeric type (an integer)." +
+            "\nSee https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types for more information.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]
         [Input("enumsAreNumbers", "(Optional, defaults to false) Whether `enum` types should be considered to be numeric.")]
         [Output("isNumeric", "True if the object is a numeric Type, false if not.")]
-        public static bool IsNumeric(this Type type, bool enumsAreNumbers = false)
+        public static bool IsNumericIntegralType(this Type type, bool enumsAreNumbers = false)
         {
+            // As per https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types
+
             switch (Type.GetTypeCode(type))
             {
                 case TypeCode.Byte:
@@ -45,9 +48,6 @@ namespace BH.Engine.Base
                 case TypeCode.Int16:
                 case TypeCode.Int32:
                 case TypeCode.Int64:
-                case TypeCode.Decimal:
-                case TypeCode.Double:
-                case TypeCode.Single:
                     return !type.IsEnum || enumsAreNumbers;
                 default:
                     return false;

--- a/BHoM_Engine/Query/IsNumericIntegralType.cs
+++ b/BHoM_Engine/Query/IsNumericIntegralType.cs
@@ -29,6 +29,7 @@ namespace BH.Engine.Base
 {
     public static partial class Query
     {
+        [PreviousVersion("6.1", "BH.Engine.Base.Query.IsNumericIntegralType(System.Type)")]
         [Description("Determine whether a type is a integral numeric type (an integer)." +
             "\nSee https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types for more information.")]
         [Input("type", "Type that we want to check if it is numeric type or not.")]

--- a/Diffing_Engine/Query/NumericalDifferenceInclusion.cs
+++ b/Diffing_Engine/Query/NumericalDifferenceInclusion.cs
@@ -73,7 +73,7 @@ namespace BH.Engine.Diffing
             // Check if we specified CustomTolerances and if this difference is a number difference.
             if ((globalNumericTolerance != double.MinValue || globalSignificantFigures != int.MaxValue
                 || (namedNumericTolerances?.Any() ?? false) || (namedSignificantFigures?.Any() ?? false))
-                && (number1?.GetType().IsNumeric() ?? false) && (number2?.GetType().IsNumeric() ?? false)) // GetType() is slow; call only after checking that any custom tolerance is present.
+                && (number1?.GetType().IsNumeric(false) ?? false) && (number2?.GetType().IsNumeric(false) ?? false)) // GetType() is slow; call only after checking that any custom tolerance is present.
             {
                 // We have specified some custom tolerance in the ComparisonConfig AND this property difference is numeric.
                 // Because we have set Kellerman to retrieve any possible numerical variation,
@@ -111,7 +111,3 @@ namespace BH.Engine.Diffing
         }
     }
 }
-
-
-
-


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3025 

<!-- Add short description of what has been fixed -->

This PR adds a new `bool EnumAsNumeric = true` optional parameter to `IsNumeric()` and `IsNumericIntegralType()` methods. This is needed to clarify whether `enums` should be considered a numeric number or not. In certain contexts like Diffing (see #3025), `IsNumeric()` is used to parse a wide variety of types, and `IsNumeric` needs this option to clarify what it does, because we had Diffing failures in certain edge cases.

The default value of this new parameter `EnumAsNumeric` is set to `true`, so it keeps the same behaviour by default, avoiding problems with any existing reference to the method. The diffing engine method that needs this parameter was changed to pass `false` in.

### Test files
<!-- Link to test files to validate the proposed changes -->
Test with the newly added unit tests.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Provided a new `EnumAsNumeric` optional input to `IsNumeric()` and `IsNumericIntegralType()` methods.
