### PR TITLE
Add isUpgraded argument to DeprecateSerialiser and pass on bool

### DIFF
--- a/Serialiser_Engine/Compute/Deserialise.cs
+++ b/Serialiser_Engine/Compute/Deserialise.cs
@@ -71,7 +71,7 @@ namespace BH.Engine.Serialiser
                         version = docVersion;
                     Type type = doc["_t"].DeserialiseType(ref failed, null, version, isUpgraded);
                     if (type == null)
-                        return DeserialiseDeprecate(doc, ref failed, version) as IObject;
+                        return DeserialiseDeprecate(doc, ref failed, version, isUpgraded) as IObject;
                     else
                         return IDeserialise(bson, type, ref failed, null, version, isUpgraded);
                 }

--- a/Serialiser_Engine/Compute/Deserialise/Deprecate.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Deprecate.cs
@@ -38,12 +38,12 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static object DeserialiseDeprecate(this BsonDocument doc, ref bool failed, string version)
+        private static object DeserialiseDeprecate(this BsonDocument doc, ref bool failed, string version, bool isUpgraded)
         {
             if (string.IsNullOrEmpty(version))
                 version = doc.Version();
 
-            if (TryUpgrade(doc, version, out object upgrade))
+            if (!isUpgraded && TryUpgrade(doc, version, out object upgrade))
             {
                 failed = false;
                 return upgrade;

--- a/Serialiser_Engine/Compute/Deserialise/IObject.cs
+++ b/Serialiser_Engine/Compute/Deserialise/IObject.cs
@@ -58,7 +58,7 @@ namespace BH.Engine.Serialiser
             Type type = doc["_t"].DeserialiseType(ref failed, null, version, isUpgraded);
             if (type == null)
             {
-                return DeserialiseDeprecate(doc, ref failed, version) as IObject;
+                return DeserialiseDeprecate(doc, ref failed, version, isUpgraded) as IObject;
             }
             if (typeof(IImmutable).IsAssignableFrom(type))
                 return bson.DeserialiseImmutable(ref failed, type, version, isUpgraded);
@@ -136,7 +136,7 @@ namespace BH.Engine.Serialiser
                             }
                             else if (!isUpgraded)
                             {
-                                return DeserialiseDeprecate(doc, ref failed, version) as IObject;
+                                return DeserialiseDeprecate(doc, ref failed, version, isUpgraded) as IObject;
                             }
                             else
                             {
@@ -154,7 +154,7 @@ namespace BH.Engine.Serialiser
             {
                 if (!isUpgraded)
                 {
-                    return DeserialiseDeprecate(doc, ref failed, version) as IObject;
+                    return DeserialiseDeprecate(doc, ref failed, version, isUpgraded) as IObject;
                 }
                 else
                 {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3055

<!-- Add short description of what has been fixed -->

Add isUpgraded argument to DeprecateSerialiser and pass on bool

Especially critical for the call to this made from the main Deserialise method when the type upgrader failed, as this was the mechanism able to cause an infinite loop


### Test files
<!-- Link to test files to validate the proposed changes -->

CheckVerisoning should still pass.

Was trying to figure out a way to add a UT for this, but could not think of a simple case that is not to involved, as it require type upgrader to fail, but an explicit upgrader to run and return a faulty type.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->