### PR TITLE
Environment_Engine: Control of duplicate control points before extruding to volume

### DIFF
--- a/Environment_Engine/Compute/ExtrudeToVolume.cs
+++ b/Environment_Engine/Compute/ExtrudeToVolume.cs
@@ -36,8 +36,6 @@ using BH.oM.Base.Attributes;
 using System.ComponentModel;
 
 using BH.oM.Analytical.Elements;
-using ICSharpCode.Decompiler.CSharp.Syntax;
-using ICSharpCode.Decompiler.IL.ControlFlow;
 
 namespace BH.Engine.Environment
 {

--- a/Environment_Engine/Compute/ExtrudeToVolume.cs
+++ b/Environment_Engine/Compute/ExtrudeToVolume.cs
@@ -36,12 +36,14 @@ using BH.oM.Base.Attributes;
 using System.ComponentModel;
 
 using BH.oM.Analytical.Elements;
+using ICSharpCode.Decompiler.CSharp.Syntax;
+using ICSharpCode.Decompiler.IL.ControlFlow;
 
 namespace BH.Engine.Environment
 {
     public static partial class Compute
     {
-        [Description("Takes a region with a Floor Perimieter and creates a collection of Environment Panels which represent the closed volume of the region. The name of the region becomes the connected space for the panels.")]
+        [Description("Takes a region with a Floor Perimeter and creates a collection of Environment Panels which represent the closed volume of the region. The name of the region becomes the connected space for the panels.")]
         [Input("region", "A region with a floor perimeter to extrude into a collection of panels.")]
         [Input("height", "The height of the region, as a double, to calculate the ceiling level of the region. This will be used as the Z value of the perimeter + the given height.")]
         [Input("tolerance", "The degree of tolerance on the angle calculation for collapsing the regions perimeter to a polyline. Default is equal to BH.oM.Geometry.Tolerance.Angle.")]
@@ -56,7 +58,7 @@ namespace BH.Engine.Environment
             return floor.ExtrudeToVolume(region.Name, height);
         }
 
-        [Description("Takes a polyline perimieter and creates a collection of Environment Panels which represent the closed volume of a space.")]
+        [Description("Takes a polyline perimeter and creates a collection of Environment Panels which represent the closed volume of a space.")]
         [Input("pLine", "A polyline perimeter to extrude into a collection of panels.")]
         [Input("connectingSpaceName", "The name of the space the panels will enclose.")]
         [Input("height", "The height of the space, as a double, to calculate the ceiling level of the room. This will be used as the Z value of the perimeter + the given height.")]
@@ -66,12 +68,20 @@ namespace BH.Engine.Environment
             if (pLine == null)
                 return new List<Panel>();
 
+            List<Point> floorPoints = pLine.ControlPoints;
+            List<Point> checkPoints = floorPoints.CullDuplicates();
+
+            if (floorPoints.Count != (checkPoints.Count + 1))
+            {
+                BH.Engine.Base.Compute.RecordError("The polyline has duplicate control points and cannot be extruded to a volume.");
+                return new List<Panel>();
+            }                     
+
             List<Panel> panels = new List<Panel>();
 
             Panel floorPanel = new Panel { ExternalEdges = pLine.ToEdges(), Type = PanelType.Floor };
             panels.Add(floorPanel);
-
-            List<Point> floorPoints = pLine.ControlPoints;
+            
             List<Point> roofPoints = new List<Point>();
             foreach (Point p in floorPoints)
                 roofPoints.Add(new Point { X = p.X, Y = p.Y, Z = p.Z + height });


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3185

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->