### PR TITLE
Geometry_Engine: Tolerance introduced to the check of 2-dimensionality of the input point set

### DIFF
--- a/Geometry_Engine/Compute/FitLine.cs
+++ b/Geometry_Engine/Compute/FitLine.cs
@@ -37,7 +37,7 @@ namespace BH.Engine.Geometry
 
         [Description("Fits a line into a set of points using Orthogonal Least Squares algorithm.")]
         [Input("points", "Points into which the line is meant to be fit.")]
-        [Input("tolerance", "Distance tolerance to be used in the process of fitting.")]
+        [Input("tolerance", "Distance tolerance to be used to check whether a line can be fit into the input points (i.e. whether the points are not coincident).")]
         [Output("fitLine", "Line fit into the input set of points based on the Orthogonal Least Squares algorithm.")]
         public static Line FitLine(this IEnumerable<Point> points, double tolerance = Tolerance.Distance)
         {

--- a/Geometry_Engine/Compute/FitLine.cs
+++ b/Geometry_Engine/Compute/FitLine.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Geometry
         /****              Public Methods               ****/
         /***************************************************/
 
-        [Description("Fits a line into a set of points using Orthogonal Least Squares algorithm.")]
+        [Description("Fits a line into a set of points using Orthogonal Least Squares algorithm. Returns null if the number of non-duplicate points is less than two.")]
         [Input("points", "Points into which the line is meant to be fit.")]
         [Input("tolerance", "Distance tolerance to be used to check whether a line can be fit into the input points (i.e. whether the points are not coincident).")]
         [Output("fitLine", "Line fit into the input set of points based on the Orthogonal Least Squares algorithm.")]

--- a/Geometry_Engine/Compute/FitLine.cs
+++ b/Geometry_Engine/Compute/FitLine.cs
@@ -35,7 +35,7 @@ namespace BH.Engine.Geometry
         /****              Public Methods               ****/
         /***************************************************/
 
-        [Description("Fits a line into a set of points using Orthogonal Least Squares algorithm. Returns null if the number of non-duplicate points is less than two.")]
+        [Description("Fits a line into a set of points using Orthogonal Least Squares algorithm. Returns null if the number of non-coincident (within tolerance) points is less than two.")]
         [Input("points", "Points into which the line is meant to be fit.")]
         [Input("tolerance", "Distance tolerance to be used to check whether a line can be fit into the input points (i.e. whether the points are not coincident).")]
         [Output("fitLine", "Line fit into the input set of points based on the Orthogonal Least Squares algorithm.")]

--- a/Geometry_Engine/Compute/FitLine.cs
+++ b/Geometry_Engine/Compute/FitLine.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Geometry
         {
             List<Point> asList = points.ToList();
             int n = asList.Count;
-            if (n < 2)
+            if (asList.CullDuplicates(tolerance).Count < 2)
                 return null;
 
             Point C = points.Average();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3288

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?RootFolder=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FGeometry%5FEngine%2F%233293%2DMakeUseOfToleranceInFitLine&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->