### PR TITLE
Structure_Engine: Add Geometry3D method for Pile, PileCap and PileFoundation

### DIFF
--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -43,7 +43,7 @@ namespace BH.Engine.Structure
         [Description("Gets the BH.oM.Geometry.Extrusion out of the Bar as its Geometry3D.")]
         [Input("bar", "The input Bar to get the Geometry3D out of, i.e.its extrusion with its cross section along its centreline.")]
         [Input("onlyOuterExtrusion", "If true, and if the cross-section of the Bar is composed by multiple edges (e.g. a Circular Hollow Section), only return the extrusion of the outermost edge.")]
-        [Output("Mesh", "The mesh defining the 3D geometry of the Bar.")]
+        [Output("3d", "Three-dimensional geometry of the Bar.")]
         public static IGeometry Geometry3D(this Bar bar, bool onlyOuterExtrusion = true)
         {
             if (bar.IsNull())

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -144,9 +144,9 @@ namespace BH.Engine.Structure
             return compositeGeometry;
         }
 
-        [Description("Gets a CompositeGeometry made of the pile cap and piles of a PadFoundation.")]
-        [Input("pileFoundation", "The input panel to get the Geometry3D out of.")]
-        [Output("Mesh", "The mesh defining the 3D geometry of the PileFoundation.")]
+        [Description("Gets a CompositeGeometry made of the PileCap and Piles of a PileFoundation.")]
+        [Input("pileFoundation", "The input PileFoundation to get the Geometry3D out of.")]
+        [Output("3d", "Three-dimensional geometry of the PileFoundation.")]
         public static IGeometry Geometry3D(this PileFoundation pileFoundation)
         {
             if (pileFoundation.IsNull())

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -107,7 +107,7 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Gets the BH.oM.Geometry.Extrusion out of the Pile as its Geometry3D.")]
-        [Input("bar", "The input Pile to get the Geometry3D out of, i.e.its extrusion with its cross section along its centreline.")]
+        [Input("pile", "The input Pile to get the Geometry3D out of, i.e.its extrusion with its cross section along its centreline.")]
         public static IGeometry Geometry3D(this Pile pile)
         {
             return Create.Bar((Line)pile.Geometry(), pile.Section, pile.OrientationAngle).Geometry3D();
@@ -116,7 +116,7 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Gets a CompositeGeometry made of the boundary surfaces of the PadFoundation, or only its central Surface.")]
-        [Input("panel", "The input panel to get the Geometry3D out of.")]
+        [Input("pad", "The input panel to get the Geometry3D out of.")]
         public static IGeometry Geometry3D(this PadFoundation pad)
         {
             if (pad.IsNull() || !pad.IsPlanar())
@@ -141,7 +141,7 @@ namespace BH.Engine.Structure
         }
 
         [Description("Gets a CompositeGeometry made of the pile cap and piles of a PadFoundation.")]
-        [Input("panel", "The input panel to get the Geometry3D out of.")]
+        [Input("pileFoundation", "The input panel to get the Geometry3D out of.")]
         public static IGeometry Geometry3D(this PileFoundation pileFoundation)
         {
             if (pileFoundation.IsNull())

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -110,7 +110,7 @@ namespace BH.Engine.Structure
 
         [Description("Gets the BH.oM.Geometry.Extrusion out of the Pile as its Geometry3D.")]
         [Input("pile", "The input Pile to get the Geometry3D out of, i.e.its extrusion with its cross section along its centreline.")]
-        [Output("Mesh", "The mesh defining the 3D geometry of the Pile.")]
+        [Output("3d", "Three-dimensional geometry of the Pile.")]
         public static IGeometry Geometry3D(this Pile pile)
         {
             return Create.Bar((Line)pile.Geometry(), pile.Section, pile.OrientationAngle).Geometry3D();

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -119,8 +119,8 @@ namespace BH.Engine.Structure
         /***************************************************/
 
         [Description("Gets a CompositeGeometry made of the boundary surfaces of the PadFoundation, or only its central Surface.")]
-        [Input("pad", "The input panel to get the Geometry3D out of.")]
-        [Output("Mesh", "The mesh defining the 3D geometry of the Pad.")]
+        [Input("pad", "The input Panel to get the Geometry3D out of.")]
+        [Output("3d", "Three-dimensional geometry of the PadFoundation.")]
         public static IGeometry Geometry3D(this PadFoundation pad)
         {
             if (pad.IsNull() || !pad.IsPlanar())

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -64,7 +64,7 @@ namespace BH.Engine.Structure
         [Description("Gets a CompositeGeometry made of the boundary surfaces of the Panel, or only its central Surface.")]
         [Input("panel", "The input panel to get the Geometry3D out of.")]
         [Input("onlyCentralSurface", "If true, the returned geometry is only the central (middle) surface of the panel. Otherwise, the whole external solid is returned as a CompositeGeometry of many surfaces.")]
-        [Output("Mesh", "The mesh defining the 3D geometry of the PadFoundation.")]
+        [Output("3d", "Three-dimensional geometry of the Panel.")]
         public static IGeometry Geometry3D(this Panel panel, bool onlyCentralSurface = false)
         {
             if (panel.IsNull())

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -43,6 +43,7 @@ namespace BH.Engine.Structure
         [Description("Gets the BH.oM.Geometry.Extrusion out of the Bar as its Geometry3D.")]
         [Input("bar", "The input Bar to get the Geometry3D out of, i.e.its extrusion with its cross section along its centreline.")]
         [Input("onlyOuterExtrusion", "If true, and if the cross-section of the Bar is composed by multiple edges (e.g. a Circular Hollow Section), only return the extrusion of the outermost edge.")]
+        [Output("Mesh", "The mesh defining the 3D geometry of the Bar.")]
         public static IGeometry Geometry3D(this Bar bar, bool onlyOuterExtrusion = true)
         {
             if (bar.IsNull())
@@ -63,6 +64,7 @@ namespace BH.Engine.Structure
         [Description("Gets a CompositeGeometry made of the boundary surfaces of the Panel, or only its central Surface.")]
         [Input("panel", "The input panel to get the Geometry3D out of.")]
         [Input("onlyCentralSurface", "If true, the returned geometry is only the central (middle) surface of the panel. Otherwise, the whole external solid is returned as a CompositeGeometry of many surfaces.")]
+        [Output("Mesh", "The mesh defining the 3D geometry of the PadFoundation.")]
         public static IGeometry Geometry3D(this Panel panel, bool onlyCentralSurface = false)
         {
             if (panel.IsNull())
@@ -108,6 +110,7 @@ namespace BH.Engine.Structure
 
         [Description("Gets the BH.oM.Geometry.Extrusion out of the Pile as its Geometry3D.")]
         [Input("pile", "The input Pile to get the Geometry3D out of, i.e.its extrusion with its cross section along its centreline.")]
+        [Output("Mesh", "The mesh defining the 3D geometry of the Pile.")]
         public static IGeometry Geometry3D(this Pile pile)
         {
             return Create.Bar((Line)pile.Geometry(), pile.Section, pile.OrientationAngle).Geometry3D();
@@ -117,6 +120,7 @@ namespace BH.Engine.Structure
 
         [Description("Gets a CompositeGeometry made of the boundary surfaces of the PadFoundation, or only its central Surface.")]
         [Input("pad", "The input panel to get the Geometry3D out of.")]
+        [Output("Mesh", "The mesh defining the 3D geometry of the Pad.")]
         public static IGeometry Geometry3D(this PadFoundation pad)
         {
             if (pad.IsNull() || !pad.IsPlanar())
@@ -142,6 +146,7 @@ namespace BH.Engine.Structure
 
         [Description("Gets a CompositeGeometry made of the pile cap and piles of a PadFoundation.")]
         [Input("pileFoundation", "The input panel to get the Geometry3D out of.")]
+        [Output("Mesh", "The mesh defining the 3D geometry of the PileFoundation.")]
         public static IGeometry Geometry3D(this PileFoundation pileFoundation)
         {
             if (pileFoundation.IsNull())


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3347 

<!-- Add short description of what has been fixed -->
Geometry3D for pile and pad foundations added to Structure_Engine

### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Structure_Engine/%233347-add-geometry3d-for-piles-and-foundations/%233347-TypicalPileFoundation_Geometry3D_TestScript.gh?csf=1&web=1&e=44L3qr

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Added Geometry3D method for `Pile`, `PadFoundation` and `PileFoundation`;

### Additional comments
<!-- As required -->