### PR TITLE
Serialiser_Engine: Improve serialisation for dynamic objects

### DIFF
--- a/Reflection_Engine/Query/PropertyNames.cs
+++ b/Reflection_Engine/Query/PropertyNames.cs
@@ -20,10 +20,17 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base;
 using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Base.Reflection;
+using BH.oM.Quantities.Attributes;
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
+using System.Reflection;
 
 namespace BH.Engine.Reflection
 {
@@ -43,6 +50,8 @@ namespace BH.Engine.Reflection
 
             if (obj is CustomObject)
                 return PropertyNames(obj as CustomObject);
+            else if (obj is IDynamicObject)
+                return PropertyNames(obj as IDynamicObject);
             else
                 return obj.GetType().PropertyNames();
         }
@@ -73,6 +82,46 @@ namespace BH.Engine.Reflection
         private static List<string> PropertyNames(this CustomObject obj)
         {
             return obj.GetType().PropertyNames().Where(x => x != "CustomData").Concat(obj.CustomData.Keys.ToList()).ToList();
+        }
+
+        /***************************************************/
+
+        private static List<string> PropertyNames(this IDynamicObject obj)
+        {
+            if (obj is IDynamicPropertyProvider)
+            {
+                object result;
+                bool success = BH.Engine.Base.Compute.TryRunExtensionMethod(obj, "GetProperties", new object[] { }, out result);
+                List<Property> properties = result as List<Property>;
+
+                if (success && properties != null)
+                    return properties.Select(x => x.Name).ToList();
+                else
+                    return new List<string>();
+            }
+            else
+            {
+                List<string> properties = new List<string>();
+
+                foreach (PropertyInfo prop in obj.GetType().GetProperties())
+                {
+                    if (prop.GetCustomAttribute<DynamicPropertyAttribute>() != null
+                        && typeof(IDictionary).IsAssignableFrom(prop.PropertyType)
+                        && prop.PropertyType.GenericTypeArguments.First().IsEnum)
+                    {
+                        IDictionary dic = prop.GetValue(obj) as IDictionary;
+                        properties.AddRange(dic.Keys.OfType<Enum>().OrderBy(x => x).Select(x => x.IToText()).Where(x => !string.IsNullOrEmpty(x)));
+
+                    }
+                    else
+                    {
+                        properties.Add(prop.Name);
+                    }
+                }
+
+                return properties;
+            }
+                
         }
 
         /***************************************************/

--- a/Serialiser_Engine/Compute/Serialise/IBHoMObject.cs
+++ b/Serialiser_Engine/Compute/Serialise/IBHoMObject.cs
@@ -45,6 +45,11 @@ namespace BH.Engine.Serialiser
                 writer.WriteNull();
                 return;
             }
+            else if (value is IDynamicObject)
+            {
+                SerialiseDynamicObject(value as IDynamicObject, writer, targetType);
+                return;
+            }
 
             writer.WriteStartDocument();
 

--- a/Serialiser_Engine/Compute/Serialise/IDynamicObject.cs
+++ b/Serialiser_Engine/Compute/Serialise/IDynamicObject.cs
@@ -1,0 +1,112 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2025, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.Base;
+using BH.Engine.Reflection;
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using MongoDB.Bson.IO;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace BH.Engine.Serialiser
+{
+    public static partial class Compute
+    {
+
+        /*******************************************/
+        /**** Private Methods                   ****/
+        /*******************************************/
+        
+        private static void SerialiseDynamicObject(this IDynamicObject value, BsonDocumentWriter writer, Type targetType)
+        {
+            if (value == null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            writer.WriteStartDocument();
+
+            writer.WriteName("_t");
+            writer.WriteString(value.GetType().FullName);
+
+            if (value is IDynamicPropertyProvider)
+            {
+                foreach (string prop in value.PropertyNames())
+                {
+                    object result;
+                    if (BH.Engine.Base.Compute.TryRunExtensionMethod(value, "GetProperty", new object[] { prop }, out result))
+                    {
+                        writer.WriteName(prop);
+                        ISerialise(result, writer, typeof(object));
+                    }
+                    else
+                    {
+                        Base.Compute.RecordWarning($"Failed to collect property {prop} when serialising {value.GetType().Name}. This property will be ignored.");
+                    }
+                } 
+            }
+            else
+            {
+                foreach (PropertyInfo prop in value.GetType().GetProperties())
+                {
+                    if (prop.GetCustomAttribute<DynamicPropertyAttribute>() != null && typeof(IDictionary).IsAssignableFrom(prop.PropertyType))
+                    {
+                        Type[] genericArguments = prop.PropertyType.GenericTypeArguments;
+                        if (genericArguments.Length != 2 || !prop.PropertyType.GenericTypeArguments.First().IsEnum)
+                        {
+                            writer.WriteName(prop.Name);
+                            ISerialise(prop.GetValue(value), writer, prop.PropertyType);
+                            BH.Engine.Base.Compute.RecordWarning($"A dynamic property container of type {prop.PropertyType.ToString()} is not supported. It will be serialised as a regular property.");
+                        }
+                        else
+                        {
+                            Type valueType = genericArguments[1];
+                            IDictionary dic = prop.GetValue(value) as IDictionary;
+                            foreach (Enum key in dic.Keys.OfType<Enum>())
+                            {
+                                writer.WriteName(key.IToText());
+                                ISerialise(dic[key], writer, valueType);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        writer.WriteName(prop.Name);
+                        ISerialise(prop.GetValue(value), writer, prop.PropertyType);
+                    }
+                }
+            }
+
+            writer.WriteEndDocument();
+        }
+
+        /*******************************************/
+    }
+}
+
+

--- a/Serialiser_Engine/Compute/Serialise/IObject.cs
+++ b/Serialiser_Engine/Compute/Serialise/IObject.cs
@@ -43,7 +43,12 @@ namespace BH.Engine.Serialiser
                 writer.WriteNull();
                 return;
             }
-
+            else if (value is IDynamicObject)
+            {
+                SerialiseDynamicObject(value as IDynamicObject, writer, targetType);
+                return;
+            }
+                
             writer.WriteStartDocument();
 
             writer.WriteName("_t");


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3503

The makes sure that the dynamic properties are elevated at the top level of the json alongside any other regular properties.

One thing I would pay extra attention to is the way enums are turned into text. Right now, I am using `IToText()` but I could see benefit to use `ToString()` instead`. It will be good to have your opinion from the perspective of the documentation and json schemas.

### Test files
I would recommend you use your own test you have for LCA toolkit. But if you want additional tests, you can use this:
[DynamicObjects_Test (3).zip](https://github.com/user-attachments/files/20389556/DynamicObjects_Test.3.zip)

### Additional comments
<!-- As required -->