### PR TITLE
Versioning_Engine: Fix Issue with all dictionary entries throwing and catching exceptions

### DIFF
--- a/Versioning_Engine/Modify/Upgrade.cs
+++ b/Versioning_Engine/Modify/Upgrade.cs
@@ -60,7 +60,7 @@ namespace BH.Engine.Versioning
             }
             else if (newDoc.Contains("k") && newDoc.Contains("v"))
             {
-                result = UpgradeObjectProperties(newDoc, converter);    //Calling UpgradeObjectProperties directly here, as that is the only part of UpgradeObejct method that is relevant. All other parts require _t to be set
+                result = UpgradeObjectProperties(newDoc, converter);    //Calling UpgradeObjectProperties directly here, as that is the only part of UpgradeObject method that is relevant. All other parts require _t to be set
             }
 
             return result;
@@ -204,13 +204,12 @@ namespace BH.Engine.Versioning
 
         private static BsonDocument UpgradeObject(BsonDocument document, Converter converter)
         {
+
+            if (!document.Contains("_t"))
+                return UpgradeObjectProperties(document, converter);    //Only method relevant to be called for the case of no type available
+
             //Get the old type
-            string oldType = "";
-            try
-            {
-                oldType = CleanTypeString(document["_t"].AsString);
-            }
-            catch { }
+            string oldType = CleanTypeString(document["_t"].AsString);
 
             // Check if the object type is classified as deleted or without update
             CheckForNoUpgrade(converter, oldType, "object type");


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3517

<!-- Add short description of what has been fixed -->

Fixes problem with exceptions being thrown and caught for each entry in a non-string based dictionary going through the upgrading loop.

Could have fixed by checking if the document contains "_t" in the UpgradeObejct method, but this almost felt clearer in terms of data flow, as the UpgradeObejctProperties is the only method in UpgradeObejct that will be called for a non-existing _t (all other parts relies on the "oldType" property.


This PR should not really change anything it terms of functionality, just make it run quicker, and hopefully make the code flow cleaner

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->