### PR TITLE
Fix typo in DomainTree creation

### DIFF
--- a/Data_Engine/Create/DomainTree.cs
+++ b/Data_Engine/Create/DomainTree.cs
@@ -20,14 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Data.Collections;
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.ComponentModel;
-using BH.oM.Base.Attributes;
-using BH.oM.Base;
-using BH.oM.Geometry;
-using BH.oM.Data.Collections;
+using System.Linq;
 
 namespace BH.Engine.Data
 {
@@ -127,7 +126,7 @@ namespace BH.Engine.Data
 
             foreach (DomainTree<T> data in list)
             {
-                if ((data.DomainBox.Domains[index].Min + data.DomainBox.Domains[index].Min) / 2 < centre)
+                if ((data.DomainBox.Domains[index].Min + data.DomainBox.Domains[index].Max) / 2 < centre)
                     one.Add(data);
                 else
                     two.Add(data);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3317 

<!-- Add short description of what has been fixed -->
The existing code does (min + min)/2 which I've rectified to (min + max)/2.

### Test files
<!-- Link to test files to validate the proposed changes -->
It's just a typo so hopefully someone who worked on Domain Tree before can approve right away 😉 

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->