### PR TITLE
Environment_Engine: Added ElementsInSpace and dependant IsContaining methods / optimisations

### DIFF
--- a/Environment_Engine/Compute/ElementsInSpace.cs
+++ b/Environment_Engine/Compute/ElementsInSpace.cs
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Environment.Elements;
+using BH.oM.Architecture.Elements;
+
+using BH.Engine.Geometry;
+using BH.oM.Geometry;
+
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+
+using BH.oM.Analytical.Elements;
+using BH.oM.Dimensional;
+
+namespace BH.Engine.Environment
+{
+    public static partial class Compute
+    {
+        [Description("Gets the elements that lie within the provided space.")]
+        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
+        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
+        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
+        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
+        [Output("elements", "The elements from the provided elements that are within the space.")]
+        public static List<IElement0D> ElementsInSpace(this Space space, double spaceHeight, List<IElement0D> elements,  bool acceptOnEdges = false)
+        {
+            if (space == null)
+                return new List<IElement0D>();
+
+            List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges);
+
+            return elements
+                .Zip(isContaining, (elem, inSpace) => new {
+                    elem,
+                    inSpace,
+                })
+                .Where(item => item.inSpace)
+                .Select(item => item.elem)
+                .ToList();
+        }
+
+    }
+}
+
+

--- a/Environment_Engine/Compute/ElementsInSpace.cs
+++ b/Environment_Engine/Compute/ElementsInSpace.cs
@@ -46,14 +46,15 @@ namespace BH.Engine.Environment
         [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
         [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
         [Input("elements", "The elements being checked to see if they are contained within the bounds of the 3D volume.")]
-        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
+        [Input("acceptOnEdges", "Decide whether to allow elements which sit on the edge of the space, default false.")]
+        [Input("acceptPartial", "Decide whether to include elements only partially within the space, default false.")]
         [Output("elements", "The elements from the provided elements that are within the space.")]
-        public static List<IElement> ElementsInSpace(this Space space, double spaceHeight, List<IElement> elements,  bool acceptOnEdges = false)
+        public static List<IElement> ElementsInSpace(this Space space, double spaceHeight, List<IElement> elements,  bool acceptOnEdges = false, bool acceptPartial = false)
         {
             if (space == null)
                 return new List<IElement>();
 
-            List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges);
+            List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges, acceptPartial);
 
             return elements
                 .Zip(isContaining, (elem, inSpace) => new {

--- a/Environment_Engine/Compute/ElementsInSpace.cs
+++ b/Environment_Engine/Compute/ElementsInSpace.cs
@@ -65,6 +65,69 @@ namespace BH.Engine.Environment
                 .ToList();
         }
 
+        [Description("Gets the elements that lie within the provided space.")]
+        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
+        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
+        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
+        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
+        [Output("elements", "The elements from the provided elements that are within the space.")]
+        public static List<IElement1D> ElementsInSpace(this Space space, double spaceHeight, List<IElement1D> elements, bool acceptOnEdges = false)
+        {
+            if (space == null)
+                return new List<IElement1D>();
+
+            List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges);
+
+            return elements
+                .Zip(isContaining, (elem, inSpace) => new {
+                    elem,
+                    inSpace,
+                })
+                .Where(item => item.inSpace)
+                .Select(item => item.elem)
+                .ToList();
+        }
+
+        [Description("Gets the elements that lie within the provided space.")]
+        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
+        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
+        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
+        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
+        [Output("elements", "The elements from the provided elements that are within the space.")]
+        public static List<IElement2D> ElementsInSpace(this Space space, double spaceHeight, List<IElement2D> elements, bool acceptOnEdges = false)
+        {
+            if (space == null)
+                return new List<IElement2D>();
+
+            List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges);
+
+            return elements
+                .Zip(isContaining, (elem, inSpace) => new {
+                    elem,
+                    inSpace,
+                })
+                .Where(item => item.inSpace)
+                .Select(item => item.elem)
+                .ToList();
+        }
+
+        /******************************************/
+        /**** Public Methods - Interfaces      ****/
+        /******************************************/
+
+        [Description("Gets the elements that lie within the provided space.")]
+        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
+        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
+        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
+        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
+        [Output("elements", "The elements from the provided elements that are within the space.")]
+        public static List<IElement> ElementsInSpace(this Space space, double spaceHeight, List<IElement> elements, bool acceptOnEdges = false)
+        {
+            return ElementsInSpace(space, spaceHeight, elements as dynamic, );
+        }
+
+        /******************************************/
+
     }
 }
 

