### PR TITLE
Serialiser_Engine: Stop throwing error on System.DBNull

### DIFF
--- a/Serialiser_Engine/Compute/Serialise.cs
+++ b/Serialiser_Engine/Compute/Serialise.cs
@@ -23,7 +23,6 @@
 using BH.oM.Base;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
-using MongoDB.Bson.Serialization.Serializers;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/Serialiser_Engine/Compute/Serialise.cs
+++ b/Serialiser_Engine/Compute/Serialise.cs
@@ -23,6 +23,7 @@
 using BH.oM.Base;
 using MongoDB.Bson;
 using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization.Serializers;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -63,7 +64,7 @@ namespace BH.Engine.Serialiser
 
         private static void Serialise(this object value, BsonDocumentWriter writer, Type targetType)
         {
-            if (value == null)
+            if (value == null || value.GetType() == typeof(System.DBNull))
                 writer.WriteNull();
             else if (value.GetType() == typeof(object))
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3210 

<!-- Add short description of what has been fixed -->
after many hours of searching, finally found out that System.DBNull should serialise as null, so we should stop throwing errors when trying to serialise it.

### Test files
<!-- Link to test files  to validate the proposed changes -->
[3210-DBNullCannotBeSerialised.zip](https://github.com/BHoM/BHoM_Engine/files/14142502/3210-DBNullCannotBeSerialised.zip)
Run through instructions made by myself in parent issue.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->