### PR TITLE
Updated AW methods to handle Cavity UValue

### DIFF
--- a/Facade_Engine/Compute/UValueOpeningAW.cs
+++ b/Facade_Engine/Compute/UValueOpeningAW.cs
@@ -198,15 +198,15 @@ namespace BH.Engine.Facade
 
             if ((glassEdgeUValue > 0) && (glassUValue > 0))
             {
+                if (cavityUValue > 0)
+                {
+                    glassUValue = 1 / (1 / cavityUValue + 1 / glassUValue);
+                }
                 for (int i = 0; i < edgeAreas.Count; i++)
                 {
                     edgeUValProduct += (glassEdgeUValue * edgeAreas[i]);
                 }
                 centerUValue = (((glassArea * glassUValue) + edgeUValProduct) / centerArea);
-                if (cavityUValue > 0)
-                {
-                    centerUValue = 1 / (1 / cavityUValue + 1 / centerUValue);
-                }
             }
             else
             {

--- a/Facade_Engine/Compute/UValueSpandrelAW.cs
+++ b/Facade_Engine/Compute/UValueSpandrelAW.cs
@@ -184,15 +184,15 @@ namespace BH.Engine.Facade
 
             if ((glassEdgeUValue > 0) && (glassUValue > 0))
             {
+                if (cavityUValue > 0)
+                {
+                    glassUValue = 1 / (1 / cavityUValue + 1 / glassUValue);
+                }
                 for (int i = 0; i < edgeAreas.Count; i++)
                 {
                     edgeUValProduct += (glassEdgeUValue * edgeAreas[i]);
                 }
                 centerUValue = (((glassArea * glassUValue) + edgeUValProduct) / centerArea);
-                if (cavityUValue > 0)
-                {
-                    centerUValue = 1 / (1 / cavityUValue + 1 / centerUValue);
-                }
             }
             else
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3315

<!-- Add short description of what has been fixed -->
Updated UValueOpeningAW and UValueSpandrelAW methods so that the Cavity UValue fragment is only applied to the center of the opening and not to the edges. 

### Test files
<!-- Link to test files to validate the proposed changes -->
New check has been added under section 5 of the SpandrelAWTestFile: https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_Engine/Facade_Engine/BHoM%20PR%20Test%20Files?csf=1&web=1&e=pf2Sja