--- a/Environment_Engine/Compute/ElementsInSpace.cs
+++ b/Environment_Engine/Compute/ElementsInSpace.cs
@@ -67,5 +67,3 @@ namespace BH.Engine.Environment
         }
     }
 }
-
-

--- a/Environment_Engine/Compute/ElementsInSpace.cs
+++ b/Environment_Engine/Compute/ElementsInSpace.cs
@@ -45,13 +45,13 @@ namespace BH.Engine.Environment
         [Description("Gets the elements that lie within the provided space.")]
         [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
         [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
+        [Input("elements", "The elements being checked to see if they are contained within the bounds of the 3D volume.")]
         [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
         [Output("elements", "The elements from the provided elements that are within the space.")]
-        public static List<IElement0D> ElementsInSpace(this Space space, double spaceHeight, List<IElement0D> elements,  bool acceptOnEdges = false)
+        public static List<IElement> ElementsInSpace(this Space space, double spaceHeight, List<IElement> elements,  bool acceptOnEdges = false)
         {
             if (space == null)
-                return new List<IElement0D>();
+                return new List<IElement>();
 
             List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges);
 
@@ -64,70 +64,6 @@ namespace BH.Engine.Environment
                 .Select(item => item.elem)
                 .ToList();
         }
-
-        [Description("Gets the elements that lie within the provided space.")]
-        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
-        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
-        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
-        [Output("elements", "The elements from the provided elements that are within the space.")]
-        public static List<IElement1D> ElementsInSpace(this Space space, double spaceHeight, List<IElement1D> elements, bool acceptOnEdges = false)
-        {
-            if (space == null)
-                return new List<IElement1D>();
-
-            List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges);
-
-            return elements
-                .Zip(isContaining, (elem, inSpace) => new {
-                    elem,
-                    inSpace,
-                })
-                .Where(item => item.inSpace)
-                .Select(item => item.elem)
-                .ToList();
-        }
-
-        [Description("Gets the elements that lie within the provided space.")]
-        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
-        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
-        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
-        [Output("elements", "The elements from the provided elements that are within the space.")]
-        public static List<IElement2D> ElementsInSpace(this Space space, double spaceHeight, List<IElement2D> elements, bool acceptOnEdges = false)
-        {
-            if (space == null)
-                return new List<IElement2D>();
-
-            List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges);
-
-            return elements
-                .Zip(isContaining, (elem, inSpace) => new {
-                    elem,
-                    inSpace,
-                })
-                .Where(item => item.inSpace)
-                .Select(item => item.elem)
-                .ToList();
-        }
-
-        /******************************************/
-        /**** Public Methods - Interfaces      ****/
-        /******************************************/
-
-        [Description("Gets the elements that lie within the provided space.")]
-        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
-        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
-        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
-        [Output("elements", "The elements from the provided elements that are within the space.")]
-        public static List<IElement> ElementsInSpace(this Space space, double spaceHeight, List<IElement> elements, bool acceptOnEdges = false)
-        {
-            return ElementsInSpace(space, spaceHeight, elements as dynamic, );
-        }
-
-        /******************************************/
-
     }
 }
 

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -144,6 +144,7 @@ namespace BH.Engine.Environment
         {
             List<Panel> panelsFromSpace = space.ExtrudeToVolume(spaceHeight);
             List<List<Point>> pointLists = new List<List<Point>>();
+
             foreach (IElement elem in elements)
             {
                 List<Point> points = elem.IControlPoints();
@@ -241,7 +242,7 @@ namespace BH.Engine.Environment
         [Input("acceptOnEdges", "Decide whether to allow the points to sit on the edge of the panel, default false.")]
         [Input("acceptPartialContainment", "Decide whether to allow some of the points to sit outside the panels as long as at least one is within them.")]
         [Output("isContaining", "True if the points of each sublist are contained within the bounds of the panels, false if it is not for each sublist of points provided.")]
-        public static List<bool> IsContaining(this List<Panel> panels, List<List<Point>> pointLists, bool acceptOnEdges = false, bool acceptPartialContainment = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
+        private static List<bool> IsContaining(this List<Panel> panels, List<List<Point>> pointLists, bool acceptOnEdges = false, bool acceptPartialContainment = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
             if (panels == null)
             {

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -147,7 +147,7 @@ namespace BH.Engine.Environment
         [Input("elements", "The elements being checked to see if they are contained within the bounds of the 3D volume.")]
         [Input("acceptOnEdges", "Decide whether to allow the element's point to sit on the edge of the space, default false.")]
         [Output("isContaining", "True if the point is contained within the space, false if it is not.")]
-        public static List<bool> IsContaining(this Space space, double spaceHeight, List<IElement> elements, bool acceptOnEdges = false)
+        public static List<bool> IsContaining(this Space space, double spaceHeight, List<IElement> elements, bool acceptOnEdges = false, bool acceptPartialContainment = false)
         {
             List<Panel> panelsFromSpace = space.ExtrudeToVolume(spaceHeight);
             List<List<Point>> pointLists = new List<List<Point>>();
@@ -156,7 +156,7 @@ namespace BH.Engine.Environment
                 List<Point> points = elem.IControlPoints();
                 pointLists.Add(points);
             }
-            return panelsFromSpace.IsContaining(pointLists, acceptOnEdges);
+            return panelsFromSpace.IsContaining(pointLists, acceptOnEdges, acceptPartialContainment);
         }
 
 

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -20,23 +20,16 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Geometry;
+using BH.Engine.Spatial;
+using BH.oM.Base.Attributes;
+using BH.oM.Dimensional;
+using BH.oM.Environment.Elements;
+using BH.oM.Geometry;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using BH.oM.Environment;
-using BH.oM.Environment.Elements;
-using BH.oM.Base;
-
-using BH.oM.Geometry;
-using BH.Engine.Geometry;
-
-using BH.oM.Base.Attributes;
 using System.ComponentModel;
-using BH.oM.Dimensional;
-using BH.Engine.Spatial;
+using System.Linq;
 
 namespace BH.Engine.Environment
 {
@@ -90,7 +83,7 @@ namespace BH.Engine.Environment
         [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not")]
         public static bool IsContaining(this List<Panel> panels, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
-            if(panels == null)
+            if (panels == null)
             {
                 BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
                 return false;
@@ -174,14 +167,15 @@ namespace BH.Engine.Environment
         [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
         private static bool IsContaining(this List<Panel> panels, List<Plane> planes, BoundingBox boundingBox, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
-            if (!BH.Engine.Geometry.Query.IsContaining(boundingBox, point, true, tolerance))
-                return false;
-
+            //Return if point is null even without checking boundingBox.IsContaining(point)
             if (point == null)
             {
                 BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the point is null.");
                 return false;
             }
+
+            if (!BH.Engine.Geometry.Query.IsContaining(boundingBox, point, true, tolerance))
+                return false;
 
             //We need to check one line that starts in the point and end outside the bounding box
             Vector vector = new Vector() { X = 1, Y = 0, Z = 0 };
@@ -262,12 +256,12 @@ namespace BH.Engine.Environment
             List<Point> ctrPoints = panels.SelectMany(x => x.Polyline().IControlPoints()).ToList();
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
-            List<bool> areContained =  new List<bool>();
+            List<bool> areContained = new List<bool>();
 
             foreach (List<Point> pts in pointLists)
             {
                 bool isContained = false;
-                if(acceptPartialContainment)
+                if (acceptPartialContainment)
                     isContained = pts.Any(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges));
                 else
                     isContained = pts.All(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges));

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -144,52 +144,20 @@ namespace BH.Engine.Environment
         [Description("Defines whether an Environment Space contains a provided Element.")]
         [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided element.")]
         [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("elements", "The point-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
+        [Input("elements", "The elements being checked to see if they are contained within the bounds of the 3D volume.")]
         [Input("acceptOnEdges", "Decide whether to allow the element's point to sit on the edge of the space, default false.")]
         [Output("isContaining", "True if the point is contained within the space, false if it is not.")]
-        public static List<bool> IsContaining(this Space space, double spaceHeight, List<IElement0D> elements, bool acceptOnEdges = false)
-        {
-            List<Panel> panelsFromSpace = space.ExtrudeToVolume(spaceHeight);
-            List<Point> points = elements.Select(x => x.IGeometry()).ToList();
-            return panelsFromSpace.IsContaining(points, acceptOnEdges);
-        }
-
-        [Description("Defines whether an Environment Space contains a provided Element.")]
-        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided element.")]
-        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("elements", "The linear elements being checked to see if they are contained within the bounds of the 3D volume.")]
-        [Input("acceptOnEdges", "Decide whether to allow the element's point to sit on the edge of the space, default false.")]
-        [Output("isContaining", "True if the point is contained within the space, false if it is not.")]
-        public static List<bool> IsContaining(this Space space, double spaceHeight, List<IElement1D> elements, bool acceptOnEdges = false)
+        public static List<bool> IsContaining(this Space space, double spaceHeight, List<IElement> elements, bool acceptOnEdges = false)
         {
             List<Panel> panelsFromSpace = space.ExtrudeToVolume(spaceHeight);
             List<List<Point>> pointLists = new List<List<Point>>();
             foreach (IElement elem in elements)
             {
-                List<Point> points = elem.ControlPoints();
+                List<Point> points = elem.IControlPoints();
                 pointLists.Add(points);
             }
             return panelsFromSpace.IsContaining(pointLists, acceptOnEdges);
         }
-
-        [Description("Defines whether an Environment Space contains a provided Element.")]
-        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided element.")]
-        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("elements", "The area-based elements being checked to see if they are contained within the bounds of the 3D volume.")]
-        [Input("acceptOnEdges", "Decide whether to allow the element's point to sit on the edge of the space, default false.")]
-        [Output("isContaining", "True if the point is contained within the space, false if it is not.")]
-        public static List<bool> IsContaining(this Space space, double spaceHeight, List<IElement2D> elements, bool acceptOnEdges = false)
-        {
-            List<Panel> panelsFromSpace = space.ExtrudeToVolume(spaceHeight);
-            List<List<Point>> pointLists = new List<List<Point>>();
-            foreach (IElement2D elem in elements)
-            {
-                List<Point> points = elem.ControlPoints();
-                pointLists.Add(points);
-            }
-            return panelsFromSpace.IsContaining(pointLists, acceptOnEdges);
-        }
-
 
 
         /***************************************************/

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -273,7 +273,3 @@ namespace BH.Engine.Environment
         }
     }
 }
-
-
-
-

--- a/Lighting_Engine/Query/Geometry.cs
+++ b/Lighting_Engine/Query/Geometry.cs
@@ -1,0 +1,56 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.oM.Lighting;
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+using BH.oM.Geometry;
+using BH.oM.Lighting.Elements;
+
+namespace BH.Engine.Lighting
+{
+    public static partial class Query
+    {
+        [Description("Gets the geometry of a Luminaire as a Point.")]
+        [Input("luminaire", "Element to get the Point from.")]
+        [Output("point", "The geometry of the Element.")]
+        public static Point Geometry(this Luminaire luminaire)
+        {
+            if(luminaire == null)
+            {
+                BH.Engine.Base.Compute.RecordError("Cannot query the geometry of a null luminaire.");
+                return null;
+            }
+
+            return luminaire.Position;
+        }
+    }
+}
+
+
+

--- a/Lighting_Engine/Query/Geometry.cs
+++ b/Lighting_Engine/Query/Geometry.cs
@@ -51,6 +51,3 @@ namespace BH.Engine.Lighting
         }
     }
 }
-
-
-


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3194 

Added ElementsInSpace for Element0D (1D/2D to follow as a latter PR). Also added IsContaining method for Element0D as well as faster method for detecting list of points' containment in a single space.


### Test files
[Test Script](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Environment_Engine/%233195-ElementInSpace?csf=1&web=1&e=uPbwro)

Test by checking that the method correctly identifies the elements in each space as per the different visualization output options in dark blue to the script's far right.
