### PR TITLE
BHoM_Engine: Exclude SpecialName methods from BhoMMethodList

### DIFF
--- a/BHoM_Engine/Compute/ExtractAssembly.cs
+++ b/BHoM_Engine/Compute/ExtractAssembly.cs
@@ -164,7 +164,7 @@ namespace BH.Engine.Base
                         // Get only the BHoM methods
                         if (!type.IsInterface && type.IsAbstract)
                         {
-                            foreach (MethodInfo info in type.GetMethods(bindingBHoM).Where(x => x.IsLegal()))
+                            foreach (MethodInfo info in type.GetMethods(bindingBHoM).Where(x => x.IsLegal() && !x.IsSpecialName))
                             {
                                 Global.BHoMMethodList.Add(info);
                             }


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3461 

<!-- Add short description of what has been fixed -->

Explude `IsSpecialName` from being added to the BHoMMethodList. This excludes Proeprty get and sets, from Properties in the engine. Also excludes Add and Remove methods for events.

This relates to these PRs:
https://github.com/BHoM/Versioning_Toolkit/pull/276
https://github.com/BHoM/Versioning_Toolkit/pull/281



### Test files
<!-- Link to test files to validate the proposed changes -->

Run the testscript on develop, internalise the results, then re-run on branch and check that the items removed make sense. @pawelbaran quite a few Revit types flagged, so good to make sure you are happy with the removal of them, and that they are not required to be in the BHoMMethod list for anything revit-related (assume not, but want to double check)

[Test script on sharepoint](https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/BHoM_Engine/%233464-RemoveEventAndPropertyMethodsFromBHomMethodList?csf=1&web=1&e=DGvj7o)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->