### PR TITLE
Security_Engine: Camera Field of View - cone shape calculation fix

### DIFF
--- a/Security_Engine/Query/ViewCone.cs
+++ b/Security_Engine/Query/ViewCone.cs
@@ -46,13 +46,13 @@ namespace BH.Engine.Security
 
             Point cameraLocation = cameraDevice.EyePosition;
             Point targetLocation = cameraDevice.TargetPosition;
-            double radius = targetLocation.Distance(cameraLocation);
-            double horizontal = cameraDevice.HorizontalFieldOfView;
-            double angle = Math.Asin(horizontal / (2 * radius)) * 2;
+            double coneRadius = targetLocation.Distance(cameraLocation);
+            double coneArcLength = cameraDevice.HorizontalFieldOfView;
+            double coneAngle = Math.Asin(coneArcLength / (2 * coneRadius)) * 2;
 
-            Vector direction = BH.Engine.Geometry.Create.Vector(cameraLocation, cameraDevice.TargetPosition);
-            Vector startPointDir = direction.Rotate(-angle / 2, Vector.ZAxis);
-            Vector endPointDir = direction.Rotate(angle / 2, Vector.ZAxis);
+            Vector viewDirection = BH.Engine.Geometry.Create.Vector(cameraLocation, cameraDevice.TargetPosition);
+            Vector startPointDir = viewDirection.Rotate(-coneAngle / 2, Vector.ZAxis);
+            Vector endPointDir = viewDirection.Rotate(coneAngle / 2, Vector.ZAxis);
             Point startPoint = cameraLocation + startPointDir;
             Point endPoint = cameraLocation + endPointDir;
 

--- a/Security_Engine/Query/ViewCone.cs
+++ b/Security_Engine/Query/ViewCone.cs
@@ -48,7 +48,7 @@ namespace BH.Engine.Security
             Point targetLocation = cameraDevice.TargetPosition;
             double radius = targetLocation.Distance(cameraLocation);
             double horizontal = cameraDevice.HorizontalFieldOfView;
-            double angle = Math.Atan(horizontal / radius);
+            double angle = Math.Asin(horizontal / (2 * radius)) * 2;
 
             Vector direction = BH.Engine.Geometry.Create.Vector(cameraLocation, cameraDevice.TargetPosition);
             Vector startPointDir = direction.Rotate(-angle / 2, Vector.ZAxis);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3100 

<!-- Add short description of what has been fixed -->
Corrected calculation of camera field of view cone shape. This change is to precise the value of horizontal field of view:

Before (HoV = 1000):
![image](https://github.com/BHoM/BHoM_Engine/assets/71321938/ddaa94ea-a575-4de6-9520-0e1a9c802cb9)

After (HoV = 1000):
![image](https://github.com/BHoM/BHoM_Engine/assets/71321938/f28d0bed-313c-466c-b12f-8856c4c2bd83)


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->