### PR TITLE
Settings_Engine: Add central settings management

### DIFF
--- a/BHoM_Engine.sln
+++ b/BHoM_Engine.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.1684
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33801.468
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BHoM_Engine", "BHoM_Engine\BHoM_Engine.csproj", "{AEAF161D-8206-40B8-93A7-67ABEBF2EE19}"
 EndProject
@@ -52,6 +52,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Structure_Engine", "Structure_Engine\Structure_Engine.csproj", "{0C8044E4-3C1E-4138-9223-65A0CFB2113F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Versioning_Engine", "Versioning_Engine\Versioning_Engine.csproj", "{28D7ABDA-43DC-4A63-8C5F-D3B137E0CD21}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Settings_Engine", "Settings_Engine\Settings_Engine.csproj", "{EFCA10EB-D1A0-48B6-8E2D-07986B2AE171}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -159,6 +161,10 @@ Global
 		{28D7ABDA-43DC-4A63-8C5F-D3B137E0CD21}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{28D7ABDA-43DC-4A63-8C5F-D3B137E0CD21}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{28D7ABDA-43DC-4A63-8C5F-D3B137E0CD21}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EFCA10EB-D1A0-48B6-8E2D-07986B2AE171}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EFCA10EB-D1A0-48B6-8E2D-07986B2AE171}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EFCA10EB-D1A0-48B6-8E2D-07986B2AE171}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EFCA10EB-D1A0-48B6-8E2D-07986B2AE171}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Settings_Engine/Compute/LoadSettings.cs
