### PR TITLE
Add support for lazy loading of assemblies on running extensions methods

### DIFF
--- a/BHoM_Engine/Objects/IAssemblyResolver.cs
+++ b/BHoM_Engine/Objects/IAssemblyResolver.cs
@@ -20,11 +20,15 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using System;
+
 namespace BH.Engine.Base.Objects
 {
     public interface IAssemblyResolver
     {
         bool MakeSureAssemblyIsLoadedForType(string type);
+
+        bool MakeSureAssemblyIsLoadedForExtensionMethod(string methodName, Type targetType);
     }
 }
 

--- a/BHoM_Engine/Query/ExtensionMethods.cs
+++ b/BHoM_Engine/Query/ExtensionMethods.cs
@@ -20,11 +20,13 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using BH.Engine.Base.Objects;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using BH.Engine.Base.Objects;
+using BH.oM.Base.Attributes;
 
 namespace BH.Engine.Base
 {
@@ -34,6 +36,11 @@ namespace BH.Engine.Base
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [Description("Finds all extension methods with the specified name that can be applied to the given type. \n" +
+            "Automatically loads required assemblies before searching to ensure all relevant extension methods are discovered.")]
+        [Input("type", "The Type to find extension methods for. The method will search for extensions where this type is assignable to the first parameter.")]
+        [Input("methodName", "The name of the extension method to search for.")]
+        [Output("methods", "A list of MethodInfo objects representing all extension methods with the specified name that can be applied to the given type.")]
         public static List<MethodInfo> ExtensionMethods(this Type type, string methodName)
         {
             // Make sure to load all assemblies that might contain this extension method

--- a/BHoM_Engine/Query/ExtensionMethods.cs
+++ b/BHoM_Engine/Query/ExtensionMethods.cs
@@ -20,11 +20,11 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
+using BH.Engine.Base.Objects;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using BH.oM.Base.Attributes;
 
 namespace BH.Engine.Base
 {
@@ -36,6 +36,12 @@ namespace BH.Engine.Base
 
         public static List<MethodInfo> ExtensionMethods(this Type type, string methodName)
         {
+            // Make sure to load all assemblies that might contain this extension method
+            IAssemblyResolver resolver = Query.AssemblyResolver();
+            if (resolver != null)
+                resolver.MakeSureAssemblyIsLoadedForExtensionMethod(methodName, type);
+
+            // Search for the method itself
             List<MethodInfo> methods = new List<MethodInfo>();
 
             foreach (MethodInfo method in BHoMMethodList().Where(x => x.Name == methodName))


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: Related to 
https://github.com/BHoM/BHoM_Engine/pull/3561
https://github.com/BHoM/BHoM_UI/pull/531
   
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3567

This add reliance on the existing IAssemblyResolver interface to make sure the required assemblies are loaded when trying to run extension methods from their name and input type.


### Test files
This PR should be merged first before the BHoM UI PR. So testing comes in two steps
 - Just compile this PR without the BHoM UI PR and make sure you can run extensions methods
 - Compile the PR from the BHoM UI and make sure that everything is still fine

For both, make sure you run a fresh installer from this milestone (any alpha would do).

Here's an example of how you can test running extension methods but, please use a few of your own. Any public method from the engine that uses `this` on the first argument should be candidate for running as an extension method :
<img width="2047" height="731" alt="image" src="https://github.com/user-attachments/assets/7c694f9f-b6ae-414a-a436-48645c46761c" />


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->