### PR TITLE
Serialiser_Engine: Deserialisation of nested lists

### DIFF
--- a/Serialiser_Engine/Compute/Deserialise.cs
+++ b/Serialiser_Engine/Compute/Deserialise.cs
@@ -53,7 +53,12 @@ namespace BH.Engine.Serialiser
             if (bson.IsBsonNull)
                 return null;
             else if (bson.IsBsonArray)
-                return bson.DeserialiseList(new List<object>(), version, isUpgraded);
+            {
+                if (IsNestedList(bson))
+                    return bson.DeserialiseNestedList(new List<List<object>>(), version, isUpgraded);
+                else
+                    return bson.DeserialiseList(new List<object>(), version, isUpgraded);
+            }
             else if (bson.IsBsonDocument)
             {
                 BsonDocument doc = bson.AsBsonDocument;

--- a/Serialiser_Engine/Compute/Deserialise/List.cs
+++ b/Serialiser_Engine/Compute/Deserialise/List.cs
@@ -50,9 +50,7 @@ namespace BH.Engine.Serialiser
                 value = new List<T>();
 
             foreach (BsonValue item in bson.AsBsonArray)
-            {
                 value.Add((T)item.IDeserialise(typeof(T), null, version, isUpgraded));
-            }
 
             return value;
         }
@@ -73,9 +71,7 @@ namespace BH.Engine.Serialiser
                 value = new List<List<T>>();
 
             foreach (BsonValue item in bson.AsBsonArray)
-            {
-                value.Add((List<T>)item.IDeserialise(typeof(List<T>), null, version, isUpgraded));
-            }
+                value.Add((List<T>)item.DeserialiseList(new List<T>(), version, isUpgraded));
 
             return value;
         }

--- a/Serialiser_Engine/Compute/Deserialise/List.cs
+++ b/Serialiser_Engine/Compute/Deserialise/List.cs
@@ -50,11 +50,49 @@ namespace BH.Engine.Serialiser
                 value = new List<T>();
 
             foreach (BsonValue item in bson.AsBsonArray)
+            {
                 value.Add((T)item.IDeserialise(typeof(T), null, version, isUpgraded));
+            }
 
             return value;
         }
 
         /*******************************************/
+
+        private static List<List<T>> DeserialiseNestedList<T>(this BsonValue bson, List<List<T>> value, string version, bool isUpgraded)
+        {
+            bson = ExtractValue(bson);
+
+            if (!bson.IsBsonArray)
+            {
+                BH.Engine.Base.Compute.RecordError("Expected to deserialise a List and received " + bson.ToString() + " instead.");
+                return value;
+            }
+
+            if (value == null)
+                value = new List<List<T>>();
+
+            foreach (BsonValue item in bson.AsBsonArray)
+            {
+                value.Add((List<T>)item.IDeserialise(typeof(List<T>), null, version, isUpgraded));
+            }
+
+            return value;
+        }
+
+        /*******************************************/
+
+        private static bool IsNestedList(this BsonValue bson)
+        {
+            int nest = 0;
+
+            while(bson.IsBsonArray)
+            {
+                nest++;
+                bson = bson[0];
+            }
+
+            return nest > 1;
+        }
     }
 }


### PR DESCRIPTION
Fixes #2674 

### Test Files

[Available here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?newTargetListUrl=%2Fsites%2FBHoM%2F02%5FCurrent&viewpath=%2Fsites%2FBHoM%2F02%5FCurrent%2FForms%2FAllItems%2Easpx&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FUI%2F%23469%2DExplodeCustomObject&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b). The JSON used has come from @tg359 on the linked issue which this PR aims to resolve.

On alpha:

![image](https://github.com/BHoM/BHoM_UI/assets/18049174/a0cf69f1-abaf-438c-8b33-6867c06e990d)

On this PR:

![image](https://github.com/BHoM/BHoM_UI/assets/18049174/2f44af4c-7754-402c-a8f4-eac3accb0458)

If testing using the provided test script **please make sure** you redrag the output of `FromJson` into the `Explode` component to get it to update. Alternatively, drop a new `Explode` component on the canvas and compare the cached one with the one from this PR.

E.G:

![image](https://github.com/BHoM/BHoM_UI/assets/18049174/05a9b588-216c-42de-9798-5ee187103a3a)