### PR TITLE
Analytical_Engine: Fix Querying geometry of Panel

### DIFF
--- a/Analytical_Engine/Query/Geometry.cs
+++ b/Analytical_Engine/Query/Geometry.cs
@@ -82,9 +82,9 @@ namespace BH.Engine.Analytical
             where TEdge : IEdge
             where TOpening : IOpening<TEdge>
         {
-            return new PlanarSurface(
-                    Engine.Geometry.Compute.IJoin(panel?.ExternalEdges?.Select(x => x?.Curve).ToList()).FirstOrDefault(),
-                    panel?.Openings.SelectMany(x => Engine.Geometry.Compute.IJoin(x?.Edges.Select(y => y?.Curve).ToList())).Cast<ICurve>().ToList());
+            return Engine.Geometry.Create.PlanarSurface(
+                Engine.Geometry.Compute.IJoin(panel?.ExternalEdges?.Select(x => x?.Curve).ToList()).FirstOrDefault(),
+                panel?.Openings.SelectMany(x => Engine.Geometry.Compute.IJoin(x?.Edges.Select(y => y?.Curve).ToList())).Cast<ICurve>().ToList());
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #2363

<!-- Add short description of what has been fixed -->
Querying the geometry of an IPanel<IEdge, IOpening> now can no longer produce a non-planar PlanarSurface if the Panel in question is non-planar.

### Test files
<!-- Link to test files to validate the proposed changes -->
[#2356 -IsPlanar-PlanarSurface.zip](https://github.com/BHoM/BHoM_Engine/files/13904856/2356.-IsPlanar-PlanarSurface.zip)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->