### PR TITLE
Structure_Engine: Add required methods for Cassette and BuiltUpRibbed properties

### DIFF
--- a/Structure_Engine/Query/Description.cs
+++ b/Structure_Engine/Query/Description.cs
@@ -356,6 +356,32 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
+        [Description("Generates a default description for the SurfaceProperty.")]
+        [Input("property", "The SurfaceProperty to get a default description for.")]
+        [Output("desc", "The generated description for the property based on its dimensions, material and type.")]
+        public static string Description(this BuiltUpRibbed property)
+        {
+            if (property == null)
+                return "null property";
+
+            return $"Ribbed: {property.TopThickness:G3} THK slab {CheckGetMaterialName(property.Material)} on {property.RibHeight:G3}x{property.RibThickness:G3} ribs {CheckGetMaterialName(property.RibMaterial ?? property.Material)} spaced {property.RibSpacing:G3}";
+        }
+
+        /***************************************************/
+
+        [Description("Generates a default description for the SurfaceProperty.")]
+        [Input("property", "The SurfaceProperty to get a default description for.")]
+        [Output("desc", "The generated description for the property based on its dimensions, material and type.")]
+        public static string Description(this Cassette property)
+        {
+            if (property == null)
+                return "null property";
+
+            return $"Cassette Top: {property.TopThickness:G3} THK {CheckGetMaterialName(property.Material)} Bot: {property.BottomThickness:G3} THK {CheckGetMaterialName(property.BottomMaterial ?? property.Material)} Ribs: {property.RibHeight:G3}x{property.RibThickness:G3} {CheckGetMaterialName(property.RibMaterial ?? property.Material)} spaced {property.RibSpacing:G3}";
+        }
+
+        /***************************************************/
+
         [Description("Generates a default description for the SurfaceProperty as 'Ribbed DepthX DepthY SpacingX SpacingY StemWidthX StemWidthY - MaterialName'.")]
         [Input("property", "The SurfaceProperty to get a default description for.")]
         [Output("desc", "The generated description for the property based on its dimensions, material and type.")]

--- a/Structure_Engine/Query/MassPerArea.cs
+++ b/Structure_Engine/Query/MassPerArea.cs
@@ -135,11 +135,56 @@ namespace BH.Engine.Structure
         [PreviousInputNames("property","loadingPanelProperty")]
         [Description("Gets the mass per area for a LoadingPanelProperty. This will always return 0.")]
         [Input("property", "The LoadingPanelProperty property to calculate the mass per area for.")]
-        [Output("massPerArea", "The mass per area for the property. THis will always return 0 for a LoadingPanelProperty.", typeof(MassPerUnitArea))]
+        [Output("massPerArea", "The mass per area for the property. This will always return 0 for a LoadingPanelProperty.", typeof(MassPerUnitArea))]
         public static double MassPerArea(this LoadingPanelProperty property)
         {
             return 0;
         }
+
+
+        /***************************************************/
+
+        [Description("Gets the mass per area for a Cassette.")]
+        [Input("property", "The Cassette property to calculate the mass per area for.")]
+        [Output("massPerArea", "The mass per area for the property.", typeof(MassPerUnitArea))]
+        public static double MassPerArea(this Cassette property)
+        {
+            if (property.IsNull() || property.Material.IsNull())
+                return double.NaN;
+
+            if (property.RibThickness <= 0 || property.RibSpacing < property.RibThickness)
+            {
+                Base.Compute.RecordError($"The {nameof(Cassette.RibThickness)} is 0 or {nameof(Cassette.RibSpacing)} smaller than {nameof(Cassette.RibThickness)}. The {nameof(Cassette)} is invalid and mass per area cannot be computed.");
+                return double.NaN;
+            }
+
+            double volPerAreaRibZone = property.RibHeight * (property.RibThickness / property.RibSpacing);
+            return property.TopThickness * property.Material.Density + 
+                   property.BottomThickness * (property.BottomMaterial ?? property.Material).Density + 
+                   volPerAreaRibZone * (property.RibMaterial ?? property.Material).Density;
+        }
+
+        /***************************************************/
+
+        [Description("Gets the mass per area for a BuiltUpRibbed.")]
+        [Input("property", "The BuiltUpRibbed property to calculate the mass per area for.")]
+        [Output("massPerArea", "The mass per area for the property.", typeof(MassPerUnitArea))]
+        public static double MassPerArea(this BuiltUpRibbed property)
+        {
+            if (property.IsNull() || property.Material.IsNull())
+                return double.NaN;
+
+            if (property.RibThickness <= 0 || property.RibSpacing < property.RibThickness)
+            {
+                Base.Compute.RecordError($"The {nameof(BuiltUpRibbed.RibThickness)} is 0 or {nameof(BuiltUpRibbed.RibSpacing)} smaller than {nameof(BuiltUpRibbed.RibThickness)}. The {nameof(BuiltUpRibbed)} is invalid and mass per area cannot be computed.");
+                return double.NaN;
+            }
+
+            double volPerAreaRibZone = property.RibHeight * (property.RibThickness / property.RibSpacing);
+            return property.TopThickness * property.Material.Density +
+                   volPerAreaRibZone * (property.RibMaterial ?? property.Material).Density;
+        }
+
 
         /***************************************************/
         /**** Public Methods - Interfaces               ****/

