### PR TITLE
Facade_Engine: Added Facade GeneralMaterialTakeoff methods

### DIFF
--- a/Facade_Engine/Query/GeneralMaterialTakeoff.cs
+++ b/Facade_Engine/Query/GeneralMaterialTakeoff.cs
@@ -34,6 +34,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using BH.oM.Facade.SectionProperties;
+using BH.oM.Geometry;
 
 namespace BH.Engine.Facade
 {
@@ -75,11 +76,10 @@ namespace BH.Engine.Facade
             {
                 GeneralMaterialTakeoff openingTakeoff = opening.GeneralMaterialTakeoff();
                 if (openingTakeoff == null)
-                    return null;
+                    continue;
 
                 takeoffs.Add(openingTakeoff);
                 openingAreas += opening.Area();
-
             }
 
             foreach (FrameEdge edge in panel.ExternalEdges)
@@ -92,7 +92,6 @@ namespace BH.Engine.Facade
         }
 
         /***************************************************/
-
 
         [Description("Gets the volumetric material takeoff from the Opening.")]
         [Input("opening", "The facade opening object to extract the general material takeoff from.")]
@@ -130,7 +129,6 @@ namespace BH.Engine.Facade
 
         /***************************************************/
 
-
         [Description("Gets the general material takeoff from the FrameEdge.")]
         [Input("edge", "The frame edge to extract the general material takeoff from.")]
         [Output("genTakeoff", "The general material takeoff for the FrameEdge.")]
@@ -165,11 +163,25 @@ namespace BH.Engine.Facade
         /***************************************************/
 
         [Description("Gets the volumetric material takeoff from the IOpening.")]
