### PR TITLE
Fix serialiser crash on failed

### DIFF
--- a/Serialiser_Engine/Compute/Deserialise/IObject.cs
+++ b/Serialiser_Engine/Compute/Deserialise/IObject.cs
@@ -119,17 +119,6 @@ namespace BH.Engine.Serialiser
                         {
                             object propertyValue = item.Value.IDeserialise(prop.PropertyType, ref failed, prop.GetValue(value), version, isUpgraded);
 
-                            if (failed)
-                            {
-                                if (!isUpgraded && TryUpgrade(doc, version, out IObject upgraded))
-                                    return upgraded;
-                                else
-                                {
-                                    Base.Compute.RecordError($"Failed to deserialise property {item.Name} for object of type {value?.GetType().Name ?? "unknown type"}. Custom object returned in its place.");
-                                    return DeserialiseDeprecatedCustomObject(doc, ref failed, version, false);
-                                }
-                            }
-
                             if (CanSetValueToProperty(prop.PropertyType, propertyValue))
                             {
                                 prop.SetValue(value, propertyValue);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3066 

As detailed in the issue, the BHoM UI was crashing on the deserialisation of a specific dataset. It appears that the 'failed' boolean that is passes up from properties to parents was used to force a different deserialisation behaviour inside the `SetProperties` method. 
 - The issue is that that boolean is never reset between properties. This means one incorrect property would trigger a failing behaviour on all the following ones. 
 - Deserialisation is also capable of restoring partial objects by saving the remaining properties inside CustomData. Those objects were still marked as 'failed' though causnig the whole chain of parents to come back as Custom objects. 

As the only place where the 'failed' boolean is used for a conditional check is inside the `SetProperty` method (where it is incorrectly used), I would recommend to get rid of that boolean altogether. We agreed with @FraserGreenroyd  to do this in two phases:
- Remove the use of the 'failed' boolean inside the `SetProperty` method (this PR)
-  Remove the 'failed' boolean as an argument of all methods (all are private). Issue raised here: https://github.com/BHoM/BHoM_Engine/issues/3087

### Test files
 - [x] Make sure the versioning check is passing
 - [x] Test on older versioning datasets (at least a year coverage)
 - [x] Test on datasets found in the BHoM folder

