### PR TITLE
Fix `AcuteAngle` returning `NaN` for identical input vectors

### DIFF
--- a/Geometry_Engine/Query/AcuteAngle.cs
+++ b/Geometry_Engine/Query/AcuteAngle.cs
@@ -40,9 +40,23 @@ namespace BH.Engine.Geometry
         [Output("angle", "The smallest possible angle between 2 vectors regardless of their directions.", typeof(Angle))]
         public static double AcuteAngle(this Vector vector1, Vector vector2)
         {
-            return Math.Acos(
-                Math.Abs(vector1.DotProduct(vector2))
-                / (vector1.Length() * vector2.Length()));
+            double length1 = vector1.Length();
+            double length2 = vector2.Length();
+
+            // Handle zero-length vectors
+            if (length1 < Tolerance.Distance || length2 < Tolerance.Distance)
+            {
+                Engine.Base.Compute.RecordWarning("One or both vectors have zero or near-zero length. Cannot compute angle.");
+                return double.NaN;
+            }
+
+            double dotProduct = vector1.DotProduct(vector2);
+            double cosAngle = Math.Abs(dotProduct) / (length1 * length2);
+
+            //When vectors are almost identical, cosAngle can slightly exceed 1 due to floating-point precision, causing Math.Acos() to return NaN. Here we clamp cosAngle to valid range [-1, 1] to prevent this.
+            cosAngle = Math.Max(-1.0, Math.Min(1.0, cosAngle));
+
+            return Math.Acos(cosAngle);
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3558 

<!-- Add short description of what has been fixed -->
When vectors are almost identical, cosAngle can slightly exceed 1 due to floating-point precision, causing Math.Acos() to return NaN. I clamped cosAngle to valid range [-1, 1] to prevent this.

### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/BHoM_Engine/Geometry_Engine/%233560-FixAcuteAngleQuery?csf=1&web=1&e=iwCtua

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->