### PR TITLE
Add proper protection for IsEquals check for Serialisation

### DIFF
--- a/.ci/code/Serialiser_Test/Verify/ObjectsToFromJson.cs
+++ b/.ci/code/Serialiser_Test/Verify/ObjectsToFromJson.cs
@@ -132,7 +132,19 @@ namespace BH.Test.Serialiser
                     Engine.Base.Compute.RecordError(e.Message);
                 }
 
-                if (!testObject.IsEqual(copy))
+                bool isEqual;
+
+                try
+                {
+                    isEqual = testObject.IsEqual(copy);
+                }
+                catch (Exception e)
+                {
+                    BH.Engine.Base.Compute.RecordError(e, $"Failed to compare the objcets of type {type.Name}");
+                    isEqual = false;
+                }
+
+                if (!isEqual)
                     return new TestResult
                     {
                         Description = typeDescription,

--- a/Diffing_Engine/Diffing_Engine.csproj
+++ b/Diffing_Engine/Diffing_Engine.csproj
@@ -17,7 +17,7 @@
     <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;&#xD;&#xA;xcopy &quot;$(TargetDir)KellermanSoftware.Compare-NET-Objects.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
   </Target>
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="4.67.0" />
+    <PackageReference Include="CompareNETObjects" Version="4.83.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BHoM_Engine\BHoM_Engine.csproj" />


### PR DESCRIPTION
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3442

<!-- Add short description of what has been fixed -->

Add try-catch around IsEquals method to ensure it does not crash the whole test method, if exception is raised inside.

### Test files
<!-- Link to test files to validate the proposed changes -->

running check serialisaiton should show some known errors for objects

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->