### PR TITLE
Serialiser_Engine: `FromJson()` to Trim the text before attempting to read it 

### DIFF
--- a/Serialiser_Engine/Convert/Json.cs
+++ b/Serialiser_Engine/Convert/Json.cs
@@ -29,6 +29,7 @@ using BH.oM.Base.Attributes;
 using System;
 using System.Collections;
 using BH.oM.Base;
+using BH.Engine.Base;
 
 namespace BH.Engine.Serialiser
 {
@@ -63,11 +64,13 @@ namespace BH.Engine.Serialiser
         [Output("obj", "Object recovered from the Json string")]
         public static object FromJson(string json)
         {
-            if (json == "")
-            {
+            if (string.IsNullOrWhiteSpace(json))
                 return null;
-            }
-            else if (json.StartsWith("{"))
+
+            // Trim the json to remove any trailing or initial whitespace/newline (#3109).
+            json = json.Trim();
+
+            if (json.StartsWith("{"))
             {
                 BsonDocument document;
                 if (BsonDocument.TryParse(json, out document))
@@ -87,7 +90,6 @@ namespace BH.Engine.Serialiser
 
                 return FromJsonArray(json);
             }
-
             else
             {
                 // Could we do something when a string is not a valid json?


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3109

<!-- Add short description of what has been fixed -->

The json text is trimmed before attempting to read it. See #3109 for a longer description.

This helps solving issues reading files with trailing/initial newlines/whitespaces, in particular for workflows that @pawelbaran highlighted in https://github.com/BHoM/File_Toolkit/issues/161 (if you go there, make sure you read its closing comment https://github.com/BHoM/File_Toolkit/issues/161#issuecomment-1640364782).

### Test files
<!-- Link to test files to validate the proposed changes -->
Attached in #3109.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

### Additional comments
<!-- As required -->