### PR TITLE
Diffing_Engine: Do not include static properties and fields in differences

### DIFF
--- a/Diffing_Engine/Query/DifferentProperties.cs
+++ b/Diffing_Engine/Query/DifferentProperties.cs
@@ -29,7 +29,6 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Diffing;
 using BH.oM.Base;
-using kellerman = KellermanSoftware.CompareNetObjects;
 using System.Reflection;
 using BH.Engine.Base;
 

--- a/Diffing_Engine/Query/NumericalDifferenceInclusion.cs
+++ b/Diffing_Engine/Query/NumericalDifferenceInclusion.cs
@@ -29,7 +29,6 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Diffing;
 using BH.oM.Base;
-using kellerman = KellermanSoftware.CompareNetObjects;
 using System.Reflection;
 using BH.Engine.Base;
 using BH.Engine.Reflection;

--- a/Diffing_Engine/Query/ObjectDifferences.cs
+++ b/Diffing_Engine/Query/ObjectDifferences.cs
@@ -87,6 +87,8 @@ namespace BH.Engine.Diffing
             kellermanComparer.Config.TypesToIgnore.Add(typeof(RevisionFragment)); // Never include the changes in RevisionFragment.
             kellermanComparer.Config.TypesToIgnore.AddRange(cc.TypeExceptions);
             kellermanComparer.Config.MembersToIgnore = cc.PropertyExceptions;
+            kellermanComparer.Config.CompareStaticFields = false;
+            kellermanComparer.Config.CompareStaticProperties = false;
 
             // Kellerman configuration for tolerance.
             // Setting Custom Tolerance for specific properties is complex with Kellerman. 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3406

<!-- Add short description of what has been fixed -->

Rule out static properties from inclusion in comparison. (see issue for a bit more detail).
Minor cleanup of unused using's.

This reinstates the behaviour for testing prior to this:
https://github.com/BHoM/Test_Toolkit/pull/474

### Test files
<!-- Link to test files to validate the proposed changes -->

Check unit-tests. This should give a not insignificant improvement in speed for running through them, especially for tests containing System.Drawing.Color.

Also, @alelom , great if you can test this through your diffing tests.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

Example run before this PR:

https://github.com/BHoM/BHoM_Engine/runs/29579805351