### PR TITLE
BHoM_Engine: Modify.SortExtensionMethods fixed not to exclude methods targeting object 

### DIFF
--- a/BHoM_Engine/Modify/SortExtensionMethods.cs
+++ b/BHoM_Engine/Modify/SortExtensionMethods.cs
@@ -110,6 +110,10 @@ namespace BH.Engine.Base
 
         private static int InheritanceLevel(this List<List<Type>> hierarchy, Type type)
         {
+            // If target type of the extension method is object, return max inheritance level (to be treated as last resort)
+            if (type == typeof(object))
+                return int.MaxValue;
+
             for (int i = 0; i < hierarchy.Count; i++)
             {
                 if (!type.IsGenericType)


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3349

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FBHoM%5FEngine%2F%233350%2DSortExtensionMethodsBug)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->