--- a/Structure_Engine/Query/TotalThickness.cs
+++ b/Structure_Engine/Query/TotalThickness.cs
@@ -173,6 +173,33 @@ namespace BH.Engine.Structure
         }
 
         /***************************************************/
+
+        [Description("Gets the total thickness of the surface property.")]
+        [Input("property", "The property to evaluate.")]
+        [Output("TotalThickness", "The total thickness, including any ribs or waffling.", typeof(Length))]
+        public static double TotalThickness(this Cassette property)
+        {
+            if (property.IsNull())
+                return 0;
+
+            return property.TopThickness + property.BottomThickness + property.RibHeight;
+        }
+
+        /***************************************************/
+
+        [Description("Gets the total thickness of the surface property.")]
+        [Input("property", "The property to evaluate.")]
+        [Output("TotalThickness", "The total thickness, including any ribs or waffling.", typeof(Length))]
+        public static double TotalThickness(this BuiltUpRibbed property)
+        {
+            if (property.IsNull())
+                return 0;
+
+            return property.TopThickness + property.RibHeight;
+        }
+
+
+        /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 

--- a/Structure_Engine/Query/VolumePerArea.cs
+++ b/Structure_Engine/Query/VolumePerArea.cs
@@ -255,6 +255,46 @@ namespace BH.Engine.Structure
         }
 
         /***************************************************/
+
+        [Description("Gets the volume per area of the property for the purpose of calculating solid volume.")]
+        [Input("property", "The property to evaluate the volume per area of.")]
+        [Output("volumePerArea", "The volume per area of the property for the purpose of calculating solid volume.", typeof(Length))]
+        public static double VolumePerArea(this Cassette property)
+        {
+            if (property.IsNull())
+                return double.NaN;
+
+            if (property.RibThickness <= 0 || property.RibSpacing < property.RibThickness)
+            {
+                Base.Compute.RecordError($"The {nameof(Cassette.RibThickness)} is 0 or {nameof(Cassette.RibSpacing)} smaller than {nameof(Cassette.RibThickness)}. The {nameof(Cassette)} is invalid and volume cannot be computed.");
+                return double.NaN;
+            }
+
+            double volPerAreaRibZone = property.RibHeight * (property.RibThickness / property.RibSpacing);
+            return property.TopThickness + property.BottomThickness + volPerAreaRibZone;
+        }
+
+
+        /***************************************************/
+
+        [Description("Gets the volume per area of the property for the purpose of calculating solid volume.")]
+        [Input("property", "The property to evaluate the volume per area of.")]
+        [Output("volumePerArea", "The volume per area of the property for the purpose of calculating solid volume.", typeof(Length))]
+        public static double VolumePerArea(this BuiltUpRibbed property)
+        {
+            if (property.IsNull())
+                return double.NaN;
+
+            if (property.RibThickness <= 0 || property.RibSpacing < property.RibThickness)
+            {
+                Base.Compute.RecordError($"The {nameof(BuiltUpRibbed.RibThickness)} is 0 or {nameof(BuiltUpRibbed.RibSpacing)} smaller than {nameof(BuiltUpRibbed.RibThickness)}. The {nameof(BuiltUpRibbed)} is invalid and volume cannot be computed.");
+                return double.NaN;
+            }
+
+            double volPerAreaRibZone = property.RibHeight * (property.RibThickness / property.RibSpacing);
+            return property.TopThickness + volPerAreaRibZone;
+        }
+        /***************************************************/
         /**** Public Methods - Interfaces               ****/
         /***************************************************/
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM/pull/1604
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Add short description of what has been fixed -->

Adds required methods for new Cassette and BuiltUpRibbed properties:

- Descriptions
- VolumePerArea
- TotalThickness
- MaterialComposition
- MassPerArea

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM/Structure_oM/%231604-AddCassetteAndBuiltUpRibProperties?csf=1&web=1&e=0MwLH7

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->