### PR TITLE
Geometry_Engine: fallback overload of CurveIntersections added

### DIFF
--- a/Geometry_Engine/Query/CurveIntersections.cs
+++ b/Geometry_Engine/Query/CurveIntersections.cs
@@ -20,13 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.oM.Base.Attributes;
 using BH.oM.Geometry;
+using BH.oM.Quantities.Attributes;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using BH.oM.Base.Attributes;
 using System.ComponentModel;
-using BH.oM.Quantities.Attributes;
+using System.Linq;
 
 namespace BH.Engine.Geometry
 {
@@ -152,9 +152,9 @@ namespace BH.Engine.Geometry
                 List<Point> intPts1 = curve1.PlaneIntersections(p2, tolerance);
                 List<Point> intPts2 = curve2.PlaneIntersections(p1, tolerance);
 
-                foreach(Point pt1 in intPts1)
+                foreach (Point pt1 in intPts1)
                 {
-                    foreach(Point pt2 in intPts2)
+                    foreach (Point pt2 in intPts2)
                     {
                         if (pt1.SquareDistance(pt2) <= sqTolerance)
                             result.Add((pt1 + pt2) * 0.5);
@@ -283,6 +283,16 @@ namespace BH.Engine.Geometry
                 }
             }
             return result.CullDuplicates(tolerance);
+        }
+
+        /***************************************************/
+        /**** Private Methods - Fallback                ****/
+        /***************************************************/
+
+        private static List<Point> CurveIntersections(this ICurve curve1, ICurve curve2, double tolerance = Tolerance.Distance)
+        {
+            BH.Engine.Base.Compute.RecordError($"Intersection between curves of type {curve1.GetType().Name} and {curve2.GetType().Name} is not implemented.");
+            return new List<Point>();
         }
 
         /***************************************************/


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3550

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
On [SharePoint](https://burohappold.sharepoint.com/sites/BHoM/02_Current/Forms/AllItems.aspx?id=%2Fsites%2FBHoM%2F02%5FCurrent%2F12%5FScripts%2F02%5FPull%20Request%2FBHoM%2FBHoM%5FEngine%2FGeometry%5FEngine%2F%233551%2DCurveIntersectionOverloadForNurbs&viewid=a5a93cba%2Dfcca%2D46cc%2Da31a%2D80b8d5cbfd7b&FolderCTID=0x0120008122C8891F89054B8ACED0196C70DFC4)


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->