### PR TITLE
BHoM_Engine: Fix issues with system types from newer runtimes to older

### DIFF
--- a/BHoM_Engine/Create/Type/GenericType.cs
+++ b/BHoM_Engine/Create/Type/GenericType.cs
@@ -142,7 +142,11 @@ namespace BH.Engine.Base
             }
             //Main type definition as string up until the first split char (first '<').
             //Number of generic arguments will be 1 less than the number of argsSplit count
-            return GenericType(name.Substring(0, argsSplit[0]) + "`" + (argsSplit.Count - 1), arguments, silent, takeFirstIfMultiple);
+            Type type = GenericType(name.Substring(0, argsSplit[0]) + "`" + (argsSplit.Count - 1), arguments, silent, takeFirstIfMultiple);
+
+            if (type != null && name.Contains("&"))
+                type = type.MakeByRefType();
+            return type;
         }
 
         /***************************************************/
@@ -209,9 +213,12 @@ namespace BH.Engine.Base
                 arguments.Add(name.Substring(argsStarts[i], argsEnd[i] - argsStarts[i]).Trim());
             }
             string mainName = name.Substring(0, nameEnd);
-            //Main type definition as string up until the first split char (first '<').
+            //Main type definition as string up until the first split char (first '[[').
             //Number of generic arguments will be 1 less than the number of argsSplit count
-            return GenericType(mainName, arguments, silent, takeFirstIfMultiple);
+            Type type = GenericType(mainName, arguments, silent, takeFirstIfMultiple);
+            if (type != null && name.Contains("&"))
+                type = type.MakeByRefType();
+            return type;
         }
 
         /***************************************************/

--- a/BHoM_Engine/Create/Type/Type.cs
+++ b/BHoM_Engine/Create/Type/Type.cs
@@ -67,9 +67,9 @@ namespace BH.Engine.Base
                 if (type == null)
                     type = System.Type.GetType(unQualifiedName);    //Fallback for when deserialising a type from a later net runtime to a lower net runtime. Can be critical when going between softwares of different net runtimes.
 
-                if (type == null && name.EndsWith("&"))
+                if (type == null && name.Contains("&"))
                 {
-                    type = Type(name.TrimEnd(new char[] { '&' }), true);
+                    type = Type(name.Replace("&", ""), silent, takeFirstIfMultiple);
                     if (type != null)
                         type = type.MakeByRefType();
                 }

--- a/BHoM_Engine/Create/Type/Type.cs
+++ b/BHoM_Engine/Create/Type/Type.cs
@@ -110,7 +110,10 @@ namespace BH.Engine.Base
             ["System.Drawing.Bitmap"] = typeof(System.Drawing.Bitmap),
             ["System.Collections.Generic.SortedDictionary`2"] = typeof(System.Collections.Generic.SortedDictionary<,>),
             ["System.Data.DataTable"] = typeof(System.Data.DataTable),
-            ["System.Collections.Generic.HashSet`1"] = typeof(System.Collections.Generic.HashSet<>)
+            ["System.Collections.Generic.HashSet`1"] = typeof(System.Collections.Generic.HashSet<>),
+            ["System.Xml.XmlNode"] = typeof(System.Xml.XmlNode),
+            ["System.Xml.Linq.XDocument"] = typeof(System.Xml.Linq.XDocument),
+            ["System.Collections.Concurrent.ConcurrentBag`1"] = typeof(System.Collections.Concurrent.ConcurrentBag<>)
         };
 
         /*******************************************/

--- a/BHoM_Engine/Create/Type/Type.cs
+++ b/BHoM_Engine/Create/Type/Type.cs
@@ -49,6 +49,13 @@ namespace BH.Engine.Base
                 return null;
             }
 
+            if (name.StartsWith("System.")) //If a system type, try create it before doing anything else. If failing, rest of method will handle unqualified, generics, reference etc
+            {
+                Type type = System.Type.GetType(name);
+                if (type != null)
+                    return type;
+            }
+
             if (name.Contains('<'))
                 return GenericTypeAngleBrackets(name, silent, takeFirstIfMultiple);
             else if (name.Contains('`') && name.Contains("[["))

--- a/Serialiser_Engine/Compute/Deserialise/Type.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Type.cs
@@ -38,7 +38,7 @@ namespace BH.Engine.Serialiser
         /*******************************************/
         /**** Private Methods                   ****/
         /*******************************************/
-        
+
         private static Type DeserialiseType(this BsonValue bson, Type value, string version, bool isUpgraded)
         {
             // Handle the case where the type is represented as a string
@@ -146,16 +146,10 @@ namespace BH.Engine.Serialiser
             Type type = null;
             if (fullName == "T")
                 return null;
-            if (fullName.IsOmNamespace())
-                type = Base.Create.Type(fullName, true, true);
             else if (fullName.IsEngineNamespace())
                 type = Base.Create.EngineType(fullName, true, true);
             else
-            {
-                type = Type.GetType(fullName);
-                if (type == null)
-                    type = System.Type.GetType(Base.Query.UnqualifiedName(fullName));
-            }
+                type = Base.Create.Type(fullName, true, true);  //Use for all cases except engine methods as method able to handle both oM, and system types, as well as adapter. Also this method is called no matter what if the type is serialised as a string rather than document in this file
 
             if (type == null)
             {


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3487

<!-- Add short description of what has been fixed -->

Fix issues with types failing to deserialise in newer runtimes.

- Always call the Base.Create.Type() method for all non-engine types. This was already done for the case that the type was serialised as a string. No reason we should be using the method for when type is serialised as a document as well
https://github.com/BHoM/BHoM_Engine/blob/216ed5fe15b609c0962b84bf816db6894550f5ac/Serialiser_Engine/Compute/Deserialise/Type.cs#L49
- The above handles problems with the m_ExplicitSystemTypes not caught before in the GetType method
- Fix handling of ref (out) types to handle the case for:
  - Qualified name (check contains rather than ends with)
  - Generic types
- Add missing explicit system types shown to be failing

### Test files
<!-- Link to test files to validate the proposed changes -->

Test file [on SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?csf=1&web=1&e=DisSkA&CID=d37f2700%2Dbf52%2D46bb%2D839a%2D33f2ff3983f4&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4&id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FBHoM%5FEngine%2F%233488%2DFixIssuesWithSystemTypesFromNewerRuntimesToOlder)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->

Re-opening based on develop, as other was intended to be done as hotfix and was based on main.

Now that strategy is changed, wanted to re-open to keep commit history clean without deployment commits.