### PR TITLE
Serialiser_Engine: Force invariant representation of number in serialisation

### DIFF
--- a/Serialiser_Engine/Compute/Deserialise/Decimal.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Decimal.cs
@@ -25,6 +25,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace BH.Engine.Serialiser
@@ -40,7 +41,7 @@ namespace BH.Engine.Serialiser
         {
             if (bson.IsDecimal128)
                 return bson.AsDecimal;
-            else if(bson.IsString && decimal.TryParse(bson.AsString, out decimal d))
+            else if(bson.IsString && decimal.TryParse(bson.AsString, NumberStyles.Any, CultureInfo.InvariantCulture, out decimal d))
                 return d;
             else
             {

--- a/Serialiser_Engine/Compute/Deserialise/Double.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Double.cs
@@ -25,6 +25,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace BH.Engine.Serialiser
@@ -44,7 +45,7 @@ namespace BH.Engine.Serialiser
                 return bson.AsInt32;
             else if (bson.IsInt64)
                 return bson.AsInt64;
-            else if (bson.IsString && double.TryParse(bson.AsString, out double d))
+            else if (bson.IsString && double.TryParse(bson.AsString, NumberStyles.Any, CultureInfo.InvariantCulture, out double d))
                 return d;
             else
             {

--- a/Serialiser_Engine/Compute/Deserialise/String.cs
+++ b/Serialiser_Engine/Compute/Deserialise/String.cs
@@ -25,6 +25,7 @@ using MongoDB.Bson;
 using MongoDB.Bson.IO;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 
 namespace BH.Engine.Serialiser
@@ -49,13 +50,13 @@ namespace BH.Engine.Serialiser
                     return doc["_v"].AsString;
             }
             else if (bson.IsDouble)
-                return bson.AsDouble.ToString();
+                return bson.AsDouble.ToString("", CultureInfo.InvariantCulture);
             else if (bson.IsInt32)
                 return bson.AsInt32.ToString();
             else if (bson.IsInt64)
                 return bson.AsInt64.ToString();
             else if (bson.IsDecimal128)
-                return bson.AsDecimal.ToString();
+                return bson.AsDecimal.ToString("", CultureInfo.InvariantCulture);
 
             BH.Engine.Base.Compute.RecordError("Expected to deserialise a string and received " + bson.ToString() + " instead.");
             return value;


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3130

 - Overall, the serialisation of numbers was already relying on Mongo to do things correctly but there was a few cases where we were doing a 'manual' conversion to/from strings.

 - I used `CultureInfo.InvariantCulture` instead of `en-GB` because it is [more robust to changes](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.cultureinfo.invariantculture?view=net-7.0) 

 -  Integers don't need formatting constraints as they don't change across cultures. I also checked other types like `Timespan` and `DateTime` and they don't need any modification as the first is invariant across cultures for default formatting and the second is represented as a long anyways. 

