### PR TITLE
Geometry_Engine: BooleanDifference secured against single-dimensional regions

### DIFF
--- a/Geometry_Engine/Compute/BooleanDifference.cs
+++ b/Geometry_Engine/Compute/BooleanDifference.cs
@@ -102,9 +102,13 @@ namespace BH.Engine.Geometry
 
             List<Polyline> allRegions = new List<Polyline> { region };
             Plane p = region.FitPlane();
+            if (p == null)
+                return new List<Polyline>();
+
             foreach (Polyline refRegion in refRegions)
             {
-                if (p.IsCoplanar(refRegion.FitPlane()))
+                Plane refPlane = refRegion.FitPlane();
+                if (refPlane != null && p.IsCoplanar(refPlane))
                     allRegions.Add(refRegion);
             }
 
@@ -268,9 +272,13 @@ namespace BH.Engine.Geometry
             
             List<ICurve> allRegions = new List<ICurve> { region };
             Plane p = region.IFitPlane();
+            if (p == null)
+                return new List<PolyCurve>();
+
             foreach (ICurve refRegion in refRegionsList)
             {
-                if (p.IsCoplanar(refRegion.IFitPlane()))
+                Plane refPlane = refRegion.IFitPlane();
+                if (refPlane != null && p.IsCoplanar(refPlane))
                     allRegions.Add(refRegion);
             }
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3368

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FGeometry%5FEngine%2F%233369%2DNullReferenceInBooleanOperations).


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->