### PR TITLE
Verification_Engine: fixed TryGetValueFromSource for nested properties

### DIFF
--- a/Verification_Engine/Compute/TryGetValueFromSource.cs
+++ b/Verification_Engine/Compute/TryGetValueFromSource.cs
@@ -250,7 +250,7 @@ namespace BH.Engine.Verification
 
         private static PropertyInfo GetProperty(object obj, Type type, string sourceName)
         {
-            var properties = type.GetProperties().Where(p => p.Name == sourceName).ToList();
+            var properties = type.GetProperties().Where(p => p.Name == sourceName);
             PropertyInfo prop = properties.FirstOrDefault(p => p.GetIndexParameters().Length == 0);
 
             if (prop?.CanRead == false)

--- a/Verification_Engine/Compute/TryGetValueFromSource.cs
+++ b/Verification_Engine/Compute/TryGetValueFromSource.cs
@@ -28,6 +28,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace BH.Engine.Verification
@@ -233,7 +234,7 @@ namespace BH.Engine.Verification
             }
 
             // Try get value from property
-            System.Reflection.PropertyInfo prop = obj.GetType().GetProperty(sourceName);
+            PropertyInfo prop = GetProperty(obj, obj.GetType(), sourceName);
             if (prop != null)
                 return ValueFound(prop.GetValue(obj));
 
@@ -243,6 +244,19 @@ namespace BH.Engine.Verification
 
             // Finally try fallback methods (currently implemented for IBHoMObject)
             return GetValue(obj as dynamic, sourceName);
+        }
+
+        /***************************************************/
+
+        private static PropertyInfo GetProperty(object obj, Type type, string sourceName)
+        {
+            var properties = type.GetProperties().Where(p => p.Name == sourceName).ToList();
+            PropertyInfo prop = properties.FirstOrDefault(p => p.GetIndexParameters().Length == 0);
+
+            if (prop?.CanRead == false)
+                prop = GetProperty(obj, prop.DeclaringType.BaseType, sourceName);
+
+            return prop;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #

<!-- Add short description of what has been fixed -->
Improve TryGetValueFromSource to work with specific cases of nested properties:
- if there's more than one property of the same name in the object, get one without indexing
- if property has no getter, check property from the base type

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->