### PR TITLE
Remove the 'failed' bool parameter in the deserialiser methods

### DIFF
--- a/Serialiser_Engine/Compute/Deserialise/Array.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Array.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static T[] DeserialiseArray<T>(this BsonValue bson, ref bool failed, T[] value, string version, bool isUpgraded)
+        private static T[] DeserialiseArray<T>(this BsonValue bson, T[] value, string version, bool isUpgraded)
         {
             bson = ExtractValue(bson);
             if (bson.IsBsonNull)
@@ -47,20 +47,19 @@ namespace BH.Engine.Serialiser
             else if (!bson.IsBsonArray)
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise an array and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
 
             List<T> values = new List<T>();
             foreach (BsonValue item in bson.AsBsonArray)
-                values.Add((T)item.IDeserialise(typeof(T), ref failed, null, version, isUpgraded));
+                values.Add((T)item.IDeserialise(typeof(T), null, version, isUpgraded));
 
             return values.ToArray();
         }
 
         /*******************************************/
 
-        private static T[,] DeserialiseArray<T>(this BsonValue bson, ref bool failed, T[,] value, string version, bool isUpgraded)
+        private static T[,] DeserialiseArray<T>(this BsonValue bson, T[,] value, string version, bool isUpgraded)
         {
             bson = ExtractValue(bson);
             if (bson.IsBsonNull)
@@ -70,13 +69,12 @@ namespace BH.Engine.Serialiser
             else if (!bson.IsBsonArray)
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise an array and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
 
             List<T[]> values = new List<T[]>();
             foreach (BsonValue item in bson.AsBsonArray)
-                values.Add(item.DeserialiseArray(ref failed, new T[0], version, isUpgraded));
+                values.Add(item.DeserialiseArray(new T[0], version, isUpgraded));
 
             int maxLength = values.Select(x => x.Length).Max();
             T[,] array = new T[values.Count, maxLength];

--- a/Serialiser_Engine/Compute/Deserialise/Bitmap.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Bitmap.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static Bitmap DeserialiseBitmap(this BsonValue bson, ref bool failed, Bitmap value = null)
+        private static Bitmap DeserialiseBitmap(this BsonValue bson, Bitmap value = null)
         {
             if (bson.IsBsonNull)
                 return null;
@@ -54,7 +54,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a bitmap and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
 

--- a/Serialiser_Engine/Compute/Deserialise/Boolean.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Boolean.cs
@@ -36,14 +36,13 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static bool DeserialiseBoolean(this BsonValue bson, ref bool failed, bool value = false)
+        private static bool DeserialiseBoolean(this BsonValue bson, bool value = false)
         {
             if (bson.IsBoolean)
                 return bson.AsBoolean;
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a bool and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/Color.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Color.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static Color DeserialiseColour(this BsonValue bson, ref bool failed, Color value = default(Color))
+        private static Color DeserialiseColour(this BsonValue bson, Color value = default(Color))
         {
             if (bson.IsBsonDocument)
             {
@@ -48,7 +48,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a color and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/CustomObject.cs
+++ b/Serialiser_Engine/Compute/Deserialise/CustomObject.cs
@@ -36,14 +36,13 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static CustomObject DeserialiseCustomObject(this BsonValue bson, ref bool failed, CustomObject value, string version, bool isUpgraded)
+        private static CustomObject DeserialiseCustomObject(this BsonValue bson, CustomObject value, string version, bool isUpgraded)
         {
             if (bson.IsBsonNull)
                 return null;
             else if (!bson.IsBsonDocument)
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a Custom object and received " + bson.ToString() + " instead.");
-                failed = true;
                 return new CustomObject();
             }
 
@@ -63,22 +62,22 @@ namespace BH.Engine.Serialiser
                         // ignore
                         break;
                     case "Name":
-                        value.Name = element.Value.DeserialiseString(ref failed, value.Name);
+                        value.Name = element.Value.DeserialiseString(value.Name);
                         break;
                     case "BHoM_Guid":
-                        value.BHoM_Guid = element.Value.DeserialiseGuid(ref failed, value.BHoM_Guid);
+                        value.BHoM_Guid = element.Value.DeserialiseGuid(value.BHoM_Guid);
                         break;
                     case "Tags":
-                        value.Tags = element.Value.DeserialiseHashSet(ref failed, value.Tags, version, isUpgraded);
+                        value.Tags = element.Value.DeserialiseHashSet(value.Tags, version, isUpgraded);
                         break;
                     case "Fragments":
-                        value.Fragments = element.Value.DeserialiseFragmentSet(ref failed, value.Fragments, version, isUpgraded);
+                        value.Fragments = element.Value.DeserialiseFragmentSet(value.Fragments, version, isUpgraded);
                         break;
                     case "CustomData":
-                        value.CustomData = element.Value.DeserialiseDictionary(ref failed, value.CustomData, version, isUpgraded);
+                        value.CustomData = element.Value.DeserialiseDictionary(value.CustomData, version, isUpgraded);
                         break;
                     default:
-                        value.CustomData[element.Name] = element.Value.IDeserialise(ref failed, version, isUpgraded);
+                        value.CustomData[element.Name] = element.Value.IDeserialise(version, isUpgraded);
                         break;
                 }
             }

--- a/Serialiser_Engine/Compute/Deserialise/DataTable.cs
+++ b/Serialiser_Engine/Compute/Deserialise/DataTable.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static DataTable DeserialiseDataTable(this BsonValue bson, ref bool failed, DataTable value, string version, bool isUpgraded)
+        private static DataTable DeserialiseDataTable(this BsonValue bson, DataTable value, string version, bool isUpgraded)
         {
             bson = ExtractValue(bson);
             if (bson.IsBsonNull)
@@ -52,7 +52,7 @@ namespace BH.Engine.Serialiser
 
                 foreach (BsonDocument doc in bson.AsBsonArray.OfType<BsonDocument>())
                 {
-                    Dictionary<string, object> rowData = doc.DeserialiseDictionary(ref failed, new Dictionary<string, object>(), version, isUpgraded);
+                    Dictionary<string, object> rowData = doc.DeserialiseDictionary(new Dictionary<string, object>(), version, isUpgraded);
                     if (!initialised)
                     {
                         foreach (var kvp in rowData)
@@ -76,7 +76,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a data table and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/DateTime.cs
+++ b/Serialiser_Engine/Compute/Deserialise/DateTime.cs
@@ -36,14 +36,13 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static DateTime DeserialiseDateTime(this BsonValue bson, ref bool failed, DateTime value = default(DateTime))
+        private static DateTime DeserialiseDateTime(this BsonValue bson, DateTime value = default(DateTime))
         {
             if (bson.IsValidDateTime)
                 return bson.ToUniversalTime();
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a date and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/DateTimeOffset.cs
+++ b/Serialiser_Engine/Compute/Deserialise/DateTimeOffset.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static DateTimeOffset DeserialiseDateTimeOffset(this BsonValue bson, ref bool failed, DateTimeOffset value = default(DateTimeOffset))
+        private static DateTimeOffset DeserialiseDateTimeOffset(this BsonValue bson, DateTimeOffset value = default(DateTimeOffset))
         {
             bson = ExtractValue(bson);
             BsonArray array;
@@ -47,14 +47,12 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a DateTimeOffset and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
 
             if (array.Count != 2)
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a DateTimeOffset and received " + bson.ToString() + " instead. This should be represented with an array of two values.");
-                failed = true;
                 return value;
             }
 

--- a/Serialiser_Engine/Compute/Deserialise/Decimal.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Decimal.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static decimal DeserialiseDecimal(this BsonValue bson, ref bool failed, decimal value = 0)
+        private static decimal DeserialiseDecimal(this BsonValue bson, decimal value = 0)
         {
             if (bson.IsDecimal128)
                 return bson.AsDecimal;
@@ -45,7 +45,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a decimal and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/Deprecate.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Deprecate.cs
@@ -38,32 +38,30 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static object DeserialiseDeprecate(this BsonDocument doc, ref bool failed, string version, bool isUpgraded)
+        private static object DeserialiseDeprecate(this BsonDocument doc, string version, bool isUpgraded)
         {
             if (string.IsNullOrEmpty(version))
                 version = doc.Version();
 
             if (!isUpgraded && TryUpgrade(doc, version, out object upgrade))
             {
-                failed = false;
                 return upgrade;
             }
             else
             {
-                return DeserialiseDeprecatedCustomObject(doc, ref failed, version);
+                return DeserialiseDeprecatedCustomObject(doc, version);
             }
             
         }
 
         /*******************************************/
 
-        private static CustomObject DeserialiseDeprecatedCustomObject(this BsonDocument doc, ref bool failed, string version, bool raiseError = true)
+        private static CustomObject DeserialiseDeprecatedCustomObject(this BsonDocument doc, string version, bool raiseError = true)
         {
             if(raiseError)
                 Engine.Base.Compute.RecordError($"The type {doc["_t"]} from version {(string.IsNullOrEmpty(version) ? "unknown" : version)} is unknown -> data returned as custom objects.");
 
-            failed = true;
-            CustomObject customObj = DeserialiseCustomObject(doc, ref failed, null, "", true);
+            CustomObject customObj = DeserialiseCustomObject(doc, null, "", true);
             customObj.CustomData["_t"] = doc["_t"];
             customObj.CustomData["_bhomVersion"] = version;
             return customObj;
@@ -80,8 +78,7 @@ namespace BH.Engine.Serialiser
 
             if (newDoc != null && !newDoc.Equals(doc))
             {
-                bool failed = false;
-                upgraded = IDeserialise(newDoc, ref failed, "", true) as T;
+                upgraded = IDeserialise(newDoc, "", true) as T;
                 return upgraded != null;
             }
             else

--- a/Serialiser_Engine/Compute/Deserialise/Dictionary.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Dictionary.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
 
-        private static Dictionary<TK,TV> DeserialiseDictionary<TK,TV>(this BsonValue bson, ref bool failed, Dictionary<TK, TV> value, string version, bool isUpgraded)
+        private static Dictionary<TK,TV> DeserialiseDictionary<TK,TV>(this BsonValue bson, Dictionary<TK, TV> value, string version, bool isUpgraded)
         {
             if (value == null)
                 value = new Dictionary<TK, TV>();
@@ -50,7 +50,7 @@ namespace BH.Engine.Serialiser
                 foreach (BsonElement item in bson.AsBsonDocument)
                 {
                     if(item.Name != "_t" && item.Name != "_bhomVersion")
-                        value[(TK)(object)(item.Name)] = (TV)item.Value.IDeserialise(typeof(TV), ref failed, null, version, isUpgraded);
+                        value[(TK)(object)(item.Name)] = (TV)item.Value.IDeserialise(typeof(TV), null, version, isUpgraded);
                 }
             }
             else if (typeof(TK) != typeof(string))
@@ -60,7 +60,6 @@ namespace BH.Engine.Serialiser
                 if (array == null)
                 {           
                     BH.Engine.Base.Compute.RecordError("Expected to deserialise a dictionary and received " + bson.ToString() + " instead.");
-                    failed = true;
                 }
                 else
                 {
@@ -69,14 +68,13 @@ namespace BH.Engine.Serialiser
                         if (item.IsBsonDocument)
                         {
                             BsonDocument doc = item.AsBsonDocument;
-                            TK key = (TK)(doc["k"].IDeserialise(typeof(TK), ref failed, null, version, isUpgraded));
-                            TV val = (TV)(doc["v"].IDeserialise(typeof(TV), ref failed, null, version, isUpgraded));
+                            TK key = (TK)(doc["k"].IDeserialise(typeof(TK), null, version, isUpgraded));
+                            TV val = (TV)(doc["v"].IDeserialise(typeof(TV), null, version, isUpgraded));
                             if (key != null)
                                 value[key] = val;
                             else
                             {
                                 BH.Engine.Base.Compute.RecordError("Cannot assign a null key to a dictionary.");
-                                failed = true;
                             }
                         }
                     }
@@ -85,7 +83,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a dictionary and received " + bson.ToString() + " instead.");
-                failed = true;
             }
 
             return value;

--- a/Serialiser_Engine/Compute/Deserialise/Double.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Double.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static double DeserialiseDouble(this BsonValue bson, ref bool failed, double value = 0)
+        private static double DeserialiseDouble(this BsonValue bson, double value = 0)
         {
             if (bson.IsDouble)
                 return bson.AsDouble;
@@ -49,7 +49,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a double and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/Enum.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Enum.cs
@@ -36,17 +36,16 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
 
-        private static T DeserialiseEnum<T>(this BsonValue bson, ref bool failed, T value, string version, bool isUpgraded) where T : Enum
+        private static T DeserialiseEnum<T>(this BsonValue bson, T value, string version, bool isUpgraded) where T : Enum
         {
             if (bson.IsString)
                 value = BH.Engine.Base.Compute.ParseEnum<T>(bson.AsString);
             else if (bson.IsBsonDocument)
             {
-                Type type = DeserialiseType(bson["TypeName"], ref failed, null, version, isUpgraded);
+                Type type = DeserialiseType(bson["TypeName"], null, version, isUpgraded);
                 if (type != typeof(T))
                 {
                     BH.Engine.Base.Compute.RecordError("The type of enum to deserialise doesn't match. Expected " + typeof(T).ToString() + " and got " + type.ToString() + " instead.");
-                    failed = true;
                 }
                 else
                     value = BH.Engine.Base.Compute.ParseEnum<T>(bson["Value"].AsString);
@@ -56,7 +55,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise an enum and received " + bson.ToString() + " instead.");
-                failed = true;
             }
 
             return value;
@@ -64,12 +62,12 @@ namespace BH.Engine.Serialiser
 
         /*******************************************/
 
-        private static Enum DeserialiseEnumTopLevel(this BsonValue bson, ref bool failed, Enum value, string version, bool isUpgraded)
+        private static Enum DeserialiseEnumTopLevel(this BsonValue bson, Enum value, string version, bool isUpgraded)
         {
             if (bson.IsBsonDocument)
             {
-                Type type = DeserialiseType(bson["TypeName"], ref failed, null, version, isUpgraded);
-                return DeserialiseEnum(bson, ref failed, EnsureNotNull(value, type) as dynamic, version, isUpgraded);
+                Type type = DeserialiseType(bson["TypeName"], null, version, isUpgraded);
+                return DeserialiseEnum(bson, EnsureNotNull(value, type) as dynamic, version, isUpgraded);
             }
 
             return null;

--- a/Serialiser_Engine/Compute/Deserialise/Float.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Float.cs
@@ -36,14 +36,13 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static float DeserialiseFloat(this BsonValue bson, ref bool failed, float value = 0)
+        private static float DeserialiseFloat(this BsonValue bson, float value = 0)
         {
             if (bson.IsDouble)
                 return (float)bson.AsDouble;
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a float and received " + bson.ToString() + " instead.");
-                failed = true; 
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/FragmentSet.cs
+++ b/Serialiser_Engine/Compute/Deserialise/FragmentSet.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static FragmentSet DeserialiseFragmentSet(this BsonValue bson, ref bool failed, FragmentSet value, string version, bool isUpgraded)
+        private static FragmentSet DeserialiseFragmentSet(this BsonValue bson, FragmentSet value, string version, bool isUpgraded)
         {
             if (value == null)
                 value = new FragmentSet();
@@ -61,7 +61,7 @@ namespace BH.Engine.Serialiser
             {
                 foreach (BsonValue item in array)
                 {
-                    IFragment fragment = item.IDeserialise(ref failed, version, isUpgraded) as IFragment;
+                    IFragment fragment = item.IDeserialise(version, isUpgraded) as IFragment;
                     if (fragment != null)
                         value.Add(fragment);
                 }
@@ -69,7 +69,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a FragmentSet and received " + bson.ToString() + " instead.");
-                failed = true;
             }
 
             return value;

--- a/Serialiser_Engine/Compute/Deserialise/Guid.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Guid.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static Guid DeserialiseGuid(this BsonValue bson, ref bool failed, Guid value = default(Guid))
+        private static Guid DeserialiseGuid(this BsonValue bson, Guid value = default(Guid))
         {
             if (bson.IsGuid)
                 return bson.AsGuid;
@@ -45,7 +45,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a Guid and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/HashSet.cs
+++ b/Serialiser_Engine/Compute/Deserialise/HashSet.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static HashSet<T> DeserialiseHashSet<T>(this BsonValue bson, ref bool failed, HashSet<T> value, string version, bool isUpgraded)
+        private static HashSet<T> DeserialiseHashSet<T>(this BsonValue bson, HashSet<T> value, string version, bool isUpgraded)
         {
             if (bson.IsBsonNull)
                 return null;
@@ -49,7 +49,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a HashSet and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
 
@@ -57,7 +56,7 @@ namespace BH.Engine.Serialiser
                 value = new HashSet<T>();
 
             foreach (BsonValue item in array)
-                value.Add((T)item.IDeserialise(typeof(T), ref failed, null, version, isUpgraded));
+                value.Add((T)item.IDeserialise(typeof(T), null, version, isUpgraded));
 
             return value;
         }

--- a/Serialiser_Engine/Compute/Deserialise/Immutable.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Immutable.cs
@@ -39,14 +39,13 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static IObject DeserialiseImmutable(this BsonValue bson, ref bool failed, Type targetType, string version, bool isUpgraded)
+        private static IObject DeserialiseImmutable(this BsonValue bson, Type targetType, string version, bool isUpgraded)
         {
             if (bson.IsBsonNull)
                 return null;
             else if (!bson.IsBsonDocument)
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise an Immutable object and received " + bson.ToString() + " instead.");
-                failed = true;
                 return null;
             }
 
@@ -71,7 +70,7 @@ namespace BH.Engine.Serialiser
                     List<object> arguments = new List<object>();
                     foreach (var match in matches)
                     {
-                        object propertyValue = IDeserialise(match.Properties.First().Value, match.Parameter.ParameterType, ref failed, null, version, isUpgraded);
+                        object propertyValue = IDeserialise(match.Properties.First().Value, match.Parameter.ParameterType, null, version, isUpgraded);
                         if (CanSetValueToProperty(match.Parameter.ParameterType, propertyValue))
                             arguments.Add(propertyValue);
                         else
@@ -86,7 +85,7 @@ namespace BH.Engine.Serialiser
                         IImmutable result = ctor.Invoke(arguments.ToArray()) as IImmutable;
 
                         if (result != null)
-                            return SetProperties(doc, ref failed, targetType, result, version, isUpgraded) as IImmutable;
+                            return SetProperties(doc, targetType, result, version, isUpgraded) as IImmutable;
                     }
                 }
 
@@ -106,8 +105,7 @@ namespace BH.Engine.Serialiser
                         message+= $" the following parameter(s) missing on the serialised document, required to be able to create the object: {string.Join(",", matches.Where(x => x.Properties.Count() != 1).Select(x => x.Parameter.Name))}.";
                     }
                     Base.Compute.RecordError(message);
-                    failed = true;
-                    return DeserialiseDeprecatedCustomObject(doc, ref failed, version);
+                    return DeserialiseDeprecatedCustomObject(doc, version);
                 }
             }
 

--- a/Serialiser_Engine/Compute/Deserialise/IntPtr.cs
+++ b/Serialiser_Engine/Compute/Deserialise/IntPtr.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static IntPtr DeserialiseIntPtr(this BsonValue bson, ref bool failed, IntPtr value = default(IntPtr))
+        private static IntPtr DeserialiseIntPtr(this BsonValue bson, IntPtr value = default(IntPtr))
         {
             bson = ExtractValue(bson);
 
@@ -47,7 +47,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise an IntPtr and received " + bson.ToString() + " instead.");
-                failed = true; 
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/Integer.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Integer.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static int DeserialiseInteger(this BsonValue bson, ref bool failed, int value = 0)
+        private static int DeserialiseInteger(this BsonValue bson, int value = 0)
         {
             if (bson.IsInt32)
                 return bson.AsInt32;
@@ -47,7 +47,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise an integer and received " + bson.ToString() + " instead.");
-                failed = true; 
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/List.cs
+++ b/Serialiser_Engine/Compute/Deserialise/List.cs
@@ -36,14 +36,13 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static List<T> DeserialiseList<T>(this BsonValue bson, ref bool failed, List<T> value, string version, bool isUpgraded)
+        private static List<T> DeserialiseList<T>(this BsonValue bson, List<T> value, string version, bool isUpgraded)
         {
             bson = ExtractValue(bson);
 
             if (!bson.IsBsonArray)
             { 
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a List and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
 
@@ -51,7 +50,7 @@ namespace BH.Engine.Serialiser
                 value = new List<T>();
 
             foreach (BsonValue item in bson.AsBsonArray)
-                value.Add((T)item.IDeserialise(typeof(T), ref failed, null, version, isUpgraded));
+                value.Add((T)item.IDeserialise(typeof(T), null, version, isUpgraded));
 
             return value;
         }

--- a/Serialiser_Engine/Compute/Deserialise/Long.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Long.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static long DeserialiseLong(this BsonValue bson, ref bool failed, long value = 0)
+        private static long DeserialiseLong(this BsonValue bson, long value = 0)
         {
             if (bson.IsInt64)
                 return bson.AsInt64;
@@ -47,7 +47,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a long and received " + bson.ToString() + " instead.");
-                failed = true; 
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/Nullable.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Nullable.cs
@@ -36,14 +36,14 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static object DeserialiseNullable(this BsonValue bson, ref bool failed, Type targetType, string version, bool isUpgraded)
+        private static object DeserialiseNullable(this BsonValue bson, Type targetType, string version, bool isUpgraded)
         {
             if (bson.IsBsonNull)
                 return null;
             else
             {
                 Type itemType = targetType.GetGenericArguments()[0];
-                return IDeserialise(bson, targetType, ref failed, null, version, isUpgraded);
+                return IDeserialise(bson, targetType, null, version, isUpgraded);
             }
         }
 

--- a/Serialiser_Engine/Compute/Deserialise/ReadOnlyCollection.cs
+++ b/Serialiser_Engine/Compute/Deserialise/ReadOnlyCollection.cs
@@ -37,9 +37,9 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static ReadOnlyCollection<T> DeserialiseReadOnlyCollection<T>(this BsonValue bson, ref bool failed, List<T> value, string version, bool isUpgraded)
+        private static ReadOnlyCollection<T> DeserialiseReadOnlyCollection<T>(this BsonValue bson, List<T> value, string version, bool isUpgraded)
         {
-            return new ReadOnlyCollection<T>(DeserialiseList<T>(bson, ref failed, value, version, isUpgraded));
+            return new ReadOnlyCollection<T>(DeserialiseList<T>(bson, value, version, isUpgraded));
         }
 
         /*******************************************/

--- a/Serialiser_Engine/Compute/Deserialise/Regex.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Regex.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static Regex DeserialiseRegex(this BsonValue bson, ref bool failed, Regex value = null)
+        private static Regex DeserialiseRegex(this BsonValue bson, Regex value = null)
         {
             bson = ExtractValue(bson);
 
@@ -48,7 +48,6 @@ namespace BH.Engine.Serialiser
             else 
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a regex and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             } 
         }

--- a/Serialiser_Engine/Compute/Deserialise/Short.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Short.cs
@@ -36,14 +36,13 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static short DeserialiseShort(this BsonValue bson, ref bool failed, short value = 0)
+        private static short DeserialiseShort(this BsonValue bson, short value = 0)
         {
             if (bson.IsInt32)
                 return (short)bson.AsInt32;
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a short and received " + bson.ToString() + " instead.");
-                failed = true; 
                 return value;
             }
         }

--- a/Serialiser_Engine/Compute/Deserialise/SortedDictionary.cs
+++ b/Serialiser_Engine/Compute/Deserialise/SortedDictionary.cs
@@ -37,9 +37,9 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static SortedDictionary<TK, TV> DeserialiseSortedDictionary<TK, TV>(this BsonValue bson, ref bool failed, Dictionary<TK, TV> value, string version, bool isUpgraded)
+        private static SortedDictionary<TK, TV> DeserialiseSortedDictionary<TK, TV>(this BsonValue bson, Dictionary<TK, TV> value, string version, bool isUpgraded)
         {
-            return new SortedDictionary<TK, TV>(DeserialiseDictionary<TK, TV>(bson, ref failed, value, version, isUpgraded));
+            return new SortedDictionary<TK, TV>(DeserialiseDictionary<TK, TV>(bson, value, version, isUpgraded));
         }
 
         /*******************************************/

--- a/Serialiser_Engine/Compute/Deserialise/String.cs
+++ b/Serialiser_Engine/Compute/Deserialise/String.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static string DeserialiseString(this BsonValue bson, ref bool failed, string value = "")
+        private static string DeserialiseString(this BsonValue bson, string value = "")
         {
             if (bson.IsBsonNull)
                 return null;
@@ -58,7 +58,6 @@ namespace BH.Engine.Serialiser
                 return bson.AsDecimal.ToString();
 
             BH.Engine.Base.Compute.RecordError("Expected to deserialise a string and received " + bson.ToString() + " instead.");
-            failed = true;
             return value;
         }
 

--- a/Serialiser_Engine/Compute/Deserialise/TimeSpan.cs
+++ b/Serialiser_Engine/Compute/Deserialise/TimeSpan.cs
@@ -36,20 +36,18 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static TimeSpan DeserialiseTimeSpan(this BsonValue bson, ref bool failed, TimeSpan value = default(TimeSpan))
+        private static TimeSpan DeserialiseTimeSpan(this BsonValue bson, TimeSpan value = default(TimeSpan))
         {
             bson = ExtractValue(bson);
 
             if (!bson.IsString)
             { 
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a timespan and received " + bson.ToString() + " instead.");
-                failed = true;
                 return value;
             }
 
             if (!TimeSpan.TryParse(bson.AsString, out value))
             {
-                failed = true;
                 BH.Engine.Base.Compute.RecordError("Failed to convert " + bson.AsString + " to a TimeSpan.");
             }
             return value;

--- a/Serialiser_Engine/Compute/Deserialise/Tuple.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Tuple.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
 
-        private static object DeserialiseTuple(this BsonValue bson, ref bool failed, Type targetType, string version, bool isUpgraded)
+        private static object DeserialiseTuple(this BsonValue bson, Type targetType, string version, bool isUpgraded)
         {
             BsonValue value = bson;
             if (bson.IsBsonDocument)
@@ -45,16 +45,15 @@ namespace BH.Engine.Serialiser
                 BsonDocument doc = bson.AsBsonDocument;
                 value = doc["_v"];
                 if (targetType == null)
-                    targetType = doc["_t"].DeserialiseType(ref failed, targetType, version, isUpgraded);
+                    targetType = doc["_t"].DeserialiseType(targetType, version, isUpgraded);
             }
             
             Type[] keys = targetType.GetGenericArguments();
             object tuple = Activator.CreateInstance(targetType, keys.Select(x => GetDefaultValue(x)).ToArray());
             if (tuple != null)
-                return DeserialiseTuple(value, ref failed, tuple as dynamic, version, isUpgraded);
+                return DeserialiseTuple(value, tuple as dynamic, version, isUpgraded);
             else
             {
-                failed = true;
                 BH.Engine.Base.Compute.RecordError("Failed to create tuple from " + bson.ToString());
                 return null;
             }
@@ -62,7 +61,7 @@ namespace BH.Engine.Serialiser
 
         /*******************************************/
 
-        private static Tuple<T1, T2> DeserialiseTuple<T1, T2>(this BsonValue bson, ref bool failed, Tuple<T1, T2> value, string version, bool isUpgraded)
+        private static Tuple<T1, T2> DeserialiseTuple<T1, T2>(this BsonValue bson, Tuple<T1, T2> value, string version, bool isUpgraded)
         {
             if (bson.IsBsonNull)
                 return null;
@@ -71,21 +70,19 @@ namespace BH.Engine.Serialiser
                 BsonArray array = bson.AsBsonArray;
                 if (array.Count != 2)
                 {
-                    failed = true;
                     BH.Engine.Base.Compute.RecordError("The tuple was expected to be represented by an array of size 2.");
                 }
                 else
                 {
                     return new Tuple<T1, T2>(
-                        (T1)array[0].IDeserialise(typeof(T1), ref failed, value.Item1, version, isUpgraded),
-                        (T2)array[1].IDeserialise(typeof(T2), ref failed, value.Item2, version, isUpgraded)
+                        (T1)array[0].IDeserialise(typeof(T1), value.Item1, version, isUpgraded),
+                        (T2)array[1].IDeserialise(typeof(T2), value.Item2, version, isUpgraded)
                     );
                 }
             }
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a tuple and received " + bson.ToString() + " instead.");
-                failed = true;
             }
 
             return value;
@@ -93,7 +90,7 @@ namespace BH.Engine.Serialiser
 
         /*******************************************/
         
-        private static Tuple<T1, T2, T3> DeserialiseTuple<T1, T2, T3>(this BsonValue bson, ref bool failed, Tuple<T1, T2, T3> value, string version, bool isUpgraded)
+        private static Tuple<T1, T2, T3> DeserialiseTuple<T1, T2, T3>(this BsonValue bson, Tuple<T1, T2, T3> value, string version, bool isUpgraded)
         {
             if (bson.IsBsonNull)
                 return null;
@@ -102,22 +99,20 @@ namespace BH.Engine.Serialiser
                 BsonArray array = bson.AsBsonArray;
                 if (array.Count != 3)
                 {
-                    failed = true;
                     BH.Engine.Base.Compute.RecordError("The tuple was expected t obe represented by an array of size 3.");
                 }
                 else
                 {
                     return new Tuple<T1, T2, T3>(
-                        (T1)array[0].IDeserialise(typeof(T1), ref failed, value.Item1, version, isUpgraded),
-                        (T2)array[1].IDeserialise(typeof(T2), ref failed, value.Item2, version, isUpgraded),
-                        (T3)array[2].IDeserialise(typeof(T3), ref failed, value.Item3, version, isUpgraded)
+                        (T1)array[0].IDeserialise(typeof(T1), value.Item1, version, isUpgraded),
+                        (T2)array[1].IDeserialise(typeof(T2), value.Item2, version, isUpgraded),
+                        (T3)array[2].IDeserialise(typeof(T3), value.Item3, version, isUpgraded)
                     );
                 }
             }
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a tuple and received " + bson.ToString() + " instead.");
-                failed = true;
             }
 
             return value;
@@ -125,7 +120,7 @@ namespace BH.Engine.Serialiser
 
         /*******************************************/
         
-        private static Tuple<T1, T2, T3, T4> DeserialiseTuple<T1, T2, T3, T4>(this BsonValue bson, ref bool failed, Tuple<T1, T2, T3, T4> value, string version, bool isUpgraded)
+        private static Tuple<T1, T2, T3, T4> DeserialiseTuple<T1, T2, T3, T4>(this BsonValue bson, Tuple<T1, T2, T3, T4> value, string version, bool isUpgraded)
         {
             if (bson.IsBsonNull)
                 return null;
@@ -134,23 +129,21 @@ namespace BH.Engine.Serialiser
                 BsonArray array = bson.AsBsonArray;
                 if (array.Count != 4)
                 {
-                    failed = true;
                     BH.Engine.Base.Compute.RecordError("The tuple was expected t obe represented by an array of size 4.");
                 }
                 else
                 {
                     return new Tuple<T1, T2, T3, T4>(
-                        (T1)array[0].IDeserialise(typeof(T1), ref failed, value.Item1, version, isUpgraded),
-                        (T2)array[1].IDeserialise(typeof(T2), ref failed, value.Item2, version, isUpgraded),
-                        (T3)array[2].IDeserialise(typeof(T3), ref failed, value.Item3, version, isUpgraded),
-                        (T4)array[3].IDeserialise(typeof(T4), ref failed, value.Item4, version, isUpgraded)
+                        (T1)array[0].IDeserialise(typeof(T1), value.Item1, version, isUpgraded),
+                        (T2)array[1].IDeserialise(typeof(T2), value.Item2, version, isUpgraded),
+                        (T3)array[2].IDeserialise(typeof(T3), value.Item3, version, isUpgraded),
+                        (T4)array[3].IDeserialise(typeof(T4), value.Item4, version, isUpgraded)
                     );
                 }
             }
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a tuple and received " + bson.ToString() + " instead.");
-                failed = true;
             }
 
             return value;
@@ -158,7 +151,7 @@ namespace BH.Engine.Serialiser
 
         /*******************************************/
         
-        private static Tuple<T1, T2, T3, T4, T5> DeserialiseTuple<T1, T2, T3, T4, T5>(this BsonValue bson, ref bool failed, Tuple<T1, T2, T3, T4, T5> value, string version, bool isUpgraded)
+        private static Tuple<T1, T2, T3, T4, T5> DeserialiseTuple<T1, T2, T3, T4, T5>(this BsonValue bson, Tuple<T1, T2, T3, T4, T5> value, string version, bool isUpgraded)
         {
             if (bson.IsBsonNull)
                 return null;
@@ -167,24 +160,22 @@ namespace BH.Engine.Serialiser
                 BsonArray array = bson.AsBsonArray;
                 if (array.Count != 5)
                 {
-                    failed = true;
                     BH.Engine.Base.Compute.RecordError("The tuple was expected t obe represented by an array of size 5.");
                 }
                 else
                 {
                     return new Tuple<T1, T2, T3, T4, T5>(
-                        (T1)array[0].IDeserialise(typeof(T1), ref failed, value.Item1, version, isUpgraded),
-                        (T2)array[1].IDeserialise(typeof(T2), ref failed, value.Item2, version, isUpgraded),
-                        (T3)array[2].IDeserialise(typeof(T3), ref failed, value.Item3, version, isUpgraded),
-                        (T4)array[3].IDeserialise(typeof(T4), ref failed, value.Item4, version, isUpgraded),
-                        (T5)array[4].IDeserialise(typeof(T5), ref failed, value.Item5, version, isUpgraded)
+                        (T1)array[0].IDeserialise(typeof(T1), value.Item1, version, isUpgraded),
+                        (T2)array[1].IDeserialise(typeof(T2), value.Item2, version, isUpgraded),
+                        (T3)array[2].IDeserialise(typeof(T3), value.Item3, version, isUpgraded),
+                        (T4)array[3].IDeserialise(typeof(T4), value.Item4, version, isUpgraded),
+                        (T5)array[4].IDeserialise(typeof(T5), value.Item5, version, isUpgraded)
                     );
                 }
             }
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a tuple and received " + bson.ToString() + " instead.");
-                failed = true;
             }
 
             return value;

--- a/Serialiser_Engine/Compute/Deserialise/Type.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Type.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static Type DeserialiseType(this BsonValue bson, ref bool failed, Type value, string version, bool isUpgraded)
+        private static Type DeserialiseType(this BsonValue bson, Type value, string version, bool isUpgraded)
         {
             // Handle the case where the type is represented as a string
             if (bson.IsBsonNull)
@@ -63,7 +63,6 @@ namespace BH.Engine.Serialiser
                         return type;
                     else
                     {
-                        failed = true;
                         BH.Engine.Base.Compute.RecordError("Failed to convert the string into a type: " + bson.AsString);
                         return value;
                     }
@@ -73,7 +72,6 @@ namespace BH.Engine.Serialiser
             // Then, if the bson is not a docuemnt, return an error
             if (!bson.IsBsonDocument)
             {
-                failed = true;
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise a type and received " + bson.ToString() + " instead.");
                 return value;
             }
@@ -90,16 +88,16 @@ namespace BH.Engine.Serialiser
                 switch (name)
                 {
                     case "Name":
-                        fullName = element.Value.DeserialiseString(ref failed);
+                        fullName = element.Value.DeserialiseString();
                         break;
                     case "_bhomVersion":
-                        version = element.Value.DeserialiseString(ref failed);
+                        version = element.Value.DeserialiseString();
                         break;
                     case "GenericArguments":
-                        genericTypes = element.Value.DeserialiseList(ref failed, genericTypes, version, isUpgraded);
+                        genericTypes = element.Value.DeserialiseList(genericTypes, version, isUpgraded);
                         break;
                     case "Constraints":
-                        constraints = element.Value.DeserialiseList(ref failed, constraints, version, isUpgraded);
+                        constraints = element.Value.DeserialiseList(constraints, version, isUpgraded);
                         break;
                 }
             }

--- a/Serialiser_Engine/Compute/Deserialise/UnsignedInteger.cs
+++ b/Serialiser_Engine/Compute/Deserialise/UnsignedInteger.cs
@@ -36,7 +36,7 @@ namespace BH.Engine.Serialiser
         /**** Private Methods                   ****/
         /*******************************************/
         
-        private static uint DeserialiseUnsignedInteger(this BsonValue bson, ref bool failed, uint value = 0)
+        private static uint DeserialiseUnsignedInteger(this BsonValue bson, uint value = 0)
         {
             if (bson.IsInt32)
                 return (uint)bson.AsInt32;
@@ -47,7 +47,6 @@ namespace BH.Engine.Serialiser
             else
             {
                 BH.Engine.Base.Compute.RecordError("Expected to deserialise an unsigned integer and received " + bson.ToString() + " instead.");
-                failed = true; 
                 return value;
             }
         }


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3087 

Parameter removed from all methods as it wasn't used anymore and its purpose could be misunderstood. 


### Test files
Just make sure that all objects are still (de)serialising correctly.
@FraserGreenroyd , I'll leave it to you to decide how much testing you need on this PR. Since this PR doesn't actually change the behaviour of the serialiser, I am pretty relax about it. 


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->