-        [Input("opening", "The physical opening object to extract the volumetric material takeoff from.")]
-        [Output("genTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
+        [Input("opening", "The physical opening object to extract the general material takeoff from.")]
+        [Output("genTakeoff", "The general material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
         public static GeneralMaterialTakeoff IGeneralMaterialTakeoff(this IOpening opening)
         {
             return GeneralMaterialTakeoff(opening as dynamic);
+        }
+
+
+        /***************************************************/
+        /**** Private Methods - Fallbacks               ****/
+        /***************************************************/
+
+        [Description("Gets the volumetric material takeoff from the object.")]
+        [Input("obj", "The object to extract the material takeoff from.")]
+        [Output("genTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
+        public static GeneralMaterialTakeoff IGeneralMaterialTakeoff(this object obj)
+        {
+            Base.Compute.RecordWarning("General Material Takeoff for object of type " + obj.GetType().Name + " is not implemented.");
+            return null;
         }
 
         /***************************************************/

--- a/Facade_Engine/Query/GeneralMaterialTakeoff.cs
+++ b/Facade_Engine/Query/GeneralMaterialTakeoff.cs
@@ -178,7 +178,7 @@ namespace BH.Engine.Facade
         [Description("Gets the volumetric material takeoff from the object.")]
         [Input("obj", "The object to extract the material takeoff from.")]
         [Output("genTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
-        public static GeneralMaterialTakeoff IGeneralMaterialTakeoff(this object obj)
+        public static GeneralMaterialTakeoff GeneralMaterialTakeoff(this object obj)
         {
             Base.Compute.RecordError("General Material Takeoff for object of type " + obj.GetType().Name + " is not implemented.");
             return null;

--- a/Facade_Engine/Query/GeneralMaterialTakeoff.cs
+++ b/Facade_Engine/Query/GeneralMaterialTakeoff.cs
@@ -157,7 +157,6 @@ namespace BH.Engine.Facade
             return Matter.Create.GeneralMaterialTakeoff(volTakeoff);
         }
 
-
         /***************************************************/
         /**** Public Methods - Interface                ****/
         /***************************************************/
@@ -170,7 +169,6 @@ namespace BH.Engine.Facade
             return GeneralMaterialTakeoff(opening as dynamic);
         }
 
-
         /***************************************************/
         /**** Private Methods - Fallbacks               ****/
         /***************************************************/
@@ -178,7 +176,7 @@ namespace BH.Engine.Facade
         [Description("Gets the volumetric material takeoff from the object.")]
         [Input("obj", "The object to extract the material takeoff from.")]
         [Output("genTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
-        public static GeneralMaterialTakeoff GeneralMaterialTakeoff(this object obj)
+        private static GeneralMaterialTakeoff GeneralMaterialTakeoff(this object obj)
         {
             Base.Compute.RecordError("General Material Takeoff for object of type " + obj.GetType().Name + " is not implemented.");
             return null;

--- a/Facade_Engine/Query/GeneralMaterialTakeoff.cs
+++ b/Facade_Engine/Query/GeneralMaterialTakeoff.cs
@@ -1,0 +1,177 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Physical.Constructions;
+using BH.oM.Physical.Elements;
+using BH.oM.Physical.Materials;
+using BH.oM.Facade.Elements;
+using BH.oM.Quantities.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using BH.oM.Facade.SectionProperties;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Gets the general material takeoff from the panel object. The takeoff will contain materials and volumes, mass and areas from the panel itself, as well as takeoffs from any openings.")]
+        [Input("panel", "The facade panel object to extract the general material takeoff from.")]
+        [Output("genTakeoff", "The general material takeoff based on buildup of the panel object as well as any of its openings.")]
+        public static GeneralMaterialTakeoff GeneralMaterialTakeoff(this Panel panel)
+        {
+            if (panel == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(GeneralMaterialTakeoff)} of a null {nameof(Panel)}.");
+                return null;
+            }
+
+            //Add null check for opening geo
+            if (panel.ExternalEdges == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(GeneralMaterialTakeoff)} of a {nameof(Panel)} with null geometry.");
+                return null;
+            }
+
+            if (panel.Construction == null)
+            {
+                Engine.Base.Compute.RecordError($"The {nameof(GeneralMaterialTakeoff)} could not be queried as no {nameof(IConstruction)} has been assigned to the {nameof(Panel)}.");
+                return null;
+            }
+
+            double openingAreas = 0;
+
+            List<GeneralMaterialTakeoff> takeoffs = new List<GeneralMaterialTakeoff>();
+
+            foreach (Opening opening in panel.Openings)
+            {
+                GeneralMaterialTakeoff openingTakeoff = opening.GeneralMaterialTakeoff();
+                if (openingTakeoff == null)
+                    return null;
+
+                takeoffs.Add(openingTakeoff);
+                openingAreas += opening.Area();
+
+            }
+
+            foreach (FrameEdge edge in panel.ExternalEdges)
+            {
+                takeoffs.Add(GeneralMaterialTakeoff(edge));
+            }
+            takeoffs.Add(Physical.Query.IGeneralMaterialTakeoff(panel.Construction, panel.Area()));
+
+            return Matter.Compute.AggregateGeneralMaterialTakeoff(takeoffs);
+        }
+
+        /***************************************************/
+
+
+        [Description("Gets the volumetric material takeoff from the Opening.")]
+        [Input("opening", "The facade opening object to extract the general material takeoff from.")]
+        [Output("genTakeoff", "The general material takeoff for the opening.")]
+        public static GeneralMaterialTakeoff GeneralMaterialTakeoff(this Opening opening)
+        {
+            if (opening == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(GeneralMaterialTakeoff)} of a null {nameof(Opening)}.");
+                return null;
+            }
+
+            if (opening.Edges == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(GeneralMaterialTakeoff)} of a {nameof(Opening)} with null geometry.");
+                return null;
+            }
+
+            if (opening.OpeningConstruction as Construction == null)
+            {
+                Engine.Base.Compute.RecordError($"The {nameof(GeneralMaterialTakeoff)} could not be queried as no {nameof(IConstruction)} has been assigned to the {nameof(Opening)}.");
+                return null;
+            }
+
+            List<GeneralMaterialTakeoff> takeoffs = new List<GeneralMaterialTakeoff>();
+
+            foreach (FrameEdge edge in opening.Edges)
+            {
+                takeoffs.Add(GeneralMaterialTakeoff(edge));
+            }
+            takeoffs.Add(Physical.Query.IGeneralMaterialTakeoff(opening.OpeningConstruction, opening.ComponentAreas().Item1));
+
+            return Matter.Compute.AggregateGeneralMaterialTakeoff(takeoffs);
+        }
+
+        /***************************************************/
+
+
+        [Description("Gets the general material takeoff from the FrameEdge.")]
+        [Input("edge", "The frame edge to extract the general material takeoff from.")]
+        [Output("genTakeoff", "The general material takeoff for the FrameEdge.")]
+        public static GeneralMaterialTakeoff GeneralMaterialTakeoff(this FrameEdge edge)
+        {
+            if (edge == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(GeneralMaterialTakeoff)} of a null {nameof(FrameEdge)}.");
+                return null;
+            }
+
+            if (edge.Curve == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot query the {nameof(GeneralMaterialTakeoff)} of a {nameof(FrameEdge)} with null geometry.");
+                return null;
+            }
+
+            if (edge.FrameEdgeProperty == null)
+            {
+                Engine.Base.Compute.RecordError($"The {nameof(GeneralMaterialTakeoff)} could not be queried as no {nameof(FrameEdgeProperty)} has been assigned to the {nameof(FrameEdge)}.");
+                return null;
+            }
+
+            VolumetricMaterialTakeoff volTakeoff = Matter.Create.VolumetricMaterialTakeoff(edge.MaterialComposition(), edge.SolidVolume());
+            
+            return Matter.Create.GeneralMaterialTakeoff(volTakeoff);
+        }
+
+
+        /***************************************************/
+        /**** Public Methods - Interface                ****/
+        /***************************************************/
+
+        [Description("Gets the volumetric material takeoff from the IOpening.")]
+        [Input("opening", "The physical opening object to extract the volumetric material takeoff from.")]
+        [Output("genTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
+        public static GeneralMaterialTakeoff IGeneralMaterialTakeoff(this IOpening opening)
+        {
+            return GeneralMaterialTakeoff(opening as dynamic);
+        }
+
+        /***************************************************/
+    }
+}

--- a/Facade_Engine/Query/GeneralMaterialTakeoff.cs
+++ b/Facade_Engine/Query/GeneralMaterialTakeoff.cs
@@ -180,7 +180,7 @@ namespace BH.Engine.Facade
         [Output("genTakeoff", "The volumetric material takeoff for the opening, made of up the volume and materiality of the construction and surface area.")]
         public static GeneralMaterialTakeoff IGeneralMaterialTakeoff(this object obj)
         {
-            Base.Compute.RecordWarning("General Material Takeoff for object of type " + obj.GetType().Name + " is not implemented.");
+            Base.Compute.RecordError("General Material Takeoff for object of type " + obj.GetType().Name + " is not implemented.");
             return null;
         }
 


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3091 

Added `GeneralMaterialTakeoff` methods for Facade namespace, so that takeoffs for these elements properly account for area and volumes.


### Test files
[Test File](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Facade_Engine/%233091-AreaTakeoffFix?csf=1&web=1&e=bPXCod)

To test, check the Panel, Opening, etc elements and confirm area takeoffs and LCA values work correctly for the Area EPD/material applied. 

### Additional comments
I have implemented this for Facade elements within Facade_Engine. Technically we could implement higher, but it seems to make sense with how @IsakNaslundBh has implemented this and others, allowing for specific approaches within namespaces as needed. It makes for a bit more redundant code, but allows for custom bits such as the implementation of opening area accounting for frame width required for Facade Openings.