### PR TITLE
Diffing_Engine: Fix is equal of DataTable

### DIFF
--- a/Diffing_Engine/Objects/CustomComparers/DataColumnComparer.cs
+++ b/Diffing_Engine/Objects/CustomComparers/DataColumnComparer.cs
@@ -1,0 +1,112 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using System;
+using System.Data;
+using KellermanSoftware.CompareNetObjects;
+using KellermanSoftware.CompareNetObjects.TypeComparers;
+
+//Minor modification of file from https://github.com/GregFinzer/Compare-Net-Objects/blob/master/Compare-NET-Objects/TypeComparers/DataColumnComparer.cs
+//Reason for inclusion in here is to allow for inclusion of these windows specific comparers in netstandard2.0
+//Link to issue: https://github.com/BHoM/BHoM_Engine/issues/3455
+//Code below under lincence as stated by https://github.com/GregFinzer/Compare-Net-Objects?tab=MS-PL-1-ov-file
+
+namespace BH.Engine.Diffing
+{
+    /// <summary>
+    /// Compare a data column
+    /// </summary>
+    public class DataColumnComparer : BaseTypeComparer
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        /// <param name="rootComparer"></param>
+        public DataColumnComparer(RootComparer rootComparer) : base(rootComparer)
+        {
+        }
+
+        /// <summary>
+        /// Returns true if both types compared are a DataColumn
+        /// </summary>
+        /// <param name="type1"></param>
+        /// <param name="type2"></param>
+        /// <returns></returns>
+        public override bool IsTypeMatch(Type type1, Type type2)
+        {
+            if (type1 == null || type2 == null)
+                return false;
+
+            return type1 == typeof(DataColumn) && type2 == typeof(DataColumn);
+        }
+
+        /// <summary>
+        /// Compare a Data Column
+        /// </summary>
+        /// <param name="parms"></param>
+        public override void CompareType(CompareParms parms)
+        {
+            //This should never happen, null check happens one level up
+            if (parms.Object1 == null || parms.Object2 == null)
+                return;
+
+            DataColumn col1 = (DataColumn)parms.Object1;
+            DataColumn col2 = (DataColumn)parms.Object2;
+
+            CompareProp(parms, col1, col2, col1.AllowDBNull, col2.AllowDBNull, "AllowDBNull");
+            CompareProp(parms, col1, col2, col1.AutoIncrement, col2.AutoIncrement, "AutoIncrement");
+            CompareProp(parms, col1, col2, col1.AutoIncrementSeed, col2.AutoIncrementSeed, "AutoIncrementSeed");
+            CompareProp(parms, col1, col2, col1.AutoIncrementStep, col2.AutoIncrementStep, "AutoIncrementStep");
+            CompareProp(parms, col1, col2, col1.Caption, col2.Caption, "Caption");
+            CompareProp(parms, col1, col2, col1.ColumnName, col2.ColumnName, "ColumnName");
+            CompareProp(parms, col1, col2, col1.DataType, col2.DataType, "DataType");
+            CompareProp(parms, col1, col2, col1.DefaultValue, col2.DefaultValue, "DefaultValue");
+            CompareProp(parms, col1, col2, col1.Expression, col2.Expression, "Expression");
+            CompareProp(parms, col1, col2, col1.MaxLength, col2.MaxLength, "MaxLength");
+            CompareProp(parms, col1, col2, col1.Namespace, col2.Namespace, "Namespace");
+            CompareProp(parms, col1, col2, col1.Ordinal, col2.Ordinal, "Ordinal");
+            CompareProp(parms, col1, col2, col1.Prefix, col2.Prefix, "Prefix");
+            CompareProp(parms, col1, col2, col1.ReadOnly, col2.ReadOnly, "ReadOnly");
+            CompareProp(parms, col1, col2, col1.Unique, col2.Unique, "Unique");
+        }
+
+        private void CompareProp<T>(CompareParms parms, DataColumn col1, DataColumn col2, T prop1, T prop2, string propName)
+        {
+            if (parms.Result.ExceededDifferences)
+                return;
+
+            string currentBreadCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, propName);
+
+            CompareParms childParms = new CompareParms();
+            childParms.Result = parms.Result;
+            childParms.Config = parms.Config;
+            childParms.BreadCrumb = currentBreadCrumb;
+            childParms.ParentObject1 = col1;
+            childParms.ParentObject2 = col2;
+            childParms.Object1 = prop1;
+            childParms.Object2 = prop2;
+
+            RootComparer.Compare(childParms);
+        }
+    }
+}

--- a/Diffing_Engine/Objects/CustomComparers/DataRowComparer.cs
+++ b/Diffing_Engine/Objects/CustomComparers/DataRowComparer.cs
@@ -1,0 +1,164 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Data;
+using KellermanSoftware;
+using KellermanSoftware.CompareNetObjects;
+using KellermanSoftware.CompareNetObjects.TypeComparers;
+
+//Minor modification of file from https://github.com/GregFinzer/Compare-Net-Objects/blob/master/Compare-NET-Objects/TypeComparers/DataRowComparer.cs
+//Reason for inclusion in here is to allow for inclusion of these windows specific comparers in netstandard2.0
+//Link to issue: https://github.com/BHoM/BHoM_Engine/issues/3455
+//Code below under lincence as stated by https://github.com/GregFinzer/Compare-Net-Objects?tab=MS-PL-1-ov-file
+
+namespace BH.Engine.Diffing
+{
+    /// <summary>
+    /// Compare all columns in a data row
+    /// </summary>
+    public class DataRowComparer : BaseTypeComparer
+    {
+        /// <summary>
+        /// Constructor that takes a root comparer
+        /// </summary>
+        /// <param name="rootComparer"></param>
+        public DataRowComparer(RootComparer rootComparer)
+            : base(rootComparer)
+        { }
+
+        /// <summary>
+        /// Returns true if this is a DataRow
+        /// </summary>
+        /// <param name="type1">The type of the first object</param>
+        /// <param name="type2">The type of the second object</param>
+        /// <returns></returns>
+        public override bool IsTypeMatch(Type type1, Type type2)
+        {
+            if(type1 == null || type2 == null)
+                return false;
+
+            return type1 == typeof(DataRow) && type2 == typeof(DataRow);
+        }
+
+        /// <summary>
+        /// Compare two data rows
+        /// </summary>
+        public override void CompareType(CompareParms parms)
+        {
+            DataRow dataRow1 = parms.Object1 as DataRow;
+            DataRow dataRow2 = parms.Object2 as DataRow;
+
+            //This should never happen, null check happens one level up
+            if (dataRow1 == null || dataRow2 == null)
+                return;
+
+            for (int i = 0; i < Math.Min(dataRow2.Table.Columns.Count, dataRow1.Table.Columns.Count); i++)
+            {
+                //Only compare specific column names
+                if (parms.Config.MembersToInclude.Count > 0 && !parms.Config.MembersToInclude.Contains(dataRow1.Table.Columns[i].ColumnName))
+                    continue;
+
+                //If we should ignore it, skip it
+                if (parms.Config.MembersToInclude.Count == 0 && parms.Config.MembersToInclude.Contains(dataRow1.Table.Columns[i].ColumnName))
+                    continue;
+
+                //If we should ignore read only, skip it
+                if (!parms.Config.CompareReadOnly && dataRow1.Table.Columns[i].ReadOnly)
+                    continue;
+
+                //Both are null
+                if (dataRow1.IsNull(i) && dataRow2.IsNull(i))
+                    continue;
+
+                string currentBreadCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, string.Empty, string.Empty, dataRow1.Table.Columns[i].ColumnName);
+
+                //Check if one of them is null
+                if (dataRow1.IsNull(i))
+                {
+                    Difference difference = new Difference
+                    {
+                        ParentObject1 = parms.ParentObject1,
+                        ParentObject2 = parms.ParentObject2,
+                        PropertyName = currentBreadCrumb,
+                        Object1Value = "(null)",
+                        Object2Value = NiceString(dataRow2[i]),
+                        Object1 = parms.Object1,
+                        Object2 = parms.Object2
+                    };
+
+                    AddDifference(parms.Result, difference);
+                    return;
+                }
+
+                if (dataRow2.IsNull(i))
+                {
+                    Difference difference = new Difference
+                    {
+                        ParentObject1 = parms.ParentObject1,
+                        ParentObject2 = parms.ParentObject2,
+                        PropertyName = currentBreadCrumb,
+                        Object1Value = NiceString(dataRow1[i]),
+                        Object2Value = "(null)",
+                        Object1 = parms.Object1,
+                        Object2 = parms.Object2
+                    };
+
+                    AddDifference(parms.Result, difference);
+                    return;
+                }
+
+                //Check if one of them is deleted
+                if (dataRow1.RowState == DataRowState.Deleted ^ dataRow2.RowState == DataRowState.Deleted)
+                {
+                    Difference difference = new Difference
+                    {
+                        ParentObject1 = parms.ParentObject1,
+                        ParentObject2 = parms.ParentObject2,
+                        PropertyName = currentBreadCrumb,
+                        Object1Value = dataRow1.RowState.ToString(),
+                        Object2Value = dataRow2.RowState.ToString(),
+                        Object1 = parms.Object1,
+                        Object2 = parms.Object2
+                    };
+
+                    AddDifference(parms.Result, difference);
+                    return;
+                }
+
+                CompareParms childParms = new CompareParms();
+                childParms.Result = parms.Result;
+                childParms.Config = parms.Config;
+                childParms.ParentObject1 = parms.Object1;
+                childParms.ParentObject2 = parms.Object2;
+                childParms.Object1 = dataRow1[i];
+                childParms.Object2 = dataRow2[i];
+                childParms.BreadCrumb = currentBreadCrumb;
+
+                RootComparer.Compare(childParms);
+
+                if (parms.Result.ExceededDifferences)
+                    return;
+            }
+        }
+    }
+}

