### PR TITLE
Structure_Engine: NullReferenceException on transform of a bar with null nodes fixed

### DIFF
--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -45,6 +45,12 @@ namespace BH.Engine.Structure
         [Output("transformed", "Modified Node with unchanged properties, but transformed position and orientation.")]
         public static Node Transform(this Node node, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
+            if (node == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not transform the Node because it was null.");
+                return null;
+            }
+
             if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Base.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
@@ -66,6 +72,12 @@ namespace BH.Engine.Structure
         [Output("transformed", "Modified Bar with unchanged properties, but transformed nodes and orientation.")]
         public static Bar Transform(this Bar bar, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
+            if (bar == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not transform the Bar because it was null.");
+                return null;
+            }
+
             if (bar.StartNode?.Position == null || bar.EndNode?.Position == null)
             {
                 BH.Engine.Base.Compute.RecordWarning("The bar could not be transformed because at least one of its nodes (or their location) is null.");
@@ -98,6 +110,12 @@ namespace BH.Engine.Structure
         [Output("transformed", "Modified RigidLink with unchanged properties, but transformed primary and secondary nodes.")]
         public static RigidLink Transform(this RigidLink link, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
+            if (link == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not transform the RigidLink because it was null.");
+                return null;
+            }
+
             if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Base.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
@@ -119,6 +137,12 @@ namespace BH.Engine.Structure
         [Output("transformed", "Modified Edge with unchanged properties, but transformed location.")]
         public static Edge Transform(this Edge edge, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
+            if (edge == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not transform the Edge because it was null.");
+                return null;
+            }
+
             if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Base.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
@@ -139,6 +163,12 @@ namespace BH.Engine.Structure
         [Output("transformed", "Modified Opening with unchanged properties, but transformed edges.")]
         public static Opening Transform(this Opening opening, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
+            if (opening == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not transform the Opening because it was null.");
+                return null;
+            }
+
             if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Base.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
@@ -159,6 +189,12 @@ namespace BH.Engine.Structure
         [Output("transformed", "Modified Panel with unchanged properties, but transformed edges, openings and orientation angle.")]
         public static Panel Transform(this Panel panel, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
+            if (panel == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not transform the Panel because it was null.");
+                return null;
+            }
+
             if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Base.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");
@@ -187,6 +223,12 @@ namespace BH.Engine.Structure
         [Output("transformed", "Modified FEMesh with unchanged properties, but transformed nodes.")]
         public static FEMesh Transform(this FEMesh mesh, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
+            if (mesh == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Could not transform the FEMesh because it was null.");
+                return null;
+            }
+
             if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Base.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");

--- a/Structure_Engine/Modify/Transform.cs
+++ b/Structure_Engine/Modify/Transform.cs
@@ -66,6 +66,12 @@ namespace BH.Engine.Structure
         [Output("transformed", "Modified Bar with unchanged properties, but transformed nodes and orientation.")]
         public static Bar Transform(this Bar bar, TransformMatrix transform, double tolerance = Tolerance.Distance)
         {
+            if (bar.StartNode?.Position == null || bar.EndNode?.Position == null)
+            {
+                BH.Engine.Base.Compute.RecordWarning("The bar could not be transformed because at least one of its nodes (or their location) is null.");
+                return bar;
+            }
+
             if (!transform.IsRigidTransformation(tolerance))
             {
                 BH.Engine.Base.Compute.RecordError("Transformation failed: only rigid body transformations are currently supported.");


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3029

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FStructure%5FEngine%2F%233030%2DBarTransformBug&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->