### PR TITLE
Serialiser_Engine: Improve size of JSON by excluding empty IBHoMObject properties

### DIFF
--- a/Serialiser_Engine/Compute/Serialise/IBHoMObject.cs
+++ b/Serialiser_Engine/Compute/Serialise/IBHoMObject.cs
@@ -84,8 +84,5 @@ namespace BH.Engine.Serialiser
             writer.WriteEndDocument();
         }
 
-        /*******************************************/
-
-        private static List<string> m_PropertyNamesToIgnore = typeof(IBHoMObject).GetProperties().Select(x => x.Name).ToList(); //Storing here so that if serialising collections of IBHoMObjects, we don't have query the properties every time
     }
 }

--- a/Serialiser_Engine/Compute/Serialise/IBHoMObject.cs
+++ b/Serialiser_Engine/Compute/Serialise/IBHoMObject.cs
@@ -57,7 +57,7 @@ namespace BH.Engine.Serialiser
                     continue; //Don't write out null or empty properties if they're part of the base IBHoMObject properties
 
                 writer.WriteName(prop.Name);
-                ISerialise(prop.GetValue(value), writer, prop.PropertyType);
+                ISerialise(propertyValue, writer, prop.PropertyType);
             }
             writer.WriteEndDocument();
         }

--- a/Serialiser_Engine/Compute/Serialise/IBHoMObject.cs
+++ b/Serialiser_Engine/Compute/Serialise/IBHoMObject.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using MongoDB.Bson.IO;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -52,32 +53,28 @@ namespace BH.Engine.Serialiser
 
             foreach (PropertyInfo prop in value.GetType().GetProperties())
             {
-                var propertyValue = prop.GetValue(value);
                 bool include = true;
 
                 switch (prop.Name)
                 {
                     case "Name":
-                        include = !string.IsNullOrEmpty(propertyValue.ToString()); //If string is not null or empty - include the property
+                        include = !string.IsNullOrEmpty(value.Name);
                         break;
                     case "Fragments":
-                        include = ((FragmentSet)propertyValue).Count > 0; //If fragment count is greater than 0, include it
+                        include = (value.Fragments != null && value.Fragments.Count > 0);
                         break;
                     case "Tags":
-                        include = ((HashSet<string>)propertyValue).Count > 0; //As with fragments
+                        include = (value.Tags != null && value.Tags.Count > 0);
                         break;
                     case "CustomData":
-                        include = ((Dictionary<string, object>)propertyValue).Count > 0;
-                        break;
-                    case "BHoM_Guid":
-                        include = !string.IsNullOrEmpty(propertyValue.ToString());
+                        include = (value.CustomData != null && value.CustomData.Count > 0);
                         break;
                 }
 
                 if(include)
                 {
                     writer.WriteName(prop.Name);
-                    ISerialise(propertyValue, writer, prop.PropertyType);
+                    ISerialise(prop.GetValue(value), writer, prop.PropertyType);
                 }
                 
             }


### PR DESCRIPTION
Fixes #3017 

Test file available [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FSerialiser%5FEngine%2F%233144%2DJSONSize&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b).

Test file is very simple - serialise any object implementing `IBHoMObject` (should be most - I went with an Environment oM Panel) without providing a Name or other property implemented from `IBHoMObject` - see that the JSON doesn't contain the key value pair for those properties. Then provide values to those properties and see them get included.

I opted to go with storing the property names on load so that if you're serialising a collection of `IBHoMObjects`, we don't lose time querying the same 5 property names over and over again. Also opted to query the `IBHoMObject` properties so that if we ever change them, we don't have to remember to update the list here.

I did consider the option of whether we would want to include empty properties if they were overridden (as @IsakNaslundBh has occasionally done to override the `Name` property so he can add his own description to it for certain Structural objects), but decided against it for now on the basis that this will only exclude them if they're empty - so even if they're overridden, if they have no value assigned, do we really want them taking up space in the JSON string? I'm arguing for not - but we could go the other way if there's strong argument to.