### PR TITLE
BHoM_Engine: RunExtensionMethodAsync and TryRunExtensionMethodAsync added

### DIFF
--- a/BHoM_Engine/Compute/RunExtensionMethod.cs
+++ b/BHoM_Engine/Compute/RunExtensionMethod.cs
@@ -20,12 +20,10 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
 using BH.oM.Base.Attributes;
-using System;
-using System.Collections.Concurrent;
 using System.ComponentModel;
-using System.Linq;
-using System.Reflection;
+using System.Threading.Tasks;
 
 namespace BH.Engine.Base
 {
@@ -60,6 +58,39 @@ namespace BH.Engine.Base
         {
             if(TryRunExtensionMethod(target, methodName, parameters, out object result))
                 return result;
+            else
+                return null;
+        }
+
+        /***************************************************/
+
+        [Description("Asynchronously runs an extension method accepting a single argument based on a provided object and method name.\n" +
+                     "Finds the method via reflection the first time it is run, then compiles it to a function and stores it for subsequent calls.")]
+        [Input("target", "The object to find and run the extension method for.")]
+        [Input("methodName", "The name of the method to be run.")]
+        [Output("result", "The result of the method execution. If no method was found, null is returned.")]
+        public static async Task<object> RunExtensionMethodAsync(object target, string methodName)
+        {
+            Output<bool, object> result = await TryRunExtensionMethodAsync(target, methodName);
+            if (result.Item1)
+                return result.Item2;
+            else
+                return null;
+        }
+
+        /***************************************************/
+
+        [Description("Asynchronously runs an extension method accepting multiple arguments based on a provided main object and method name and additional arguments.\n" +
+                     "Finds the method via reflection the first time it is run, then compiles it to a function and stores it for subsequent calls.")]
+        [Input("target", "The first of the argument of the method to find and run the extention method for.")]
+        [Input("methodName", "The name of the method to be run.")]
+        [Input("parameters", "The additional arguments of the call to the method, skipping the first argument provided by 'target'.")]
+        [Output("result", "The result of the method execution. If no method was found, null is returned.")]
+        public static async Task<object> RunExtensionMethodAsync(object target, string methodName, object[] parameters)
+        {
+            Output<bool, object> result = await TryRunExtensionMethodAsync(target, methodName, parameters);
+            if (result.Item1)
+                return result.Item2;
             else
                 return null;
         }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3140

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Write a simple `public static async` Engine method taking `BHoMObject` and try running it via script uploaded [here](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FBHoM%5FEngine%2F%233191%2DRunExtensionMethodAsync&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
The methods added are to large extent a rewrite of `TryRunExtensionMethod`. However, `async` methods are not allowed to have `out` parameters, therefore I changed the method signature compared to synchronous flavour - happy to discuss if anyone has different/better ideas :+1: