### PR TITLE
Serialiser_Engine: Added condition that the serialised value must be null if the deserialised result was null.

### DIFF
--- a/Serialiser_Engine/Compute/Deserialise/IObject.cs
+++ b/Serialiser_Engine/Compute/Deserialise/IObject.cs
@@ -117,7 +117,7 @@ namespace BH.Engine.Serialiser
                         {
                             object propertyValue = item.Value.IDeserialise(prop.PropertyType, prop.GetValue(value), version, isUpgraded);
 
-                            if (CanSetValueToProperty(prop.PropertyType, propertyValue))
+                            if (CanSetValueToProperty(prop.PropertyType, propertyValue, item.Value))
                             {
                                 prop.SetValue(value, propertyValue);
                             }
@@ -152,10 +152,10 @@ namespace BH.Engine.Serialiser
 
         /*******************************************/
 
-        private static bool CanSetValueToProperty(Type propType, object value)
+        private static bool CanSetValueToProperty(Type propType, object value, BsonValue bsonValue)
         {
             if (value == null)
-                return !propType.IsValueType || Nullable.GetUnderlyingType(propType) != null;
+                return (!propType.IsValueType || Nullable.GetUnderlyingType(propType) != null) && (bsonValue == null || bsonValue.IsBsonNull);
             else
                 return propType.IsAssignableFrom(value.GetType());
         }

--- a/Serialiser_Engine/Compute/Deserialise/Immutable.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Immutable.cs
@@ -70,8 +70,10 @@ namespace BH.Engine.Serialiser
                     List<object> arguments = new List<object>();
                     foreach (var match in matches)
                     {
-                        object propertyValue = IDeserialise(match.Properties.First().Value, match.Parameter.ParameterType, null, version, isUpgraded);
-                        if (CanSetValueToProperty(match.Parameter.ParameterType, propertyValue))
+                        BsonValue bsonValue = match.Properties.First().Value;
+                        object propertyValue = IDeserialise(bsonValue, match.Parameter.ParameterType, null, version, isUpgraded);
+
+                        if (CanSetValueToProperty(match.Parameter.ParameterType, propertyValue, bsonValue))
                             arguments.Add(propertyValue);
                         else
                         {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3462 

<!-- Add short description of what has been fixed -->
See the linked issue:
With help from @IsakNaslundBh in isolating the problem, added a condition to `CanSetValueToProperty` which ensures that if a deserialised property is null, then the serialised property must also have been null to pass. 

### Test files
<!-- Link to test files to validate the proposed changes -->
See the linked issue for a script that demonstrated the original problem - There is still an error being recorded (as a value is still being deserialised to null) but the versioning upgrade is happening and the object contains the FileSettings object in a correct form (rather than null/empty)

There will be knock-on effects from this PR on historical versioning, which will likely snowball so testing for this will be ongoing. Running versioning will probably highlight some of these but as @IsakNaslundBh says, much will be missed and it is best to test thoroughly

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->