### PR TITLE
BHoM_Engine: Additional check for assembly qualified type without version for Create EngineType

### DIFF
--- a/BHoM_Engine/Create/Type/EngineType.cs
+++ b/BHoM_Engine/Create/Type/EngineType.cs
@@ -73,7 +73,7 @@ namespace BH.Engine.Base
                 //If more than one type found, and assembly name was found, try use it to further filter
                 if (types.Count > 1 && assemblyName != null)
                 {
-                    List<Type> assemblyMatches = types.Where(x => x.Assembly.FullName.Split(',')[0] == assemblyName).ToList();  //Assembly fullname contains both name and version. Split removes the verison
+                    List<Type> assemblyMatches = types.Where(x => x.Assembly.GetName().Name == assemblyName).ToList();
                     if (assemblyMatches.Any())   //If any matches are found, use them
                         types = assemblyMatches;
                 }

--- a/BHoM_Engine/Create/Type/EngineType.cs
+++ b/BHoM_Engine/Create/Type/EngineType.cs
@@ -49,14 +49,34 @@ namespace BH.Engine.Base
                 return null;
             }
 
-            // Try finding any types based on the assembly qualified name
+            // Try finding any types based on the assembly qualified name. This checks both assembly name as well as version
             List<Type> types = Global.EngineTypeList.Where(x => x.AssemblyQualifiedName == name).ToList();
             
             // If not found, look also based on unqualified name
             if (types.Count == 0)
             {
-                string unQualifiedName = name.Contains(",") ? name.Split(',').First() : name;
+                string unQualifiedName, assemblyName;
+                if (name.Contains(","))
+                {
+                    string[] split = name.Split(',');
+                    unQualifiedName = split[0];
+                    assemblyName = split[1].Trim(); //Assembly name is second part. Trim to remove whitespace
+                }
+                else
+                { 
+                    unQualifiedName = name;
+                    assemblyName = null;
+                }
+
                 types = Global.EngineTypeList.Where(x => x.FullName == unQualifiedName).ToList();
+
+                //If more than one type found, and assembly name was found, try use it to further filter
+                if (types.Count > 1 && assemblyName != null)
+                {
+                    List<Type> assemblyMatches = types.Where(x => x.Assembly.FullName.Split(',')[0] == assemblyName).ToList();  //Assembly fullname contains both name and version. Split removes the verison
+                    if (assemblyMatches.Any())   //If any matches are found, use them
+                        types = assemblyMatches;
+                }
             }
 
             if (types.Count == 1 || (takeFirstIfMultiple && types.Count > 1))


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3398 

<!-- Add short description of what has been fixed -->

Add additional check for assembly qualified name without version. Important for edgecase of same namespace and typename, from different assemblies for types serialized in an older major version. Only runs this additional step if more than one type is found.

Generally having this duplication should most likely be avoided, but as that has not been enforced, and was not an issue before #3389 which fixed other critical issues, but introduced this edge case problem, we should still attempt to make sure it works after that fix.

### Test files
<!-- Link to test files to validate the proposed changes -->

All query components should deserialise correctly:

[On Sharepoint](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BuroHappoldEngineering/ModelLaundry_Toolkit/BuroHappold_BHoM_v3.3.beta_Structures_ML_BasicWorkFlow.gh?csf=1&web=1&e=6E7xl3)https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BuroHappoldEngineering/ModelLaundry_Toolkit/[BuroHappold_BHoM_v3.3.beta_Structures_ML_BasicWorkFlow.gh](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BuroHappoldEngineering/ModelLaundry_Toolkit/BuroHappold_BHoM_v3.3.beta_Structures_ML_BasicWorkFlow.gh?csf=1&web=1&e=6E7xl3)?csf=1&web=1&e=6E7xl3

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->