### PR TITLE
BHoM_Engine: Replace \\ in description attributes with /

### DIFF
--- a/BHoM_Engine/Query/BHoMFolder.cs
+++ b/BHoM_Engine/Query/BHoMFolder.cs
@@ -33,7 +33,7 @@ namespace BH.Engine.Base
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Returns the folder path for the top level assemblies directory, for example for the C: drive it will return C:\\ProgramData\\BHoM\\Assemblies")]
+        [Description("Returns the folder path for the top level assemblies directory, for example for the C: drive it will return C:/ProgramData/BHoM/Assemblies")]
         public static string BHoMFolder()
         {
             return System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Assemblies");
@@ -41,7 +41,7 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
-        [Description("Returns the folder path for the top level datasets directory, for example for the C: drive it will return C:\\ProgramData\\BHoM\\Datasets")]
+        [Description("Returns the folder path for the top level datasets directory, for example for the C: drive it will return C:/ProgramData/BHoM/Datasets")]
         public static string BHoMFolderDatasets()
         {
             return System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Datasets");
@@ -49,7 +49,7 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
-        [Description("Returns the folder path for the top level extensions directory, for example for the C: drive it will return C:\\ProgramData\\BHoM\\Extensions")]
+        [Description("Returns the folder path for the top level extensions directory, for example for the C: drive it will return C:/ProgramData/BHoM/Extensions")]
         public static string BHoMFolderExtensions()
         {
             return System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Extensions");
@@ -57,7 +57,7 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
-        [Description("Returns the folder path for the top level logs directory, for example for the C: drive it will return C:\\ProgramData\\BHoM\\Logs")]
+        [Description("Returns the folder path for the top level logs directory, for example for the C: drive it will return C:/ProgramData/BHoM/Logs")]
         public static string BHoMFolderLogs()
         {
             return System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Logs");
@@ -65,7 +65,7 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
-        [Description("Returns the folder path for the top level resources directory, for example for the C: drive it will return C:\\ProgramData\\BHoM\\Resources")]
+        [Description("Returns the folder path for the top level resources directory, for example for the C: drive it will return C:/ProgramData/BHoM/Resources")]
         public static string BHoMFolderResources()
         {
             return System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Resources");
@@ -73,7 +73,7 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
-        [Description("Returns the folder path for the top level settings directory, for example for the C: drive it will return C:\\ProgramData\\BHoM\\Settings")]
+        [Description("Returns the folder path for the top level settings directory, for example for the C: drive it will return C:/ProgramData/BHoM/Settings")]
         public static string BHoMFolderSettings()
         {
             return System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Settings");
@@ -81,7 +81,7 @@ namespace BH.Engine.Base
 
         /***************************************************/
 
-        [Description("Returns the folder path for the top level upgrades directory, which houses sub-directories for upgraders for different BHoM versions. For example for the C: drive it will return C:\\ProgramData\\BHoM\\Upgrades")]
+        [Description("Returns the folder path for the top level upgrades directory, which houses sub-directories for upgraders for different BHoM versions. For example for the C: drive it will return C:/ProgramData/BHoM/Upgrades")]
         public static string BHoMFolderUpgrades()
         {
             return System.IO.Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.CommonApplicationData), "BHoM", "Upgrades");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3227 

<!-- Add short description of what has been fixed -->
Description attributes which referred to file paths now use `/` instead of `\\` as there are some json issues during beta deployment.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->