### PR TITLE
Facade_Engine: Updated FrameEdge GenMaterialTakeoff to return for null FrameEdgeProperty

### DIFF
--- a/Facade_Engine/Query/GeneralMaterialTakeoff.cs
+++ b/Facade_Engine/Query/GeneralMaterialTakeoff.cs
@@ -148,8 +148,8 @@ namespace BH.Engine.Facade
 
             if (edge.FrameEdgeProperty == null)
             {
-                Engine.Base.Compute.RecordError($"The {nameof(GeneralMaterialTakeoff)} could not be queried as no {nameof(FrameEdgeProperty)} has been assigned to the {nameof(FrameEdge)}.");
-                return null;
+                Engine.Base.Compute.RecordWarning($"No {nameof(FrameEdgeProperty)} has been assigned to the {nameof(FrameEdge)}. An empty MaterialTakeoff has been returned.");
+                return Matter.Create.GeneralMaterialTakeoff(Matter.Create.VolumetricMaterialTakeoff(new MaterialComposition(new List<Material>(), new List<double>()), 0));
             }
 
             VolumetricMaterialTakeoff volTakeoff = Matter.Create.VolumetricMaterialTakeoff(edge.MaterialComposition(), edge.SolidVolume());


### PR DESCRIPTION
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3555

Updated method to return empty Takeoff for a FrameEdge with a null FrameEdgeProperty, as this is still a valid FrameEdge.


### Test files
[Test File, Confirm the Option for Panels w/o FrameEdgeProperties works](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/03_Alpha/BHoM/BHoM_Engine/Facade_Engine/Facade_Engine-TestFacadeAndPhysicalForEPDAndTakeoffAreas.gh)
