### PR TITLE
Fallback on versioning to upgrade via pipes if direct calling crashes

### DIFF
--- a/Versioning_Engine/Convert/ToNewVersion.cs
+++ b/Versioning_Engine/Convert/ToNewVersion.cs
@@ -83,11 +83,9 @@ namespace BH.Engine.Versioning
             // Get the list of upgraders to call
             List<string> versions = Query.UpgradersToCall(version);
 
-            bool versionWithPipes = false;
-
             lock (m_versioningLock)
             {
-                if (versionWithPipes)
+                if (m_VersionWithPipes)
                 {
                     // Call all the upgraders in sequence
                     for (int i = 0; i < versions.Count; i++)
@@ -132,6 +130,13 @@ namespace BH.Engine.Versioning
                             Func<BsonDocument, BsonDocument> upgrader = GetUpgraderMethod(versions[i]);
                             if (upgrader != null)
                                 result = upgrader(document);    //Upgrade
+                        }
+                        catch (BadImageFormatException badImageException)
+                        {
+                            //This exception is thrown when there is a problem directly laoding up the upgrades dlls due to runtime of .net
+                            //If this happends, we fall back to runnign via pipes instead
+                            m_VersionWithPipes = true;
+                            return ToNewVersion(document, version);
                         }
                         catch (Exception e)
                         {
@@ -343,6 +348,8 @@ namespace BH.Engine.Versioning
         /***************************************************/
         /**** Private Fields                            ****/
         /***************************************************/
+
+        private static bool m_VersionWithPipes = false;
 
         private static Dictionary<string, NamedPipeServerStream> m_Pipes = new Dictionary<string, NamedPipeServerStream>();
 


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3470

<!-- Add short description of what has been fixed -->

Fixes issues with versioning in net framework environments not compatible with the upgrades dlls.
Tries with the direct call system, by extractign upgrade methods from the upgrader assemblies, and if it fails, sets the system to use the pipes instead.

Explicitly important to get versioning working for Rhino 8.


### Test files
<!-- Link to test files to validate the proposed changes -->

[Link to GH files that require versioning](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&web=1&e=FuvTMj&CID=7ba6b874%2D3b0f%2D4112%2D8f61%2D6aa88e8a609c&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F03%5FAlpha%2FBuroHappoldEngineering%2FModelLaundry%5FToolkit)
### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->