### PR TITLE
Environment_Engine: Refactor of IsContaining and ElementsInSpace methods to Geometry and Analytical namespaces as appropriate

### DIFF
--- a/Analytical_Engine/Compute/ElementsInRegion.cs
+++ b/Analytical_Engine/Compute/ElementsInRegion.cs
@@ -34,9 +34,8 @@ using System.ComponentModel;
 
 using BH.oM.Analytical.Elements;
 using BH.oM.Dimensional;
-using BH.Engine.Analytical;
 
-namespace BH.Engine.Environment
+namespace BH.Engine.Analytical
 {
     public static partial class Compute
     {

--- a/Analytical_Engine/Compute/ElementsInRegion.cs
+++ b/Analytical_Engine/Compute/ElementsInRegion.cs
@@ -26,9 +26,6 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using BH.oM.Environment.Elements;
-using BH.oM.Architecture.Elements;
-
 using BH.Engine.Geometry;
 using BH.oM.Geometry;
 
@@ -37,6 +34,7 @@ using System.ComponentModel;
 
 using BH.oM.Analytical.Elements;
 using BH.oM.Dimensional;
+using BH.Engine.Analytical;
 
 namespace BH.Engine.Environment
 {
@@ -49,12 +47,12 @@ namespace BH.Engine.Environment
         [Input("acceptOnEdges", "Decide whether to allow elements which sit on the edge of the space, default false.")]
         [Input("acceptPartial", "Decide whether to include elements only partially within the space, default false.")]
         [Output("elements", "The elements from the provided elements that are within the space.")]
-        public static List<IElement> ElementsInSpace(this Space space, double spaceHeight, List<IElement> elements,  bool acceptOnEdges = false, bool acceptPartial = false)
+        public static List<IElement> ElementsInRegion(this IRegion region, double regionHeight, List<IElement> elements,  bool acceptOnEdges = false, bool acceptPartial = false)
         {
-            if (space == null)
+            if (region == null)
                 return new List<IElement>();
 
-            List<bool> isContaining = space.IsContaining(spaceHeight, elements, acceptOnEdges, acceptPartial);
+            List<bool> isContaining = region.IsContaining(regionHeight, elements, acceptOnEdges, acceptPartial);
 
             return elements
                 .Zip(isContaining, (elem, inSpace) => new {

--- a/Analytical_Engine/Compute/ElementsInRegion.cs
+++ b/Analytical_Engine/Compute/ElementsInRegion.cs
@@ -40,8 +40,8 @@ namespace BH.Engine.Analytical
     public static partial class Compute
     {
         [Description("Gets the elements that lie within the provided space.")]
-        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
-        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
+        [Input("region", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
+        [Input("regionHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
         [Input("elements", "The elements being checked to see if they are contained within the bounds of the 3D volume.")]
         [Input("acceptOnEdges", "Decide whether to allow elements which sit on the edge of the space, default false.")]
         [Input("acceptPartial", "Decide whether to include elements only partially within the space, default false.")]

--- a/Analytical_Engine/Compute/ExtrudeToVolume.cs
+++ b/Analytical_Engine/Compute/ExtrudeToVolume.cs
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using BH.Engine.Geometry;
+using BH.oM.Geometry;
+
+using BH.oM.Base.Attributes;
+using System.ComponentModel;
+
+using BH.oM.Analytical.Elements;
+
+namespace BH.Engine.Analytical
+{
+    public static partial class Compute
+    {
+        [Description("Takes a region with a Floor Perimeter and creates a collection of polylines which represent the closed volume of the region.")]
+        [Input("region", "A region with a floor perimeter to extrude into a collection of panels.")]
+        [Input("height", "The height of the region, as a double, to calculate the ceiling level of the region. This will be used as the Z value of the perimeter + the given height.")]
+        [Input("tolerance", "The degree of tolerance on the angle calculation for collapsing the regions perimeter to a polyline. Default is equal to BH.oM.Geometry.Tolerance.Angle.")]
+        [Output("polylines", "A collection of polylines which represent the closed volume of the region.")]
+        [PreviousInputNames("region", "room, space")]
+        public static List<Polyline> ExtrudeToVolume(this IRegion region, double height, double tolerance = BH.oM.Geometry.Tolerance.Angle)
+        {
+            if (region == null)
+                return new List<Polyline>();
+
+            Polyline floor = region.Perimeter.ICollapseToPolyline(tolerance);
+            return floor.ExtrudeToVolume(region.Name, height);
+        }
+
+        [Description("Takes a polyline perimeter and creates a collection of polylines which represent the closed volume of a space.")]
+        [Input("pLine", "A polyline perimeter to extrude into a collection of panels.")]
+        [Input("connectingSpaceName", "The name of the space the panels will enclose.")]
+        [Input("height", "The height of the space, as a double, to calculate the ceiling level of the room. This will be used as the Z value of the perimeter + the given height.")]
+        [Output("polylines", "A collection of polylines which represent the closed volume of the region.")]
+        public static List<Polyline> ExtrudeToVolume(this Polyline pLine, string connectingSpaceName, double height)
+        {
+            if (pLine == null)
+                return new List<Polyline>();
+
+            List<Point> floorPoints = pLine.ControlPoints;
+            List<Point> checkPoints = floorPoints.CullDuplicates();
+
+            if (floorPoints.Count != (checkPoints.Count + 1))
+            {
+                BH.Engine.Base.Compute.RecordError("The polyline has duplicate control points and cannot be extruded to a volume.");
+                return new List<Polyline>();
+            }                     
+
+            List<Polyline> panels = new List<Polyline>();
+
+            Polyline floorPanel = pLine;
+            panels.Add(floorPanel);
+            
+            List<Point> roofPoints = new List<Point>();
+            foreach (Point p in floorPoints)
+                roofPoints.Add(new Point { X = p.X, Y = p.Y, Z = p.Z + height });
+
+            Polyline roofPanel = new Polyline { ControlPoints = roofPoints };
+            panels.Add(roofPanel);
+
+            for (int a = 0; a < floorPoints.Count - 1; a++)
+            {
+                List<Point> panelPoints = new List<Point>();
+                panelPoints.Add(floorPoints[a]);
+                panelPoints.Add(new Point { X = floorPoints[a].X, Y = floorPoints[a].Y, Z = floorPoints[a].Z + height });
+                panelPoints.Add(new Point { X = floorPoints[a + 1].X, Y = floorPoints[a + 1].Y, Z = floorPoints[a + 1].Z + height });
+                panelPoints.Add(floorPoints[a + 1]);
+                panelPoints.Add(floorPoints[a]);
+
+                panels.Add(new Polyline {ControlPoints = panelPoints });
+            }
+
+            return panels;
+        }
+    }
+}
+
+

--- a/Analytical_Engine/Query/IsContaining.cs
+++ b/Analytical_Engine/Query/IsContaining.cs
@@ -31,6 +31,8 @@ using BH.oM.Geometry;
 using BH.Engine.Geometry;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
+using BH.oM.Dimensional;
+using BH.Engine.Spatial;
 using System.ComponentModel;
 
 namespace BH.Engine.Analytical
@@ -80,6 +82,40 @@ namespace BH.Engine.Analytical
                 Item1 = results,
                 Item2 = notContained,
             };
+        }
+
+        [Description("Defines whether an Environment Space contains each of a provided list of points.")]
+        [Input("region", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
+        [Input("regionHeight", "The height of the region.", typeof(BH.oM.Quantities.Attributes.Length))]
+        [Input("points", "The points being checked to see if it is contained within the bounds of the 3D volume.")]
+        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the region, default false.")]
+        [Output("isContaining", "True if the point is contained within the region, false if it is not.")]
+        public static List<bool> IsContaining(this IRegion region, double regionHeight, List<Point> points, bool acceptOnEdges = false)
+        {
+            List<Polyline> panelsFromSpace = region.ExtrudeToVolume(regionHeight);
+            return panelsFromSpace.IsContaining(points, acceptOnEdges);
+        }
+
+        [Description("Defines whether an Environment Space contains a provided Element.")]
+        [Input("region", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided element.")]
+        [Input("regionHeight", "The height of the region.", typeof(BH.oM.Quantities.Attributes.Length))]
+        [Input("elements", "The elements being checked to see if they are contained within the bounds of the 3D volume.")]
+        [Input("acceptOnEdges", "Decide whether to allow the element's point to sit on the edge of the region, default false.")]
+        [Input("acceptPartialContainment", "Decide whether to count elements overlapping the region as contained.")]
+        [Output("isContaining", "True if the point is contained within the region, false if it is not.")]
+        public static List<bool> IsContaining(this IRegion region, double regionHeight, List<IElement> elements, bool acceptOnEdges = false, bool acceptPartialContainment = false)
+        {
+            List<Polyline> polylines = region.ExtrudeToVolume(regionHeight);
+
+            List<List<Point>> pointLists = new List<List<Point>>();
+
+            foreach (IElement elem in elements)
+            {
+                List<Point> points = elem.IControlPoints();
+                pointLists.Add(points);
+            }
+
+            return BH.Engine.Geometry.Query.IsContaining(polylines, pointLists, acceptOnEdges, acceptPartialContainment);
         }
     }
 }

--- a/Analytical_Engine/Query/IsContaining.cs
+++ b/Analytical_Engine/Query/IsContaining.cs
@@ -93,7 +93,7 @@ namespace BH.Engine.Analytical
         public static List<bool> IsContaining(this IRegion region, double regionHeight, List<Point> points, bool acceptOnEdges = false)
         {
             List<Polyline> panelsFromSpace = region.ExtrudeToVolume(regionHeight);
-            return panelsFromSpace.IsContaining(points, acceptOnEdges);
+            return panelsFromSpace.IsContaining(points, acceptOnEdges, Tolerance.Distance);
         }
 
         [Description("Defines whether an Environment Space contains a provided Element.")]

--- a/Environment_Engine/Environment_Engine.csproj
+++ b/Environment_Engine/Environment_Engine.csproj
@@ -16,6 +16,7 @@
     <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
   </Target>
   <ItemGroup>
+    <ProjectReference Include="..\Analytical_Engine\Analytical_Engine.csproj" />
     <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj" />
     <ProjectReference Include="..\Data_Engine\Data_Engine.csproj" />
     <ProjectReference Include="..\Diffing_Engine\Diffing_Engine.csproj" />

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -22,6 +22,7 @@
 
 using BH.Engine.Geometry;
 using BH.Engine.Spatial;
+using BH.Engine.Analytical;
 using BH.oM.Analytical.Elements;
 using BH.oM.Base.Attributes;
 using BH.oM.Dimensional;
@@ -115,6 +116,18 @@ namespace BH.Engine.Environment
                 polylines.Add(be.Polyline());
 
             return Engine.Geometry.Query.IsContaining(polylines, points, acceptOnEdges, tolerance);
+        }
+
+
+        [Description("Defines whether an Environment Space contains a provided point.")]
+        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
+        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
+        [Input("points", "The points being checked to see if it is contained within the bounds of the 3D volume.")]
+        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
+        [Output("isContaining", "True if the point is contained within the space, false if it is not.")]
+        public static List<bool> IsContaining(this Space space, double spaceHeight, List<Point> points, bool acceptOnEdges = false)
+        {
+            return BH.Engine.Analytical.Query.IsContaining(space, spaceHeight, points, acceptOnEdges);
         }
     }
 }

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -114,44 +114,7 @@ namespace BH.Engine.Environment
             foreach (Panel be in panels)
                 polylines.Add(be.Polyline());
 
-            return points.Select(point => Engine.Geometry.Query.IsContaining(polylines, points, acceptOnEdges)).ToList();
-        }
-
-        [Description("Defines whether an Environment Space contains each of a provided list of points.")]
-        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided point.")]
-        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("points", "The points being checked to see if it is contained within the bounds of the 3D volume.")]
-        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the space, default false.")]
-        [Output("isContaining", "True if the point is contained within the space, false if it is not.")]
-        public static List<bool> IsContaining(this Space space, double spaceHeight, List<Point> points, bool acceptOnEdges = false)
-        {
-            List<Panel> panelsFromSpace = space.ExtrudeToVolume(spaceHeight);
-            return panelsFromSpace.IsContaining(points, acceptOnEdges);
-        }
-
-        [Description("Defines whether an Environment Space contains a provided Element.")]
-        [Input("space", "An Environment Space object defining a perimeter to build a 3D volume from and check if the volume contains the provided element.")]
-        [Input("spaceHeight", "The height of the space.", typeof(BH.oM.Quantities.Attributes.Length))]
-        [Input("elements", "The elements being checked to see if they are contained within the bounds of the 3D volume.")]
-        [Input("acceptOnEdges", "Decide whether to allow the element's point to sit on the edge of the space, default false.")]
-        [Output("isContaining", "True if the point is contained within the space, false if it is not.")]
-        public static List<bool> IsContaining(this Space space, double spaceHeight, List<IElement> elements, bool acceptOnEdges = false, bool acceptPartialContainment = false)
-        {
-            List<Panel> panelsFromSpace = space.ExtrudeToVolume(spaceHeight);
-
-            List<Polyline> polylines = new List<Polyline>();
-            foreach (Panel be in panelsFromSpace)
-                polylines.Add(be.Polyline());
-
-            List<List<Point>> pointLists = new List<List<Point>>();
-
-            foreach (IElement elem in elements)
-            {
-                List<Point> points = elem.IControlPoints();
-                pointLists.Add(points);
-            }
-
-            return BH.Engine.Geometry.Query.IsContaining(polylines, pointLists, acceptOnEdges, acceptPartialContainment);
+            return Engine.Geometry.Query.IsContaining(polylines, points, acceptOnEdges, tolerance);
         }
     }
 }

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -22,6 +22,7 @@
 
 using BH.Engine.Geometry;
 using BH.Engine.Spatial;
+using BH.oM.Analytical.Elements;
 using BH.oM.Base.Attributes;
 using BH.oM.Dimensional;
 using BH.oM.Environment.Elements;
@@ -89,14 +90,11 @@ namespace BH.Engine.Environment
                 return false;
             }
 
-            List<Plane> planes = new List<Plane>();
+            List<Polyline> polylines = new List<Polyline>();
             foreach (Panel be in panels)
-                planes.Add(be.Polyline().IControlPoints().FitPlane(tolerance));
+                polylines.Add(be.Polyline());
 
-            List<Point> ctrPoints = panels.SelectMany(x => x.Polyline().IControlPoints()).ToList();
-            BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
-
-            return IsContaining(panels, planes, boundingBox, point, acceptOnEdges);
+            return Engine.Geometry.Query.IsContaining(polylines, point, acceptOnEdges, tolerance);
         }
 
         [Description("Defines whether a collection of Environment Panels contains each of a provided list of points.")]
@@ -112,14 +110,11 @@ namespace BH.Engine.Environment
                 return new List<bool>() { false };
             }
 
-            List<Plane> planes = new List<Plane>();
+            List<Polyline> polylines = new List<Polyline>();
             foreach (Panel be in panels)
-                planes.Add(be.Polyline().IControlPoints().FitPlane(tolerance));
+                polylines.Add(be.Polyline());
 
-            List<Point> ctrPoints = panels.SelectMany(x => x.Polyline().IControlPoints()).ToList();
-            BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
-
-            return points.Select(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges)).ToList();
+            return points.Select(point => Engine.Geometry.Query.IsContaining(polylines, points, acceptOnEdges)).ToList();
         }
 
         [Description("Defines whether an Environment Space contains each of a provided list of points.")]
