### PR TITLE
Base_Engine: Create.EngineType fixed to always return alphabetically first type in case of a few types matching the unqualified name

### DIFF
--- a/BHoM_Engine/Create/Type/EngineType.cs
+++ b/BHoM_Engine/Create/Type/EngineType.cs
@@ -78,8 +78,15 @@ namespace BH.Engine.Base
                 }
             }
 
-            if (types.Count == 1 || (takeFirstIfMultiple && types.Count > 1))
+            if (types.Count == 1)
                 return types[0];
+            else if (types.Count > 1 && takeFirstIfMultiple)
+            {
+                if (!silent)
+                    Compute.RecordWarning($"Ambiguous match: Multiple types correspond the the name provided:\n{string.Join("\n", types.Select(x => x.FullName))}");
+
+                return types.OrderBy(x => x.Assembly.FullName).First();
+            }
             else
             {
                 //Unique method not found in list, check if it can be extracted using the system Type


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3490

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Locally apply the tweak from https://github.com/BHoM/Versioning_Toolkit/pull/297 to _C:\ProgramData\BHoM\Upgrades\BHoMUpgrader81\Upgrades.json_ and run versioning check - on `develop` it will throw errors, while after this fix it will be all good.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->