### PR TITLE
BHoM_Engine: assembly resolution mechanism added to Global class

### DIFF
--- a/BHoM_Engine/Objects/Global.cs
+++ b/BHoM_Engine/Objects/Global.cs
@@ -89,7 +89,7 @@ namespace BH.Engine.Base
             AppDomain.CurrentDomain.AssemblyLoad += ReflectAssemblyOnLoad;
 
             // Dedicated assembly resolution mechanism to minimise issues related with dependency incompatibility
-            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(ResolveBHoMAssembly);
+            AppDomain.CurrentDomain.AssemblyResolve += ResolveBHoMAssembly;
 
             // Reflect the assemblies that have already been loaded.
             foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/Excel_Toolkit/pull/81


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
The PR adds a central assembly resolution mechanism that attempts to load the failing assembly from the BHoM folder in case of `AppDomain.CurrentDomain.AssemblyResolve` event being triggered as a result of BHoM method call.


### Additional comments
<!-- As required -->