### PR TITLE
BHoM_Engine: Fix ThrowError confusion for developers

### DIFF
--- a/BHoM_Engine/Compute/RecordEvent.cs
+++ b/BHoM_Engine/Compute/RecordEvent.cs
@@ -114,7 +114,7 @@ namespace BH.Engine.Base
                     OnEventRecorded(newEvent); //Only raise an event if we're not in switched off mode
             }
 
-            if (newEvent.Type == EventType.Error && !m_SuppressErrorThrowing && !m_SuppressError) //Only throw the event as an exception if someone has asked us to throw it, AND we aren't suppressing them
+            if (newEvent.Type == EventType.Error && m_ThrowError && !m_SuppressError) //Only throw the event as an exception if someone has asked us to throw it, AND we aren't suppressing them
                 throw new Exception(newEvent.ToText());
 
             return true;
@@ -149,7 +149,7 @@ namespace BH.Engine.Base
         private static bool m_SuppressWarning = false;
         private static bool m_SuppressNote = false;
 
-        private static bool m_SuppressErrorThrowing = true; //Default to true - do not throw errors as exceptions. However, if a user (developer user or UI user) has unsuppressed this, then errors will be thrown for try/catch statements to handle.
+        private static bool m_ThrowError = false; //Default to false - do not throw errors as exceptions. However, if a user (developer user or UI user) has unsuppressed this, then errors will be thrown for try/catch statements to handle.
         //ToDo: Discuss whether we want this to be true by default and have BHoM_UI switch it off on load, or keep as is. FYI @alelom
     }
 }

--- a/BHoM_Engine/Compute/ThrowErrorsAsExceptions.cs
+++ b/BHoM_Engine/Compute/ThrowErrorsAsExceptions.cs
@@ -35,10 +35,10 @@ namespace BH.Engine.Base
         /***************************************************/
 
         [Description("Decide whether or not to have BHoM Events of type error thrown as C# excceptions or not. Default behaviour of BHoM Event log is for errors to NOT be thrown. Turn this off if you would like to catch BHoM Events of type error as C# exceptions.")]
-        [Input("suppressErrorThrowing", "Set this to false if you want to have BHoM Events of type Error to be thrown when they are logged. Set this to true if you do NOT want this to happen (default BHoM Log behaviour).")]
-        public static void ThrowError(bool suppressErrorThrowing)
+        [Input("throwErrorsAsExceptions", "Set this to true if you want to have BHoM Events of type Error to be thrown as Exceptions when they are logged. Set this to false if you do NOT want this to happen (default BHoM Log behaviour).")]
+        public static void ThrowErrorsAsExceptions(bool throwErrorsAsExceptions)
         {
-            m_SuppressErrorThrowing = suppressErrorThrowing;
+            m_ThrowError = throwErrorsAsExceptions;
         }
     }
 }


### PR DESCRIPTION
Fixes #3301

This will now make it so that `ThrowErrorsAsExceptions(true)` is turning on error throwing, as opposed to turning it off in the previous implementation.