### PR TITLE
Humans_Engine: Update View Quality DocumentationURL

### DIFF
--- a/Humans_Engine/Query/CvalueAnalysis.cs
+++ b/Humans_Engine/Query/CvalueAnalysis.cs
@@ -44,7 +44,7 @@ namespace BH.Engine.Humans.ViewQuality
         [Input("playingArea", "Polyline to be used for defining edge of performance or playing area.")]
         [Input("focalPoint", "Point defining a single focal point used by all spectators. Used only when CvalueFocalMethodEnum is SinglePoint.")]
         [Output("results", "Collection of Cvalue results.")]
-        [DocumentationURL("https://bhom.xyz/documentation/Conventions/BHoM-View-quality-conventions/", oM.Base.Attributes.Enums.DocumentationType.Documentation)]
+        [DocumentationURL("https://bhom.xyz/documentation/BHoM_Engine/Humans_Engine/ViewQuality/", oM.Base.Attributes.Enums.DocumentationType.Documentation)]
         public static List<Cvalue> CvalueAnalysis(this Audience audience, CvalueSettings settings, Polyline playingArea, Point focalPoint = null)
         {
             if (audience == null || settings == null || playingArea == null)
@@ -65,7 +65,7 @@ namespace BH.Engine.Humans.ViewQuality
         [Input("playingArea", "Polyline to be used for defining edge of performance or playing area.")]
         [Input("focalPoint", "Point defining a single focal point used by all spectators. Used only when CvalueFocalMethodEnum is SinglePoint.")]
         [Output("results", "Collection of Cvalue results.")]
-        [DocumentationURL("https://bhom.xyz/documentation/Conventions/BHoM-View-quality-conventions/", oM.Base.Attributes.Enums.DocumentationType.Documentation)]
+        [DocumentationURL("https://bhom.xyz/documentation/BHoM_Engine/Humans_Engine/ViewQuality/", oM.Base.Attributes.Enums.DocumentationType.Documentation)]
         public static List<List<Cvalue>> CvalueAnalysis(this List<Audience> audience, CvalueSettings settings, Polyline playingArea, Point focalPoint = null)
         {
             if (audience == null || settings == null || playingArea == null)


### PR DESCRIPTION
Fixing the Documentation URLs to the Humans Engine View Quality Conventions

As part of the Documentation restructuring as per issue https://github.com/BHoM/documentation/issues/85


I matched the new location of the Humans View Quality Conventions page to be both within the BHoM Engine documentation navigation and then with in the same Discipline Engine and Namespace of the methods being documented. 

Which seems a logical approach. But as we expand our documentation - will be good to formalise (and document 😄) our documentation conventions further.

@travispotterBH @pawelbaran very relevant to our conversations around documentation long term strategy 