--- a/Diffing_Engine/Objects/CustomComparers/DataTableComparer.cs
+++ b/Diffing_Engine/Objects/CustomComparers/DataTableComparer.cs
@@ -1,0 +1,201 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Data;
+using System.Globalization;
+using System.Linq;
+using KellermanSoftware.CompareNetObjects;
+using KellermanSoftware.CompareNetObjects.TypeComparers;
+
+//Minor modification of file from https://github.com/GregFinzer/Compare-Net-Objects/blob/master/Compare-NET-Objects/TypeComparers/DataTableComparer.cs
+//Reason for inclusion in here is to allow for inclusion of these windows specific comparers in netstandard2.0
+//Link to issue: https://github.com/BHoM/BHoM_Engine/issues/3455
+//Code below under lincence as stated by https://github.com/GregFinzer/Compare-Net-Objects?tab=MS-PL-1-ov-file
+
+namespace BH.Engine.Diffing
+{
+    /// <summary>
+    /// Compare all rows in a data table
+    /// </summary>
+    public class DataTableComparer : BaseTypeComparer
+    {
+        /// <summary>
+        /// Constructor that takes a root comparer
+        /// </summary>
+        /// <param name="rootComparer"></param>
+        public DataTableComparer(RootComparer rootComparer)
+            : base(rootComparer)
+        {
+        }
+
+        /// <summary>
+        /// Returns true if both objects are of type DataTable
+        /// </summary>
+        /// <param name="type1">The type of the first object</param>
+        /// <param name="type2">The type of the second object</param>
+        /// <returns></returns>
+        public override bool IsTypeMatch(Type type1, Type type2)
+        {
+            if (type1 == null || type2 == null)
+                return false;
+
+            return type1 == typeof(DataTable) && type2 == typeof(DataTable);
+        }
+
+        /// <summary>
+        /// Compare two datatables
+        /// </summary>
+        public override void CompareType(CompareParms parms)
+        {
+            DataTable dataTable1 = parms.Object1 as DataTable;
+            DataTable dataTable2 = parms.Object2 as DataTable;
+
+            //This should never happen, null check happens one level up
+            if (dataTable1 == null || dataTable2 == null)
+                return;
+
+            //Only compare specific table names
+            if (parms.Config.MembersToInclude.Count > 0 && !parms.Config.MembersToInclude.Contains(dataTable1.TableName))
+                return;
+
+            //If we should ignore it, skip it
+            if (parms.Config.MembersToInclude.Count == 0 && parms.Config.MembersToIgnore.Contains(dataTable1.TableName))
+                return;
+
+            //There must be the same amount of rows in the datatable
+            if (dataTable1.Rows.Count != dataTable2.Rows.Count)
+            {
+                Difference difference = new Difference
+                {
+                    ParentObject1 = parms.ParentObject1,
+                    ParentObject2 = parms.ParentObject2,
+                    PropertyName = parms.BreadCrumb,
+                    Object1Value = dataTable1.Rows.Count.ToString(CultureInfo.InvariantCulture),
+                    Object2Value = dataTable2.Rows.Count.ToString(CultureInfo.InvariantCulture),
+                    ChildPropertyName = "Rows.Count",
+                    Object1 = parms.Object1,
+                    Object2 = parms.Object2
+                };
+
+                AddDifference(parms.Result, difference);
+
+                if (parms.Result.ExceededDifferences)
+                    return;
+            }
+
+            if (ColumnsDifferent(parms)) return;
+
+            CompareEachRow(parms);
+        }
+
+        private bool ColumnsDifferent(CompareParms parms)
+        {
+            DataTable dataTable1 = parms.Object1 as DataTable;
+            DataTable dataTable2 = parms.Object2 as DataTable;
+
+            if (dataTable1 == null)
+                throw new ArgumentException("parms.Object1");
+
+            if (dataTable2 == null)
+                throw new ArgumentException("parms.Object2");
+
+            if (dataTable1.Columns.Count != dataTable2.Columns.Count)
+            {
+                Difference difference = new Difference
+                {
+                    ParentObject1 = parms.ParentObject1,
+                    ParentObject2 = parms.ParentObject2,
+                    PropertyName = parms.BreadCrumb,
+                    Object1Value = dataTable1.Columns.Count.ToString(CultureInfo.InvariantCulture),
+                    Object2Value = dataTable2.Columns.Count.ToString(CultureInfo.InvariantCulture),
+                    ChildPropertyName = "Columns.Count",
+                    Object1 = parms.Object1,
+                    Object2 = parms.Object2
+                };
+
+                AddDifference(parms.Result, difference);
+
+                if (parms.Result.ExceededDifferences)
+                    return true;
+            }
+
+            foreach (var i in Enumerable.Range(0, dataTable1.Columns.Count))
+            {
+                string currentBreadCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, "Columns", string.Empty, i);
+
+                CompareParms childParms = new CompareParms
+                {
+                    Result = parms.Result,
+                    Config = parms.Config,
+                    ParentObject1 = parms.Object1,
+                    ParentObject2 = parms.Object2,
+                    Object1 = dataTable1.Columns[i],
+                    Object2 = dataTable2.Columns[i],
+                    BreadCrumb = currentBreadCrumb
+                };
+
+                RootComparer.Compare(childParms);
+
+                if (parms.Result.ExceededDifferences)
+                    return true;
+            }
+
+            return false;
+        }
+
+        private void CompareEachRow(CompareParms parms)
+        {
+            DataTable dataTable1 = parms.Object1 as DataTable;
+            DataTable dataTable2 = parms.Object2 as DataTable;
+
+            if (dataTable1 == null)
+                throw new ArgumentException("parms.Object1");
+
+            if (dataTable2 == null)
+                throw new ArgumentException("parms.Object2");
+
+            for (int i = 0; i < Math.Min(dataTable1.Rows.Count, dataTable2.Rows.Count); i++)
+            {
+                string currentBreadCrumb = AddBreadCrumb(parms.Config, parms.BreadCrumb, "Rows", string.Empty, i);
+
+                CompareParms childParms = new CompareParms
+                {
+                    Result = parms.Result,
+                    Config = parms.Config,
+                    ParentObject1 = parms.Object1,
+                    ParentObject2 = parms.Object2,
+                    Object1 = dataTable1.Rows[i],
+                    Object2 = dataTable2.Rows[i],
+                    BreadCrumb = currentBreadCrumb
+                };
+
+                RootComparer.Compare(childParms);
+
+                if (parms.Result.ExceededDifferences)
+                    return;
+            }
+        }
+
+
+    }
+}