@@ -143,6 +138,11 @@ namespace BH.Engine.Environment
         public static List<bool> IsContaining(this Space space, double spaceHeight, List<IElement> elements, bool acceptOnEdges = false, bool acceptPartialContainment = false)
         {
             List<Panel> panelsFromSpace = space.ExtrudeToVolume(spaceHeight);
+
+            List<Polyline> polylines = new List<Polyline>();
+            foreach (Panel be in panelsFromSpace)
+                polylines.Add(be.Polyline());
+
             List<List<Point>> pointLists = new List<List<Point>>();
 
             foreach (IElement elem in elements)
@@ -150,126 +150,8 @@ namespace BH.Engine.Environment
                 List<Point> points = elem.IControlPoints();
                 pointLists.Add(points);
             }
-            return panelsFromSpace.IsContaining(pointLists, acceptOnEdges, acceptPartialContainment);
-        }
 
-
-        /***************************************************/
-        /**** Private Methods                           ****/
-        /***************************************************/
-
-        [Description("Defines whether a point lies within a collection of panels using their primitive planes and bounds.")]
-        [Input("panels", "A collection of Environment Panels to check with.")]
-        [Input("planes", "Planes corresponding to each panel for intersection calculations.")]
-        [Input("boundingBox", "The bounding box of the collection of panels.")]
-        [Input("point", "The point to check to see if it is contained within the bounds of the panels.")]
-        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]
-        [Input("tolerance", "Distance tolerance to use to determine intersections.")]
-        [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
-        private static bool IsContaining(this List<Panel> panels, List<Plane> planes, BoundingBox boundingBox, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
-        {
-            //Return if point is null even without checking boundingBox.IsContaining(point)
-            if (point == null)
-            {
-                BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the point is null.");
-                return false;
-            }
-
-            if (!BH.Engine.Geometry.Query.IsContaining(boundingBox, point, true, tolerance))
-                return false;
-
-            //We need to check one line that starts in the point and end outside the bounding box
-            Vector vector = new Vector() { X = 1, Y = 0, Z = 0 };
-            //Use a length longer than the longest side in the bounding box. Change to infinite line?
-            Line line = new Line() { Start = point, End = point.Translate(vector * (((boundingBox.Max - boundingBox.Min).Length()) * 10)) };
-
-            bool isInPlane = false;
-            do
-            {
-                isInPlane = false;
-                foreach (Plane p in planes)
-                    isInPlane = isInPlane || line.IsInPlane(p);
-
-                if (isInPlane)
-                {
-                    Vector v = new Vector() { X = 0.5, Y = 0.5, Z = 0.5 };
-                    line = new Line() { Start = point, End = point.Translate(v * (((boundingBox.Max - boundingBox.Min).Length()) * 10)) };
-                }
-            }
-            while (isInPlane);
-
-            //Check intersections
-            List<Point> intersectPoints = new List<Point>();
-
-            for (int x = 0; x < planes.Count; x++)
-            {
-                if (planes[x] != null)
-                {
-                    if ((BH.Engine.Geometry.Query.PlaneIntersection(line, planes[x], false, tolerance)) == null)
-                        continue;
-
-                    List<Point> intersectingPoints = new List<oM.Geometry.Point>();
-                    intersectingPoints.Add(BH.Engine.Geometry.Query.PlaneIntersection(line, planes[x], true, tolerance));
-                    Polyline pLine = panels[x].Polyline();
-
-                    if (intersectingPoints != null && BH.Engine.Geometry.Query.IsContaining(pLine, intersectingPoints, true, tolerance))
-                        intersectPoints.AddRange(intersectingPoints);
-                }
-            }
-
-            bool isContained = !((intersectPoints.CullDuplicates().Count % 2) == 0);
-
-            if (!isContained && acceptOnEdges)
-            {
-                //Check the edges in case the point is on the edge of the BE
-                foreach (Panel p in panels)
-                {
-                    List<Line> subParts = p.Polyline().ISubParts() as List<Line>;
-                    foreach (Line l in subParts)
-                    {
-                        if (l.IsOnCurve(point))
-                            isContained = true;
-                    }
-                }
-            }
-
-            return isContained; //If the number of intersections is odd the point is outsde the space
-        }
-
-        [Description("Defines whether a collection of Environment Panels contains each of a provided list of list of points.")]
-        [Input("panels", "A collection of Environment Panels to check with.")]
-        [Input("pointLists", "The List of Lists of points to check to see if each List of points are contained within the bounds of the panels.")]
-        [Input("acceptOnEdges", "Decide whether to allow the points to sit on the edge of the panel, default false.")]
-        [Input("acceptPartialContainment", "Decide whether to allow some of the points to sit outside the panels as long as at least one is within them.")]
-        [Output("isContaining", "True if the points of each sublist are contained within the bounds of the panels, false if it is not for each sublist of points provided.")]
-        private static List<bool> IsContaining(this List<Panel> panels, List<List<Point>> pointLists, bool acceptOnEdges = false, bool acceptPartialContainment = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
-        {
-            if (panels == null)
-            {
-                BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
-                return new List<bool>() { false };
-            }
-
-            List<Plane> planes = new List<Plane>();
-            foreach (Panel be in panels)
-                planes.Add(be.Polyline().IControlPoints().FitPlane(tolerance));
-
-            List<Point> ctrPoints = panels.SelectMany(x => x.Polyline().IControlPoints()).ToList();
-            BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
-
-            List<bool> areContained = new List<bool>();
-
-            foreach (List<Point> pts in pointLists)
-            {
-                bool isContained = false;
-                if (acceptPartialContainment)
-                    isContained = pts.Any(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges));
-                else
-                    isContained = pts.All(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges));
-                areContained.Add(isContained);
-            }
-
-            return areContained;
+            return BH.Engine.Geometry.Query.IsContaining(polylines, pointLists, acceptOnEdges, acceptPartialContainment);
         }
     }
 }

