### PR TITLE
Reflection_Engine: StackOverflowException in PropertyFullNameValueGroups fixed

### DIFF
--- a/Reflection_Engine/Query/PropertyFullNameValueDictionary.cs
+++ b/Reflection_Engine/Query/PropertyFullNameValueDictionary.cs
@@ -102,12 +102,14 @@ namespace BH.Engine.Reflection
             if (obj == null)
                 return;
 
-            IList iList = obj as IList;
             Type objType = obj.GetType();
-
             if (objType.IsPrimitive())
                 return;
 
+            if (obj is Type || obj is Assembly || obj is Module || obj is Attribute || obj is MemberInfo)
+                return;
+
+            IList iList = obj as IList;
             if (iList == null)
             {
                 var props = objType.GetProperties();


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3481

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
See https://github.com/BHoM/BHoM_Engine/issues/3481

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->