--- a/Diffing_Engine/Query/ObjectDifferences.cs
+++ b/Diffing_Engine/Query/ObjectDifferences.cs
@@ -96,6 +96,12 @@ namespace BH.Engine.Diffing
             kellermanComparer.Config.DoublePrecision = 0;
             kellermanComparer.Config.DecimalPrecision = 0;
 
+            //Include local copies of the DataTable comparers, as they are ruled out by netstandard builds in the NugetPackage.
+            //See: https://github.com/BHoM/BHoM_Engine/issues/3455
+            kellermanComparer.Config.CustomComparers.Add(new DataTableComparer(kellerman.RootComparerFactory.GetRootComparer()));
+            kellermanComparer.Config.CustomComparers.Add(new DataRowComparer(kellerman.RootComparerFactory.GetRootComparer()));
+            kellermanComparer.Config.CustomComparers.Add(new DataColumnComparer(kellerman.RootComparerFactory.GetRootComparer()));
+
             // Perform the comparison using the Kellerman library.
             kellerman.ComparisonResult kellermanResult = kellermanComparer.Compare(pastObject, followingObject);
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3455 

<!-- Add short description of what has been fixed -->

Fix IsEqual check for DataTables by inclusion of local copies of the custom comparers from Kellerman. See issue for more detail.

### Test files
<!-- Link to test files to validate the proposed changes -->

[On Sharpoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Diffing_Engine/%233456-FixIsEqualOfDataTable?csf=1&web=1&e=whOnFz)

Serialisation check for the branch should not give warning about tables.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->