--- a/Environment_Engine/Query/IsContaining.cs
+++ b/Environment_Engine/Query/IsContaining.cs
@@ -94,7 +94,7 @@ namespace BH.Engine.Environment
             foreach (Panel be in panels)
                 polylines.Add(be.Polyline());
 
-            return Engine.Geometry.Query.IsContaining(polylines, point, acceptOnEdges, tolerance);
+            return Engine.Geometry.Query.IsContaining(polylines, new List<Point> (){ point }, acceptOnEdges, tolerance).First();
         }
 
         [Description("Defines whether a collection of Environment Panels contains each of a provided list of points.")]

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -829,12 +829,6 @@ namespace BH.Engine.Geometry
                 return false;
             }
 
-            if (planes.Any(x => x == null))
-            {
-                BH.Engine.Base.Compute.RecordError("Cannot query if a provided plane is null.");
-                return false;
-            }
-
             if (!BH.Engine.Geometry.Query.IsContaining(boundingBox, point, true, tolerance))
                 return false;
 

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -720,9 +720,7 @@ namespace BH.Engine.Geometry
         [Input("tolerance", "Distance tolerance to use to determine intersections.")]
         [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
         public static bool IsContaining(this List<Polyline> panels, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
-        {
-            bool isContained = false;
-            
+        {         
             if (panels == null)
             {
                 BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
@@ -740,7 +738,7 @@ namespace BH.Engine.Geometry
 
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
-            return isContained = IsContaining(panels, planes, boundingBox, point, acceptOnEdges);
+            return IsContaining(panels, planes, boundingBox, point, acceptOnEdges);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -729,11 +729,15 @@ namespace BH.Engine.Geometry
                 return false;
             }
 
+            List<Point> ctrPoints = new List<Point>();
             List<Plane> planes = new List<Plane>();
             foreach (Polyline be in panels)
-                planes.Add(be.IControlPoints().FitPlane(tolerance));
+            {
+                List <Point> srfPts = be.IControlPoints();
+                planes.Add(srfPts.FitPlane(tolerance));
+                ctrPoints.AddRange(srfPts);
+            }
 
-            List<Point> ctrPoints = panels.SelectMany(x => x.IControlPoints()).ToList();
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
             return isContained = IsContaining(panels, planes, boundingBox, point, acceptOnEdges);
@@ -755,11 +759,15 @@ namespace BH.Engine.Geometry
                 return new List<bool>() { false };
             }
 
+            List<Point> ctrPoints = new List<Point>();
             List<Plane> planes = new List<Plane>();
             foreach (Polyline be in panels)
-                planes.Add(be.IControlPoints().FitPlane(tolerance));
+            {
+                List<Point> srfPts = be.IControlPoints();
+                planes.Add(srfPts.FitPlane(tolerance));
+                ctrPoints.AddRange(srfPts);
+            }
 
-            List<Point> ctrPoints = panels.SelectMany(x => x.IControlPoints()).ToList();
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
             return points.Select(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges)).ToList();
@@ -781,11 +789,15 @@ namespace BH.Engine.Geometry
                 return new List<bool>() { false };
             }
 
+            List<Point> ctrPoints = new List<Point>();
             List<Plane> planes = new List<Plane>();
             foreach (Polyline be in panels)
-                planes.Add(be.IControlPoints().FitPlane(tolerance));
+            {
+                List<Point> srfPts = be.IControlPoints();
+                planes.Add(srfPts.FitPlane(tolerance));
+                ctrPoints.AddRange(srfPts);
+            }
 
-            List<Point> ctrPoints = panels.SelectMany(x => x.IControlPoints()).ToList();
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
             List<bool> areContained = new List<bool>();

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -833,6 +833,10 @@ namespace BH.Engine.Geometry
                 return false;
 
             List<Line> uniqueEdges = UniqueSegments(closedVolume, tolerance);
+
+            if (uniqueEdges.Any(p => point.IsOnCurve(p, tolerance)))
+                return acceptOnEdges;
+            
             double rayLength = (boundingBox.Max - boundingBox.Min).Length() + 1;
             Vector rVec;
             Line line = null;
@@ -869,11 +873,6 @@ namespace BH.Engine.Geometry
             }
 
             bool isContained = intersectPoints.CullDuplicates().Count % 2 != 0;
