### PR TITLE
Structure_Engine: Geometry3D Panel Extrusion method using wrong thickness and normal vector

### DIFF
--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -61,10 +61,10 @@ namespace BH.Engine.Structure
 
         /***************************************************/
 
-        [Description("Gets a CompositeGeometry made of the boundary surfaces of the Panel, or only its central Surface.")]
+        [Description("Gets a CompositeGeometry made of the boundary surfaces of the Panel envelope, or only its central Surface.")]
         [Input("panel", "The input panel to get the Geometry3D out of.")]
         [Input("onlyCentralSurface", "If true, the returned geometry is only the central (middle) surface of the panel. Otherwise, the whole external solid is returned as a CompositeGeometry of many surfaces.")]
-        [Output("3d", "Three-dimensional geometry of the Panel.")]
+        [Output("3d", "Three-dimensional geometry of the Panel envelope.")]
         public static IGeometry Geometry3D(this Panel panel, bool onlyCentralSurface = false)
         {
             if (panel.IsNull())

--- a/Structure_Engine/Query/Geometry3D.cs
+++ b/Structure_Engine/Query/Geometry3D.cs
@@ -79,13 +79,14 @@ namespace BH.Engine.Structure
             else
             {
                 CompositeGeometry compositeGeometry = new CompositeGeometry();
+                Vector localZ = centralPlanarSurface.Normal().Normalise();
+                double thickness = panel.Property.ITotalThickness();
 
-                double thickness = panel.Property.IVolumePerArea();
-                Vector translateVect = new Vector() { Z = -thickness / 2 };
-                Vector extrudeVect = new Vector() { Z = thickness };
+                Vector translateVect = localZ * -thickness / 2;
+                Vector extrudeVect = localZ * thickness;
 
-                Vector upHalf = new Vector() { X = 0, Y = 0, Z = thickness / 2 };
-                Vector downHalf = new Vector() { X = 0, Y = 0, Z = -thickness / 2 };
+                Vector upHalf = localZ * thickness / 2;
+                Vector downHalf = localZ * -thickness / 2;
 
                 PlanarSurface topSrf = centralPlanarSurface.ITranslate(upHalf) as PlanarSurface;
                 PlanarSurface botSrf = centralPlanarSurface.ITranslate(downHalf) as PlanarSurface;


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

![Panel2_070325](https://github.com/user-attachments/assets/f771e505-e9c5-4dd2-a981-0bbc1d968e55)


![Panel070325](https://github.com/user-attachments/assets/906407e0-e5c8-4102-9335-1656798e132b)


Solves issue and adds functionality to Geometry3D for panels. Previously, extrusion of panel was created along global Z-axis, meaning extruded geometry for walls was incorrect. Furthermore, extrusion distance was calculated from VolumePerArea() property,  meaning extruded dimension of i.e. Waffle Slab was incorrect.

To fix above, extrusion direction is changed from global Z vector to the normal vector of the panel surface and extrusion distance from VolumePerArea() to TotalThickness().

Closes #2852 

<!-- Add short description of what has been fixed -->


### Test files

Check different thicknesses and different slab types. Control that results reasonable and like expected.
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Structure_Engine/%232852-Geometry3DPanel-WrongThicknessAndNormalVector/%232852_PanelGeometry3D.gh?csf=1&web=1&e=NYvuMd

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->