### PR TITLE
Environment_Engine: Compute Openings from a list of panels and a glazing ratio

### DIFF
--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -20,7 +20,7 @@ namespace BH.Engine.Environment
         [Input("glazingLocations", "The point in 3D space corresponding to the desired locations of the openings.")]
         [Input("glazingRatio", "Ratio of total external panel surface area and glazed area. Ratio as decimal {0-1}.")]
         [Input("panelsToIgnore", "Optional input for selecting a collection of Environment Panels to be ignored in the calculation")]
-        [Input("sillHeight", "Optional input for defining the distance between the base of the panel and the bottom of the opening - default: 0.5m.")]
+        [Input("sillHeight", "Optional input for defining the distance between the base of the panel and the bottom of the opening - default: 0.5.")]
         [Input("openingHeight", "Optional input for defining the height of opening - default: 1.2m.")]
         [Input("openingType", "Optional input for defining the opening type of the output Openings, can be either 'Glazing' or 'Door' - default: Glazing.")]
         [Output("openings", "Returns the openings.")]

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -1,4 +1,26 @@
-﻿using BH.Engine.Geometry;
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2024, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Geometry;
 using BH.oM.Base;
 using BH.oM.Base.Attributes;
 using BH.oM.Environment.Configuration;

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -91,7 +91,7 @@ namespace BH.Engine.Environment
             //area avaialable per for new glazing is area avaialble minus area used by other galzing 
             //area per window avaialable is total area left divided for number of windows
             //window width is then area per window divided by the entered height
-            double areaRequiredPerWindow = (area * glazingRatio - existingGlazingArea)/numberOfWindows;
+            double areaRequiredPerWindow = (area * glazingRatio - existingGlazingArea) / numberOfWindows;
             return areaRequiredPerWindow / height;
         }
     }

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -23,7 +23,7 @@ namespace BH.Engine.Environment
         [Input("sillHeight", "Optional input for defining the distance between the base of the panel and the bottom of the opening - default: 0.5.")]
         [Input("openingHeight", "Optional input for defining the height of opening - default: 1.2.")]
         [Input("openingType", "Optional input for defining the opening type of the output Openings, can be either 'Glazing' or 'Door' - default: Glazing.")]