-
-            if (!isContained && acceptOnEdges)
-            {
-                isContained = uniqueEdges.Any(p => point.IsOnCurve(p, tolerance));
-            }
 
             return isContained; //If the number of intersections is odd the point is outsde the space
         }

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -714,14 +714,14 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Checks if a point lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
-        [Input("panels", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
+        [Input("closedVolume", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
         [Input("point", "The point to check to see if it is contained within the bounds of the panels.")]
         [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]
         [Input("tolerance", "Distance tolerance to use to determine intersections.")]
         [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
-        public static bool IsContaining(this List<Polyline> panels, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
+        public static bool IsContaining(this List<Polyline> closedVolume, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {         
-            if (panels == null)
+            if (closedVolume == null)
             {
                 BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
                 return false;
@@ -729,7 +729,7 @@ namespace BH.Engine.Geometry
 
             List<Point> ctrPoints = new List<Point>();
             List<Plane> planes = new List<Plane>();
-            foreach (Polyline be in panels)
+            foreach (Polyline be in closedVolume)
             {
                 List <Point> srfPts = be.IControlPoints();
                 planes.Add(srfPts.FitPlane(tolerance));
@@ -738,20 +738,20 @@ namespace BH.Engine.Geometry
 
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
-            return IsContaining(panels, planes, boundingBox, point, acceptOnEdges);
+            return IsContaining(closedVolume, planes, boundingBox, point, acceptOnEdges);
         }
 
         /***************************************************/
 
         [Description("Checks if a list of points lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
-        [Input("panels", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
+        [Input("closedVolume", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
         [Input("points", "The points to check to see if it is contained within the bounds of the panels.")]
         [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]
         [Input("tolerance", "Distance tolerance to use to determine intersections.")]
         [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
-        public static List<bool> IsContaining(this List<Polyline> panels, List<Point> points, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
+        public static List<bool> IsContaining(this List<Polyline> closedVolume, List<Point> points, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
-            if (panels == null)
+            if (closedVolume == null)
             {
                 BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
                 return new List<bool>() { false };
@@ -759,7 +759,7 @@ namespace BH.Engine.Geometry
 
             List<Point> ctrPoints = new List<Point>();
             List<Plane> planes = new List<Plane>();
-            foreach (Polyline be in panels)
+            foreach (Polyline be in closedVolume)
             {
                 List<Point> srfPts = be.IControlPoints();
                 planes.Add(srfPts.FitPlane(tolerance));
@@ -768,20 +768,20 @@ namespace BH.Engine.Geometry
 
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
-            return points.Select(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges)).ToList();
+            return points.Select(point => IsContaining(closedVolume, planes, boundingBox, point, acceptOnEdges)).ToList();
         }
 
         /***************************************************/
 
         [Description("Checks if a point lies within a collection of polylines describing a closed volume contains each of a provided list of list of points.")]
-        [Input("panels", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
+        [Input("closedVolume", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
         [Input("pointLists", "The List of Lists of points to check to see if each List of points are contained within the bounds of the panels.")]
         [Input("acceptOnEdges", "Decide whether to allow the points to sit on the edge of the panel, default false.")]
         [Input("acceptPartialContainment", "Decide whether to allow some of the points to sit outside the panels as long as at least one is within them.")]
         [Output("isContaining", "True if the points of each sublist are contained within the bounds of the panels, false if it is not for each sublist of points provided.")]
-        public static List<bool> IsContaining(this List<Polyline> panels, List<List<Point>> pointLists, bool acceptOnEdges = false, bool acceptPartialContainment = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
+        public static List<bool> IsContaining(this List<Polyline> closedVolume, List<List<Point>> pointLists, bool acceptOnEdges = false, bool acceptPartialContainment = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
-            if (panels == null)
+            if (closedVolume == null)
             {
                 BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
                 return new List<bool>() { false };
@@ -789,7 +789,7 @@ namespace BH.Engine.Geometry
 
             List<Point> ctrPoints = new List<Point>();
             List<Plane> planes = new List<Plane>();
-            foreach (Polyline be in panels)
+            foreach (Polyline be in closedVolume)
             {
                 List<Point> srfPts = be.IControlPoints();
                 planes.Add(srfPts.FitPlane(tolerance));
@@ -804,9 +804,9 @@ namespace BH.Engine.Geometry
             {
                 bool isContained = false;
                 if (acceptPartialContainment)
-                    isContained = pts.Any(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges));
+                    isContained = pts.Any(point => IsContaining(closedVolume, planes, boundingBox, point, acceptOnEdges));
                 else
-                    isContained = pts.All(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges));
+                    isContained = pts.All(point => IsContaining(closedVolume, planes, boundingBox, point, acceptOnEdges));
                 areContained.Add(isContained);
             }
 
@@ -818,14 +818,14 @@ namespace BH.Engine.Geometry
         /***************************************************/
 
         [Description("Checks if a point lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
-        [Input("panels", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
+        [Input("closedVolume", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
         [Input("planes", "Planes corresponding to each panel for intersection calculations.")]
         [Input("boundingBox", "The bounding box of the collection of panels.")]
         [Input("point", "The point to check to see if it is contained within the bounds of the panels.")]
         [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]
         [Input("tolerance", "Distance tolerance to use to determine intersections.")]
         [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
-        private static bool IsContaining(this List<Polyline> panels, List<Plane> planes, BoundingBox boundingBox, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
+        private static bool IsContaining(this List<Polyline> closedVolume, List<Plane> planes, BoundingBox boundingBox, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
             //Return if point is null even without checking boundingBox.IsContaining(point)
             if (point == null)
@@ -869,7 +869,7 @@ namespace BH.Engine.Geometry
 
                     List<Point> intersectingPoints = new List<oM.Geometry.Point>();
                     intersectingPoints.Add(BH.Engine.Geometry.Query.PlaneIntersection(line, planes[x], true, tolerance));
-                    Polyline pLine = panels[x];
+                    Polyline pLine = closedVolume[x];
 
                     if (intersectingPoints != null && BH.Engine.Geometry.Query.IsContaining(pLine, intersectingPoints, true, tolerance))
                         intersectPoints.AddRange(intersectingPoints);
@@ -881,7 +881,7 @@ namespace BH.Engine.Geometry
             if (!isContained && acceptOnEdges)
             {
                 //Check the edges in case the point is on the edge of the BE
-                foreach (Polyline p in panels)
+                foreach (Polyline p in closedVolume)
                 {
                     List<Line> subParts = p.ISubParts() as List<Line>;
                     foreach (Line l in subParts)

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -878,23 +878,23 @@ namespace BH.Engine.Geometry
             return isContained; //If the number of intersections is odd the point is outsde the space
         }
 
-        public static List<Line> UniqueSegments(this List<Polyline> outlines, double tolerance)
+        private static List<Line> UniqueSegments(this List<Polyline> outlines, double tolerance)
         {
             double sqTol = tolerance * tolerance;
             List<Line> lines = new List<Line>();
             foreach (Line line in outlines.SelectMany(x => x.SubParts()))
             {
-                if (lines.All(x => !x.IsEqual(line)))
+                if (lines.All(x => !x.IsSimilar(line, tolerance)))
                     lines.Add(line);
             }
 
             return lines;
         }
 
-        public static bool IsSimilar(this Line line1, Line line2, double squareTolerance)
+        private static bool IsSimilar(this Line line1, Line line2, double squareTolerance)
         {
             return (line1.Start.SquareDistance(line2.Start) <= squareTolerance || line1.Start.SquareDistance(line2.End) <= squareTolerance)
-                && (line1.End.SquareDistance(line2.Start) <= squareTolerance && line1.End.SquareDistance(line2.End) <= squareTolerance);
+                && (line1.End.SquareDistance(line2.Start) <= squareTolerance || line1.End.SquareDistance(line2.End) <= squareTolerance);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -838,16 +838,10 @@ namespace BH.Engine.Geometry
             do
             {
                 int seed = 1;
-                 rVec = BH.Engine.Geometry.Create.RandomVector(seed); 
-                
-                isInPlane = false;
-                foreach (Plane p in planes)
-                    isInPlane = isInPlane || rVec.IsInPlane(p, tolerance);
-
+                rVec = BH.Engine.Geometry.Create.RandomVector(seed).Normalise();
+                isInPlane = planes.Any(p => rVec.IsInPlane(p, tolerance));
                 if (isInPlane)
-                {
-                    seed += 1;
-                }
+                    seed++;
             }
             while (isInPlane);
 
@@ -872,12 +866,7 @@ namespace BH.Engine.Geometry
 
             if (!isContained && acceptOnEdges)
             {
-                //Check the edges in case the point is on the edge of the BE
-                foreach (Polyline p in closedVolume)
-                {
-                    if (point.IsOnCurve(p, tolerance))
-                        isContained = true;
-                }
+                isContained = closedVolume.Any(p => point.IsOnCurve(p, tolerance));
             }
 
             return isContained; //If the number of intersections is odd the point is outsde the space

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -745,15 +745,14 @@ namespace BH.Engine.Geometry
         [Input("panels", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
         [Input("points", "The points to check to see if it is contained within the bounds of the panels.")]
         [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]
-        [Input("acceptPartialContainment", "Decide whether to allow some of the points to sit outside the panels as long as at least one is within them.")]
         [Input("tolerance", "Distance tolerance to use to determine intersections.")]
         [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
-        public static bool IsContaining(this List<Polyline> panels, List<Point> points, bool acceptPartialContainment = false, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
+        public static List<bool> IsContaining(this List<Polyline> panels, List<Point> points, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
         {
             if (panels == null)
             {
                 BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
-                return false;
+                return new List<bool>() { false };
             }
 
             List<Plane> planes = new List<Plane>();
@@ -763,10 +762,7 @@ namespace BH.Engine.Geometry
             List<Point> ctrPoints = panels.SelectMany(x => x.IControlPoints()).ToList();
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
 
-            if (acceptPartialContainment)
-                return points.Any(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges));
-            else
-                return points.All(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges));
+            return points.Select(point => IsContaining(panels, planes, boundingBox, point, acceptOnEdges)).ToList();
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -846,16 +846,12 @@ namespace BH.Engine.Geometry
                 if (isValid)
                 {
                     line = new Line { Start = point, End = point + rVec * rayLength };
-                    isValid = uniqueEdges.All(x => line.LineIntersection(x, false, tolerance) == null);
                 }
 
                 if (!isValid)
                     seed++;
             }
             while (!isValid);
-
-            //Use a length longer than the longest side in the bounding box. Change to infinite line?
-            //Line line = new Line() { Start = point, End = point.Translate(rVec * (((boundingBox.Max - boundingBox.Min).Length()) * 10)) };
 
             //Check intersections
             List<Point> intersectPoints = new List<Point>();
@@ -900,8 +896,6 @@ namespace BH.Engine.Geometry
             return (line1.Start.SquareDistance(line2.Start) <= squareTolerance || line1.Start.SquareDistance(line2.End) <= squareTolerance)
                 && (line1.End.SquareDistance(line2.Start) <= squareTolerance && line1.End.SquareDistance(line2.End) <= squareTolerance);
         }
-
-
 
         /***************************************************/
         /**** Public Methods - Interfaces               ****/

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -770,7 +770,7 @@ namespace BH.Engine.Geometry
         {
             if (closedVolume == null)
             {
-                BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
+                BH.Engine.Base.Compute.RecordError("Cannot query if a collection of polylines contains a point if the polylines are null.");
                 return new List<bool>() { false };
             }
 
@@ -783,6 +783,12 @@ namespace BH.Engine.Geometry
                 if (fitPlane != null)
                     planes.Add(fitPlane);
                 ctrPoints.AddRange(srfPts);
+            }
+
+            if (ctrPoints == null || ctrPoints.Count == 0)
+            {
+                BH.Engine.Base.Compute.RecordError("Polylines provided had no control points, indicating missing or corrupt geometry.");
+                return new List<bool>() { false };
             }
 
             BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -713,32 +713,30 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Closed Volume Polylines  ****/
         /***************************************************/
 
-        [Description("Checks if each of the provided points lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
+        [Description("Checks if a point lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
+        [Input("closedVolume", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
+        [Input("point", "The point to check to see if it is contained within the bounds of the panels.")]
+        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]
+        [Input("tolerance", "Distance tolerance to use to determine intersections.")]
+        [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
+        public static bool IsContaining(this List<Polyline> closedVolume, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
+        {
+            List<Point> pointLists = new List<Point>() { point };
+            return IsContaining(closedVolume, pointLists, acceptOnEdges, tolerance).First();
+        }
+
+        /***************************************************/
+
+        [Description("Checks if a list of points lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
         [Input("closedVolume", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
         [Input("points", "The points to check to see if it is contained within the bounds of the panels.")]
         [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]
         [Input("tolerance", "Distance tolerance to use to determine intersections.")]
         [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
         public static List<bool> IsContaining(this List<Polyline> closedVolume, List<Point> points, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
-        {
-            if (closedVolume == null)
-            {
-                BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
-                return new List<bool>() { false };
-            }
-
-            List<Point> ctrPoints = new List<Point>();
-            List<Plane> planes = new List<Plane>();
-            foreach (Polyline be in closedVolume)
-            {
-                List<Point> srfPts = be.IControlPoints();
-                planes.Add(srfPts.FitPlane(tolerance));
-                ctrPoints.AddRange(srfPts);
-            }
-
-            BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
-
-            return points.Select(point => IsContaining(closedVolume, planes, boundingBox, point, acceptOnEdges)).ToList();
+        {           
+            List<List<Point>> pointLists = points.Select(x => new List<Point>() { x }).ToList();
+            return IsContaining(closedVolume, pointLists, acceptOnEdges, false, tolerance);
         }
 
         /***************************************************/

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -713,37 +713,7 @@ namespace BH.Engine.Geometry
         /**** Public Methods - Closed Volume Polylines  ****/
         /***************************************************/
 
-        [Description("Checks if a point lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
-        [Input("closedVolume", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
-        [Input("point", "The point to check to see if it is contained within the bounds of the panels.")]
-        [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]
-        [Input("tolerance", "Distance tolerance to use to determine intersections.")]
-        [Output("isContaining", "True if the point is contained within the bounds of the panels, false if it is not for each point provided.")]
-        public static bool IsContaining(this List<Polyline> closedVolume, Point point, bool acceptOnEdges = false, double tolerance = BH.oM.Geometry.Tolerance.Distance)
-        {         
-            if (closedVolume == null)
-            {
-                BH.Engine.Base.Compute.RecordError("Cannot query if a collection of panels contains a point if the panels are null.");
-                return false;
-            }
-
-            List<Point> ctrPoints = new List<Point>();
-            List<Plane> planes = new List<Plane>();
-            foreach (Polyline be in closedVolume)
-            {
-                List <Point> srfPts = be.IControlPoints();
-                planes.Add(srfPts.FitPlane(tolerance));
-                ctrPoints.AddRange(srfPts);
-            }
-
-            BoundingBox boundingBox = BH.Engine.Geometry.Query.Bounds(ctrPoints);
-
-            return IsContaining(closedVolume, planes, boundingBox, point, acceptOnEdges);
-        }
-
-        /***************************************************/
-
-        [Description("Checks if a list of points lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
+        [Description("Checks if each of the provided points lies within a collection of polylines describing a closed volume using their primitive planes and bounds.")]
         [Input("closedVolume", "A collection of Polylines outlining each of the faces of the closed volume to check with.")]
         [Input("points", "The points to check to see if it is contained within the bounds of the panels.")]
         [Input("acceptOnEdges", "Decide whether to allow the point to sit on the edge of the panel, default false.")]

--- a/Geometry_Engine/Query/IsContaining.cs
+++ b/Geometry_Engine/Query/IsContaining.cs
@@ -29,7 +29,6 @@ using System.ComponentModel;
 using BH.oM.Quantities.Attributes;
 using BH.oM.Base;
 using BH.oM.Geometry.CoordinateSystem;
-using System.Numerics;
 
 namespace BH.Engine.Geometry
 {

--- a/Structure_Engine/Modify/SetAnalysisParameters.cs
+++ b/Structure_Engine/Modify/SetAnalysisParameters.cs
@@ -82,7 +82,7 @@ namespace BH.Engine.Structure
                 timber.YoungsModulus = new Vector { X = timber.E_0_k, Y = timber.E_90_Mean, Z = timber.E_90_Mean };
                 timber.ShearModulus = new Vector { X = timber.G_Mean, Y = timber.G_Mean, Z = timber.G_Mean };
 
-                message = $"{nameof(SawnTimber)} materials does not contain characteristic values for youngs modulus perpendicular. Mean value of perpendicular stiffness used." + Environment.NewLine;
+                message = $"{nameof(SawnTimber)} materials does not contain characteristic values for youngs modulus perpendicular. Mean value of perpendicular stiffness used." + System.Environment.NewLine;
                 message += $"{nameof(SawnTimber)} only contains mean value for shear modulus, no characteristic values or rolling shear stiffness. Mean shear stiffness ({nameof(timber.G_Mean)}) will be applied in all directions.";
             }
             timber.SetPoissonsRatio(poissonsRatio_0_90, poissonsRatio_90_90);

--- a/Structure_Engine/Modify/SetAnalysisParameters.cs
+++ b/Structure_Engine/Modify/SetAnalysisParameters.cs
@@ -82,7 +82,7 @@ namespace BH.Engine.Structure
                 timber.YoungsModulus = new Vector { X = timber.E_0_k, Y = timber.E_90_Mean, Z = timber.E_90_Mean };
                 timber.ShearModulus = new Vector { X = timber.G_Mean, Y = timber.G_Mean, Z = timber.G_Mean };
 
-                message = $"{nameof(SawnTimber)} materials does not contain characteristic values for youngs modulus perpendicular. Mean value of perpendicular stiffness used." + System.Environment.NewLine;
+                message = $"{nameof(SawnTimber)} materials does not contain characteristic values for youngs modulus perpendicular. Mean value of perpendicular stiffness used." + Environment.NewLine;
                 message += $"{nameof(SawnTimber)} only contains mean value for shear modulus, no characteristic values or rolling shear stiffness. Mean shear stiffness ({nameof(timber.G_Mean)}) will be applied in all directions.";
             }
             timber.SetPoissonsRatio(poissonsRatio_0_90, poissonsRatio_90_90);


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3198 and #3199 

Methods for IsContaining were added to Geometry_Engine, and the ElementsInSpace method was moved to analytical. Both now work off polylines and regions respectively to allow for wider usage outside of the Environment_Engine.


### Test files
[Test Script](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Environment_Engine/%233199-IsContaining_Refactor?csf=1&web=1&e=o1EJ7L)