### PR TITLE
Facade_Engine: Added PsiValuesMatch method and OpeningsSAM check for matching

### DIFF
--- a/Facade_Engine/Compute/UValueOpeningsSAM.cs
+++ b/Facade_Engine/Compute/UValueOpeningsSAM.cs
@@ -49,6 +49,12 @@ namespace BH.Engine.Facade
         [Output("effectiveUValue", "Effective total U-value result of opening calculated using SAM.")]
         public static OverallUValue UValueOpeningsSAM(this List<Opening> openings)
         {
+            if (!openings.PsiValuesMatch())
+            {
+                BH.Engine.Base.Compute.RecordError("Openings have PsiValues at adjacent edges that do not match. SAM UValue method requires matching PsiValues at adjacent edges to work correctly.");
+                return null;
+            }
+
             double uValueProduct = 0;
             double totalArea = 0;
             foreach (Opening opening in openings)

--- a/Facade_Engine/Query/PsiValuesMatch.cs
+++ b/Facade_Engine/Query/PsiValuesMatch.cs
@@ -1,0 +1,159 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using BH.oM.Geometry;
+using BH.oM.Dimensional;
+using BH.oM.Analytical.Elements;
+using BH.Engine.Geometry;
+using BH.oM.Base;
+using System.Collections.Generic;
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+using BH.oM.Facade.Elements;
+using BH.oM.Facade.Fragments;
+using BH.Engine.Base;
+
+namespace BH.Engine.Facade
+{
+    public static partial class Query
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Returns if all FrameEdges have matching Psi Values.")]
+        [Input("openings", "Reference Openings.")]
+        [Output("bool", "True if all adjacent edge PsiValues on the provided Openings match.")]
+        public static bool PsiValuesMatch(this List<Opening> openings)
+        {
+            for (int i = 0; i < openings.Count; i++)
+            {
+                List<Opening> otherOpenings = openings;
+                otherOpenings.RemoveAt(i);
+
+                Opening o = openings[i];
+                if(!o.PsiValuesMatch(otherOpenings))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        [Description("Returns if FrameEdges have matching Psi Values.")]
+        [Input("opening", "Reference Opening.")]
+        [Input("otherOpenings", "Other Openings to check PsiValue match for.")]
+        [Output("bool", "True if all otherEdge's PsiValues match edge's PsiValue.")]
+        public static bool PsiValuesMatch(this Opening opening, List<Opening> otherOpenings)
+        {
+            List<FrameEdge> edges = new List<FrameEdge>();
+
+            foreach (Opening o in otherOpenings)
+                edges.AddRange(o.Edges);
+            
+            foreach (FrameEdge edge in opening.Edges)
+            {
+                foreach (FrameEdge e in edges)
+                {
+                    if (edge.IsAdjacent(e) && !edge.PsiValuesMatch(e))
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        [Description("Returns if FrameEdges have matching Psi Values.")]
+        [Input("edge", "Reference FrameEdge.")]
+        [Input("otherEdges", "FrameEdges to check PsiValue for.")]
+        [Output("bool", "True if all otherEdge's PsiValues match edge's PsiValue.")]
+        public static bool PsiValuesMatch(this FrameEdge edge, List<FrameEdge> otherEdges)
+        {
+            if (edge == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Cannot query if PsiValues match if edge is null.");
+                return false;
+            }
+
+            foreach (FrameEdge otherEdge in otherEdges)
+            {
+                if (!edge.PsiValuesMatch(otherEdge))
+                    return false;
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        [Description("Returns if FrameEdges have matching Psi Values.")]
+        [Input("edge", "Reference FrameEdge.")]
+        [Input("otherEdge", "FrameEdge to check PsiValue for.")]
+        [Output("bool", "True if otherEdge's PsiValue matches edge's PsiValue.")]
+        public static bool PsiValuesMatch (this FrameEdge edge, FrameEdge otherEdge)
+        {
+            if(edge == null || otherEdge == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Cannot query if PsiValues match if either edge is null.");
+                return false;
+            }
+
+            List<IFragment> psiRef = edge.FrameEdgeProperty.GetAllFragments(typeof(PsiJoint));
+            List<IFragment> psiOther = otherEdge.FrameEdgeProperty.GetAllFragments(typeof(PsiJoint));
+
+            if (psiRef.Count == 0)
+            {
+                BH.Engine.Base.Compute.RecordError($"FrameEdge with guid {edge.BHoM_Guid} has no Psi Value assigned. Method requires a PsiJoint fragment assigned to the element.");
+                return false;
+            }
+            if (psiOther.Count == 0)
+            {
+                BH.Engine.Base.Compute.RecordError($"FrameEdge with guid {otherEdge.BHoM_Guid} has no Psi Value assigned. Method requires a PsiJoint fragment assigned to the element.");
+                return false;
+            }
+
+            if (psiRef.Count > 1)
+            {
+                BH.Engine.Base.Compute.RecordError($"FrameEdge with guid {edge.BHoM_Guid} has multiple Psi Value assigned. Method requires a signle PsiJoint fragment assigned to the element.");
+                return false;
+            }
+            if (psiOther.Count >1)
+            {
+                BH.Engine.Base.Compute.RecordError($"FrameEdge with guid {edge.BHoM_Guid} has multiple Psi Value assigned. Method requires a signle PsiJoint fragment assigned to the element.");
+                return false;
+            }
+
+            PsiJoint psiVal = (PsiJoint)psiRef[0];
+            PsiJoint psiValOther = (PsiJoint)psiOther[0];
+
+            return psiVal.PsiValue == psiValOther.PsiValue;
+        }
+
+        /***************************************************/
+    }
+}
+
+

--- a/Facade_Engine/Query/PsiValuesMatch.cs
+++ b/Facade_Engine/Query/PsiValuesMatch.cs
@@ -32,6 +32,7 @@ using System.ComponentModel;
 using BH.oM.Facade.Elements;
 using BH.oM.Facade.Fragments;
 using BH.Engine.Base;
+using System.Linq;
 
 namespace BH.Engine.Facade
 {
@@ -48,7 +49,7 @@ namespace BH.Engine.Facade
         {
             for (int i = 0; i < openings.Count; i++)
             {
-                List<Opening> otherOpenings = openings;
+                List<Opening> otherOpenings = openings.ToList();
                 otherOpenings.RemoveAt(i);
 
                 Opening o = openings[i];


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3132

Added method to check that adjacent frame edges have matching PsiValues, as mismatching PsiValues indicates an error in frame properties that needs to be resolved before running the calc.


### Test files
[Test file](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_Engine/Facade_Engine/Facade_Engine-OverallUFactorCalculationMethods_PsiBased.gh?csf=1&web=1&e=L7pxdh)