-        [Output("openings", "Returns the openings.")]
+        [Output("openings", "Returns the constructed openings which can then be applied to panels.")]
         public static List<Opening> OpeningsFromGlazingRatio(
             List<List<Panel>> panelsAsSpaces,
             List<Point> glazingLocations,

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -15,7 +15,7 @@ namespace BH.Engine.Environment
 {
     public static partial class Compute
     {
-        [Description("Creates openings for input Panels at the locations provided.\n The total area of the openings is equal to the total area of the external panels, multiplied by the glazing ratio.")]
+        [Description("Creates openings for input Panels at the locations provided.\nThe total area of the openings is equal to the total area of the external panels, multiplied by the glazing ratio.")]
         [Input("panelsAsSpaces", "Panels as spaces - A collection of Environment Panels which will be used to identify the host panel for the opening from the provided location point.")]
         [Input("glazingLocations", "The point in 3D space corresponding to the desired locations of the openings.")]
         [Input("glazingRatio", "Ratio of total external panel surface area and glazed area. Ratio as decimal {0-1}.")]

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -15,7 +15,7 @@ namespace BH.Engine.Environment
 {
     public static partial class Compute
     {
-        [Description("Creates openings on the input panels at the locations provided.\n The total area of the openings is equal to the total area of the external panels, multiplied by the glazing ratio.")]
+        [Description("Creates openings for input Panels at the locations provided.\n The total area of the openings is equal to the total area of the external panels, multiplied by the glazing ratio.")]
         [Input("panelsAsSpaces", "Panels as spaces - A collection of Environment Panels which will be used to identify the host panel for the opening from the provided location point.")]
         [Input("glazingLocations", "The point in 3D space corresponding to the desired locations of the openings.")]
         [Input("glazingRatio", "Ratio of total external panel surface area and glazed area. Ratio as decimal {0-1}.")]

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -68,13 +68,9 @@ namespace BH.Engine.Environment
                 Opening opening = Create.Opening(point, option, filteredPanels);
 
                 if(opening != null)
-                {
                     openings.Add(opening);
-                }
                 else
-                {
-                    BH.Engine.Base.Compute.RecordWarning($"Could not find a host panel for the opening at ({point.X}, {point.Y}, {point.Z}).");
-                }
+                    BH.Engine.Base.Compute.RecordWarning($"Could not find a host panel for the opening at ({point.X}, {point.Y}, {point.Z}). An Opening has not been created for this location.");
             }
 
             return openings;

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -15,6 +15,10 @@ namespace BH.Engine.Environment
 {
     public static partial class Compute
     {
+        /***************************************************/
+        /**** Public methods                            ****/
+        /***************************************************/
+
         [Description("Creates openings for input Panels at the locations provided.\nThe total area of the openings is equal to the total area of the external panels, multiplied by the glazing ratio.")]
         [Input("panelsAsSpaces", "Panels as spaces - A collection of Environment Panels which will be used to identify the host panel for the opening from the provided location point.")]
         [Input("glazingLocations", "The point in 3D space corresponding to the desired locations of the openings.")]
@@ -76,6 +80,10 @@ namespace BH.Engine.Environment
             return openings;
         }
 
+        /***************************************************/
+        /**** Private methods                           ****/
+        /***************************************************/
+
         private static double WindowWidth(
             double area,
             double glazingRatio,
@@ -90,5 +98,8 @@ namespace BH.Engine.Environment
             double areaRequiredPerWindow = (area * glazingRatio - existingGlazingArea) / numberOfWindows;
             return areaRequiredPerWindow / height;
         }
+
+
+        /***************************************************/
     }
 }

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -36,8 +36,8 @@ namespace BH.Engine.Environment
         {
             switch (openingType)
             {
+                case OpeningType.Undefined:
                 case OpeningType.Door:
-                    break;
                 case OpeningType.Glazing:
                     break;
                 default:
@@ -45,7 +45,7 @@ namespace BH.Engine.Environment
                     return new List<Opening>();
             }
 
-            List<Panel> wallPanels =  Query.FilterPanelsByType(panelsAsSpaces.SelectMany(x => x).Distinct().ToList(), new List<PanelType>() { PanelType.Wall }).Item1;
+            List<Panel> wallPanels = Query.FilterPanelsByType(panelsAsSpaces.SelectMany(x => x).Distinct().ToList(), new List<PanelType>() { PanelType.Wall }).Item1;
             List<Panel> externalPanels = wallPanels.IsExternal().Item1;
             List<Panel> filteredPanels = externalPanels.RemovePanels(panelsToIgnore ?? new List<Panel>());
 
@@ -62,9 +62,11 @@ namespace BH.Engine.Environment
             };
 
             List<Opening> openings = new List<Opening>();
+
             foreach(Point point in glazingLocations)
             {
                 Opening opening = Create.Opening(point, option, filteredPanels);
+
                 if(opening != null)
                 {
                     openings.Add(opening);
@@ -74,6 +76,7 @@ namespace BH.Engine.Environment
                     BH.Engine.Base.Compute.RecordWarning($"Could not find a host panel for the opening at ({point.X}, {point.Y}, {point.Z}).");
                 }
             }
+
             return openings;
         }
 

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -21,7 +21,7 @@ namespace BH.Engine.Environment
         [Input("glazingRatio", "Ratio of total external panel surface area and glazed area. Ratio as decimal {0-1}.")]
         [Input("panelsToIgnore", "Optional input for selecting a collection of Environment Panels to be ignored in the calculation")]
         [Input("sillHeight", "Optional input for defining the distance between the base of the panel and the bottom of the opening - default: 0.5.")]
-        [Input("openingHeight", "Optional input for defining the height of opening - default: 1.2m.")]
+        [Input("openingHeight", "Optional input for defining the height of opening - default: 1.2.")]
         [Input("openingType", "Optional input for defining the opening type of the output Openings, can be either 'Glazing' or 'Door' - default: Glazing.")]
         [Output("openings", "Returns the openings.")]
         public static List<Opening> OpeningsFromGlazingRatio(

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -45,7 +45,7 @@ namespace BH.Engine.Environment
                     return new List<Opening>();
             }
 
-            List<Panel> wallPanels = Query.FilterPanelsByType(panelsAsSpaces.SelectMany(x => x).Distinct().ToList(), new List<PanelType>() { PanelType.Wall }).Item1;
+            List<Panel> wallPanels = panelsAsSpaces.SelectMany(x => x).Distinct().ToList();
             List<Panel> externalPanels = wallPanels.IsExternal().Item1;
             List<Panel> filteredPanels = externalPanels.RemovePanels(panelsToIgnore ?? new List<Panel>());
 

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Environment
             List<Panel> externalPanels = wallPanels.IsExternal().Item1;
             List<Panel> filteredPanels = externalPanels.RemovePanels(panelsToIgnore ?? new List<Panel>());
 
-            double totalArea = filteredPanels.Select(x=>x.Area()).Sum();
+            double totalArea = filteredPanels.Select(x => x.Area()).Sum();
             double existingOpeningArea = filteredPanels.Select(x => x.Openings.Select(y => y.Polyline().Area()).Sum()).Sum();
             double windowWidth = WindowWidth(totalArea, glazingRatio, glazingLocations.Count(), openingHeight, existingOpeningArea);
 

--- a/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
+++ b/Environment_Engine/Compute/OpeningsFromGlazingRatio.cs
@@ -1,0 +1,90 @@
+﻿using BH.Engine.Geometry;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Environment.Configuration;
+using BH.oM.Environment.Elements;
+using BH.oM.Geometry;
+using ICSharpCode.Decompiler.IL.Patterns;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+
+namespace BH.Engine.Environment
+{
+    public static partial class Compute
+    {
+        [Description("Creates openings on the panels, at the locations provided, where the total opening area is the provided glazing ratio of the total external panel areas.")]
+        [Input("panelsAsSpaces", "Panels as spaces - A collection of Environment Panels which will be used to identify the host panel for the opening from the provided location point.")]
+        [Input("glazingLocations", "The point in 3D space where the opening should begin to be generated.")]
+        [Input("glazingRatio", "Ratio of total external panel surface area and glazed area. Ratio as decimal {0-1}.")]
+        [Input("panelsToIgnore", "Optional input for selecting a collection of Environment Panels to be ignored in the calculation - ")]
+        [Input("sillHeight", "Optional input for defining the distance between the base of the panel and the bottom of the opening - default = 0.5m.")]
+        [Input("openingHeight", "Optional input for defining the height of opening - default = 1.2m.")]
+        [Output("openings", "Returns the openings.")]
+        public static List<Opening> OpeningsFromGlazingRatio(
+            List<List<Panel>> panelsAsSpaces,
+            List<Point> glazingLocations,
+            double glazingRatio,
+            List<Panel> panelsToIgnore = null,
+            double sillHeight = 0.5,
+            double openingHeight = 1.2,
+            OpeningType openingType = OpeningType.Glazing
+            ) 
+        {
+            switch (openingType)
+            {
+                case OpeningType.Door:
+                    break;
+                case OpeningType.Glazing:
+                    break;
+                default:
+                    BH.Engine.Base.Compute.RecordError($"Error: type: {openingType} is not supported, please use type: 'Glazing' or 'Door'.");
+                    return new List<Opening>();
+            }
+
+            List<Panel> wallPanels =  Query.FilterPanelsByType(panelsAsSpaces.SelectMany(x => x).Distinct().ToList(), new List<PanelType>() { PanelType.Wall }).Item1;
+            List<Panel> externalPanels = wallPanels.IsExternal().Item1;
+            List<Panel> filteredPanels = externalPanels.RemovePanels(panelsToIgnore);
+
+            double totalArea = filteredPanels.Select(x=>x.Area()).Sum();
+            double existingOpeningArea = filteredPanels.Select(x => x.Openings.Select(y => y.Polyline().Area()).Sum()).Sum();
+            double windowWidth = WindowWidth(totalArea, glazingRatio, glazingLocations.Count(), openingHeight, existingOpeningArea);
+
+            OpeningOption option = new OpeningOption()
+            {
+                Height = openingHeight,
+                Width = windowWidth,
+                SillHeight = sillHeight,
+                Type = openingType,
+            };
+
+            List<Opening> openings = new List<Opening>();
+            foreach(Point point in glazingLocations)
+            {
+                Opening opening = Create.Opening(point, option, filteredPanels);
+                if(opening != null)
+                {
+                    openings.Add(opening);
+                }
+            }
+            return openings;
+        }
+
+        private static double WindowWidth(
+            double area,
+            double glazingRatio,
+            double numberOfWindows,
+            double height,
+            double existingGlazingArea)
+        {
+            //area available for glazing is total area * glazing ratio
+            //area avaialable per for new glazing is area avaialble minus area used by other galzing 
+            //area per window avaialable is total area left divided for number of windows
+            //window width is then area per window divided by the entered height
+            double areaRequiredPerWindow = (area * glazingRatio - existingGlazingArea)/numberOfWindows;
+            return areaRequiredPerWindow / height;
+        }
+    }
+}


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3226

<!-- Add short description of what has been fixed -->

Added compute method, as described in the linked issue, the method calculates window sizes based on glazing ratio, for externally facing panels and creates openings.

### Test files
<!-- Link to test files to validate the proposed changes -->
[OpeningsByGlazingByRatioTestScript.zip](https://github.com/BHoM/BHoM_Engine/files/14163921/OpeningsByGlazingByRatioTestScript.zip)
Unzip, open in Rhino and check actual area is equal to expected area 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->