+++ b/Settings_Engine/Compute/LoadSettings.cs
@@ -38,7 +38,9 @@ namespace BH.Engine.Settings
                 try
                 {
                     ISettings settings = BH.Engine.Serialiser.Convert.FromJson(contents) as ISettings;
-                    Global.BHoMSettings.TryAdd(settings.GetType(), settings);
+                    Type type = settings.GetType();
+                    Global.BHoMSettings[type] = settings;
+                    Global.BHoMSettingsFilePaths[type] = file;
                 }
                 catch (Exception ex)
                 {

--- a/Settings_Engine/Compute/LoadSettings.cs
+++ b/Settings_Engine/Compute/LoadSettings.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 
-namespace BH.Engine.Serialiser
+namespace BH.Engine.Settings
 {
     public static partial class Compute
     {

--- a/Settings_Engine/Compute/LoadSettings.cs
+++ b/Settings_Engine/Compute/LoadSettings.cs
@@ -1,0 +1,50 @@
+﻿using BH.Engine.Base;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Text;
+
+namespace BH.Engine.Serialiser
+{
+    public static partial class Compute
+    {
+        [Description("Load all the JSON settings stored within the provided folder into memory. If no folder is provided, the default folder of %ProgramData%/BHoM/Settings is used instead. All JSON files are scraped within the directory (including subdirectories) and deserialised to ISettings objects.")]
+        [Input("settingsFolder", "Optional input to determine where to load settings from. Defaults to %ProgramData%/BHoM/Settings if no folder is provided.")]
+        public static void LoadSettings(string settingsFolder = null)
+        {
+            if (string.IsNullOrEmpty(settingsFolder))
+                settingsFolder = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Settings"); //Defaults to C:/ProgramData/BHoM/Settings if no folder is provided
+
+            var settingsFiles = Directory.EnumerateFiles(settingsFolder, "*.json", SearchOption.AllDirectories);
+
+            foreach (var file in settingsFiles)
+            {
+                string contents = "";
+                try
+                {
+                    contents = File.ReadAllText(file);
+                }
+                catch (Exception ex)
+                {
+                    BH.Engine.Base.Compute.RecordError(ex, $"Error when trying to read settings file: {file}.");
+                }
+
+                if (string.IsNullOrEmpty(contents))
+                    continue;
+
+                try
+                {
+                    ISettings settings = BH.Engine.Serialiser.Convert.FromJson(contents) as ISettings;
+                    Global.BHoMSettings.TryAdd(settings.GetType(), settings);
+                }
+                catch (Exception ex)
+                {
+                    BH.Engine.Base.Compute.RecordWarning(ex, $"Cannot deserialise the contents of {file} to an ISettings object.");
+                }
+            }
+        }
+    }
+}

--- a/Settings_Engine/Compute/SaveSettings.cs
+++ b/Settings_Engine/Compute/SaveSettings.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace BH.Engine.Settings
@@ -12,13 +13,18 @@ namespace BH.Engine.Settings
     {
         [Description("Save a single instance of settings to the specified file path. If no file path is provided, it will default to %ProgramData%/BHoM/Settings/{settingsType}.json - if a file with that name already exists, it will be overwritten.")]
         [Input("settings", "The settings object to save as JSON in the specified file path.")]
+        [Input("run", "Boolean toggle to determine whether to run the method. Useful for Visual Programming to prevent settings being saved/overwritten before providing a file path if desired.")]
         [Input("filePath", "Optional file path of where to save the file. If the file already exists, it will be overwritten.")]
-        public static void SaveSettings(ISettings settings, string filePath = null)
+        [Output("success", "True if the settings have been successfully saved, false otherwise.")]
+        public static bool SaveSettings(ISettings settings, bool run = false, string filePath = null)
         {
+            if (!run)
+                return false;
+
             if(settings == null)
             {
                 BH.Engine.Base.Compute.RecordError($"Cannot save null settings.");
-                return;
+                return false;
             }
 
             if(string.IsNullOrEmpty(filePath))
@@ -32,16 +38,25 @@ namespace BH.Engine.Settings
             catch(Exception ex)
             {
                 BH.Engine.Base.Compute.RecordError(ex, $"Error occurred when trying to save settings of type {settings.GetType()} to file path {filePath}.");
+                return false;
             }
+
+            return true;
         }
 
         [Description("Saves all settings in memory to their respective files. Settings are saved back to the same file they were loaded from, overwriting them if they've changed. If settings were added during runtime and do not have an associated file, then a new file will be created with the name {settingsType}.json. If no folder is specified, the default of %ProgramData%/BHoM/Settings/{settingsType}.json will be used.")]
         [Input("outputDirectory", "Optional input to specify where to save settings file to. If the provided output directory differs from the saved load directory, settings will be saved in the provided output directory and not where they were originally loaded from.")]
-        public static void SaveSettings(string outputDirectory = null)
+        [Input("run", "Boolean toggle to determine whether to run the method. Useful for Visual Programming to prevent settings being saved/overwritten before providing a file path if desired.")]
+        [Output("success", "True if the settings have been successfully saved, false otherwise.")]
+        public static bool SaveSettings(string outputDirectory = null, bool run = false)
         {
+            if (!run)
+                return false;
+
             if (string.IsNullOrEmpty(outputDirectory))
                 outputDirectory = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Settings");
 
+            bool allSuccess = true;
             foreach(var kvp in Global.BHoMSettings)
             {
                 string loadedFrom = "";
@@ -51,8 +66,14 @@ namespace BH.Engine.Settings
                 if (string.IsNullOrEmpty(loadedFrom))
                     loadedFrom = Path.Combine(outputDirectory, $"{kvp.Value.GetType()}.json");
 
-                SaveSettings(kvp.Value, loadedFrom);
+                if (!SaveSettings(kvp.Value, true, loadedFrom))
+                {
+                    BH.Engine.Base.Compute.RecordError($"Settings of type {kvp.Key} could not be saved to {loadedFrom}.");
+                    allSuccess = false;
+                }
             }
+
+            return allSuccess;
         }
     }
 }

--- a/Settings_Engine/Compute/SaveSettings.cs
+++ b/Settings_Engine/Compute/SaveSettings.cs
@@ -1,0 +1,58 @@
+﻿using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Text;
+
+namespace BH.Engine.Settings
+{
+    public static partial class Compute
+    {
+        [Description("Save a single instance of settings to the specified file path. If no file path is provided, it will default to %ProgramData%/BHoM/Settings/{settingsType}.json - if a file with that name already exists, it will be overwritten.")]
+        [Input("settings", "The settings object to save as JSON in the specified file path.")]
+        [Input("filePath", "Optional file path of where to save the file. If the file already exists, it will be overwritten.")]
+        public static void SaveSettings(ISettings settings, string filePath = null)
+        {
+            if(settings == null)
+            {
+                BH.Engine.Base.Compute.RecordError($"Cannot save null settings.");
+                return;
+            }
+
+            if(string.IsNullOrEmpty(filePath))
+                filePath = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Settings", $"{settings.GetType()}.json");
+
+            var json = BH.Engine.Serialiser.Convert.ToJson(settings);
+            try
+            {
+                System.IO.File.WriteAllText(filePath, json);
+            }
+            catch(Exception ex)
+            {
+                BH.Engine.Base.Compute.RecordError(ex, $"Error occurred when trying to save settings of type {settings.GetType()} to file path {filePath}.");
+            }
+        }
+
+        [Description("Saves all settings in memory to their respective files. Settings are saved back to the same file they were loaded from, overwriting them if they've changed. If settings were added during runtime and do not have an associated file, then a new file will be created with the name {settingsType}.json. If no folder is specified, the default of %ProgramData%/BHoM/Settings/{settingsType}.json will be used.")]
+        [Input("outputDirectory", "Optional input to specify where to save settings file to. If the provided output directory differs from the saved load directory, settings will be saved in the provided output directory and not where they were originally loaded from.")]
+        public static void SaveSettings(string outputDirectory = null)
+        {
+            if (string.IsNullOrEmpty(outputDirectory))
+                outputDirectory = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Settings");
+
+            foreach(var kvp in Global.BHoMSettings)
+            {
+                string loadedFrom = "";
+                if(Global.BHoMSettingsFilePaths.ContainsKey(kvp.Key) && Global.BHoMSettingsFilePaths[kvp.Key].Contains(outputDirectory))
+                    loadedFrom = Global.BHoMSettingsFilePaths[kvp.Key]; //Save to the loaded file path if one is stored, and the output directory matches the load path. If the output directory does not match the load path, then this is skipped and the default below is used.
+
+                if (string.IsNullOrEmpty(loadedFrom))
+                    loadedFrom = Path.Combine(outputDirectory, $"{kvp.Value.GetType()}.json");
+
+                SaveSettings(kvp.Value, loadedFrom);
+            }
+        }
+    }
+}

--- a/Settings_Engine/Modify/UpdateSettings.cs
+++ b/Settings_Engine/Modify/UpdateSettings.cs
@@ -1,0 +1,26 @@
+﻿using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace BH.Engine.Settings
+{
+    public static partial class Modify
+    {
+        [Description("Update settings in memory with the provided settings object. If the settings already exist in memory, they will be updated to the ones provided. If they do not exist in memory, they will be added.")]
+        [Input("settings", "New settings to update or add to memory.")]
+        public static void UpdateSettings(ISettings settings)
+        {
+            if (settings == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Cannot update null settings.");
+                return;
+            }
+
+            Type type = settings.GetType();
+            Global.BHoMSettings[settings.GetType()] = settings;
+        }
+    }
+}

--- a/Settings_Engine/Objects/Global.cs
+++ b/Settings_Engine/Objects/Global.cs
@@ -1,0 +1,40 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.oM.Base;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace BH.Engine.Base
+{
+    internal static class Global
+    {
+        /***************************************************/
+        /****     Internal properties - collections     ****/
+        /***************************************************/
+        internal static ConcurrentDictionary<Type, ISettings> BHoMSettings { get; set; } = new ConcurrentDictionary<Type, ISettings>();
+    }
+}
+
+

--- a/Settings_Engine/Objects/Global.cs
+++ b/Settings_Engine/Objects/Global.cs
@@ -26,7 +26,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace BH.Engine.Base
+namespace BH.Engine.Settings
 {
     internal static class Global
     {

--- a/Settings_Engine/Objects/Global.cs
+++ b/Settings_Engine/Objects/Global.cs
@@ -34,6 +34,7 @@ namespace BH.Engine.Settings
         /****     Internal properties - collections     ****/
         /***************************************************/
         internal static ConcurrentDictionary<Type, ISettings> BHoMSettings { get; set; } = new ConcurrentDictionary<Type, ISettings>();
+        internal static ConcurrentDictionary<Type, string> BHoMSettingsFilePaths { get; set; } = new ConcurrentDictionary<Type, string>(); //Store where settings came from for saving on shut down
     }
 }
 

--- a/Settings_Engine/Query/GetSettings.cs
+++ b/Settings_Engine/Query/GetSettings.cs
@@ -11,18 +11,18 @@ namespace BH.Engine.Settings
     public static partial class Query
     {
         [Description("Obtain settings of the specified type if they exist in memory.")]
+        [Input("type", "The type of settings you want to obtain.")]
         [Output("settings", "The requested settings if they exist in memory. If they don't exist, a default is returned instead.")]
-        public static T GetSettings<T>()
+        public static object GetSettings(Type type)
         {
-            Type type = typeof(T);
             ISettings settings = null;
-            if(!Global.BHoMSettings.TryGetValue(type, out settings))
+            if (!Global.BHoMSettings.TryGetValue(type, out settings))
             {
-                BH.Engine.Base.Compute.RecordError($"Could not find settings of type {type} loaded in memory.");
-                return default(T);
+                BH.Engine.Base.Compute.RecordWarning($"Could not find settings of type {type} loaded in memory. Returning a default instance of the settings object instead.");
+                return Activator.CreateInstance(type);
             }
 
-            return (T)settings;
+            return settings;
         }
     }
 }

--- a/Settings_Engine/Query/GetSettings.cs
+++ b/Settings_Engine/Query/GetSettings.cs
@@ -1,0 +1,28 @@
+﻿using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Management;
+using System.Text;
+
+namespace BH.Engine.Settings
+{
+    public static partial class Query
+    {
+        [Description("Obtain settings of the specified type if they exist in memory.")]
+        [Output("settings", "The requested settings if they exist in memory. If they don't exist, a default is returned instead.")]
+        public static T GetSettings<T>()
+        {
+            Type type = typeof(T);
+            ISettings settings = null;
+            if(!Global.BHoMSettings.TryGetValue(type, out settings))
+            {
+                BH.Engine.Base.Compute.RecordError($"Could not find settings of type {type} loaded in memory.");
+                return default(T);
+            }
+
+            return (T)settings;
+        }
+    }
+}

--- a/Settings_Engine/Query/GetSettings.cs
+++ b/Settings_Engine/Query/GetSettings.cs
@@ -19,7 +19,30 @@ namespace BH.Engine.Settings
             if (!Global.BHoMSettings.TryGetValue(type, out settings))
             {
                 BH.Engine.Base.Compute.RecordWarning($"Could not find settings of type {type} loaded in memory. Returning a default instance of the settings object instead.");
-                return Activator.CreateInstance(type);
+                ISettings obj = null;
+                try
+                {
+                    var activator = Activator.CreateInstance(type);
+
+                    try
+                    {
+                        obj = activator as ISettings;
+                    }
+                    catch(Exception ex)
+                    {
+                        BH.Engine.Base.Compute.RecordError(ex, $"Could not cast object of type {activator.GetType()} to an ISettings object. Settings not saved in memory.");
+                        return activator;
+                    }
+                }
+                catch(Exception ex)
+                {
+                    BH.Engine.Base.Compute.RecordError(ex, $"Could not create instance of object of type {type}.");
+                    return null;
+                }
+
+                Global.BHoMSettings[type] = obj;
+
+                return obj;
             }
 
             return settings;

--- a/Settings_Engine/Query/GetSettings.cs
+++ b/Settings_Engine/Query/GetSettings.cs
@@ -48,7 +48,7 @@ namespace BH.Engine.Settings
 
                     try
                     {
-                        obj = activator as ISettings;
+                        obj = (ISettings)activator;
                     }
                     catch(Exception ex)
                     {

--- a/Settings_Engine/Settings_Engine.csproj
+++ b/Settings_Engine/Settings_Engine.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>BH.Engine.Settings</RootNamespace>
+  </PropertyGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
+  </Target>
+
+  <ItemGroup>
+    <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj" />
+    <ProjectReference Include="..\Serialiser_Engine\Serialiser_Engine.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="BHoM">
+      <HintPath>..\..\..\..\..\..\..\ProgramData\BHoM\Assemblies\BHoM.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Issues addressed by this PR
Fixes #2709 


### Test files
Available [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FSettings%5FEngine&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b) - thanks @peterjamesnugent for the nudge!

### Additional comments

Please see [this comment](https://github.com/BHoM/BHoM_Engine/issues/2709#issuecomment-1665354605) for a brief overview of why a new project was added instead of utilising an existing project.

You may also be asking how does this link in with existing BHoM_UI methods on [saving](https://github.com/BHoM/BHoM_UI/blob/eba2e7d933178705d9082090ebe57934154e56c1/UI_Engine/Compute/SaveSettings.cs#L46) and [loading](https://github.com/BHoM/BHoM_UI/blob/eba2e7d933178705d9082090ebe57934154e56c1/UI_Engine/Query/Settings.cs#L46) settings. BHoM_UI is at a higher dependency level which may prohibit toolkits (such as Revit_Toolkit) from accessing them. Tools within the ZeroCodeTool Space along the BIM spectrum may also encounter issues. Thus, this is designed to be a central settings management system, accessible to any level of BHoM beneath it and not restricted just to the UI levels. What this means for the existing UI functionality is that, in separate issues of narrow scope, that functionality will be ported over from BHoM_UI into here, and BHoM_UI will call these methods to handle loading settings into UI elements. That's the plan at any rate.

The script in the folder for testing goes through the methods/workflows this PR adds and nothing more. There is also a test settings JSON file within the folder to use as well if you don't have one of your own. The test script does assume that you don't already have a `LibrarySettings` object serialised within the folder you're loading from - if you do you might find the `return default object` test doesn't work in the script - but feel free to test with another object as appropriate. The test script is a guide after all and not a definitive.

I don't think the methods added should be extension methods and thus do not agree with the code-compliance failure the bot is reporting, but happy to debate depending on what others think.