### PR TITLE
Verification_Engine: Fixed `TryGetValueFromSource` nested property bug

### DIFF
--- a/Verification_Engine/Compute/TryGetValueFromSource.cs
+++ b/Verification_Engine/Compute/TryGetValueFromSource.cs
@@ -128,6 +128,9 @@ namespace BH.Engine.Verification
         // with the last segment of the source path (segments = separated by dots).
         private static Output<bool, object> TryGetValueFromSource(this object obj, string sourceName)
         {
+            if (obj is Output<bool, object> objAsOutput)
+                obj = objAsOutput.Item2;
+
             // If source name not set, compare entire object
             if (obj == null || sourceName == null)
                 return ValueNotFound();
@@ -294,6 +297,9 @@ namespace BH.Engine.Verification
         [Description("Called when the method terminated correctly and value was found.")]
         private static Output<bool, object> ValueFound(object value)
         {
+            if (value is Output<bool, object> valueAsOutput)
+                value = valueAsOutput.Item2;
+
             return new Output<bool, object> { Item1 = true, Item2 = value };
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->
When trying to get nested property from object, method returns `Output<bool, Output<bool, object>>`. After this fix it returns `Output<bool, object>` as expected.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->