### PR TITLE
Fix map position domain to work as intended

### DIFF
--- a/Spatial_Engine/Modify/MapPositionDomain.cs
+++ b/Spatial_Engine/Modify/MapPositionDomain.cs
@@ -20,9 +20,7 @@
  * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
  */
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Spatial.ShapeProfiles;
@@ -40,20 +38,9 @@ namespace BH.Engine.Spatial
         [Output("taperedProfile", "TaperedProfile with a position domain of 0 and 1.")]
         public static TaperedProfile MapPositionDomain(this TaperedProfile taperedProfile)
         {
-            TaperedProfile newTaperedProfile = null;
             List<double> positions = new List<double>(taperedProfile.Profiles.Keys);
-
-            if (!positions.Contains(0) && !positions.Contains(1))
-            {
-                List<double> newPositions = Compute.MapDomain(positions, positions);
-                newTaperedProfile = Create.TaperedProfile(newPositions, new List<IProfile>(taperedProfile.Profiles.Values), taperedProfile.InterpolationOrder);
-            }
-            else
-            {
-                newTaperedProfile = taperedProfile;
-            }
-
-            return newTaperedProfile;
+            List<double> newPositions = Compute.MapDomain(positions, positions);
+            return Create.TaperedProfile(newPositions, new List<IProfile>(taperedProfile.Profiles.Values), taperedProfile.InterpolationOrder);
         }
     }
 }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #3582

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
[BarOffsets](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23447-AddBarOffsets/%23445%20BarOffsets.gh?csf=1&web=1&e=rEjG2e)
[BarOffsets for TaperedProfile](https://burohappold.sharepoint.com/:u:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/Lusas_Toolkit/%23447-AddBarOffsets/%23445%20BarOffsets%20TaperedSections.gh?csf=1&web=1&e=QrszZx)

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Fixed bug in `MapPositionDomain` that only mapped the positions if a 0 and 1 were included;
- The `MapDomain` works for any case so the conditional for including 0 or 1 has been removed;

### Additional comments
<!-- As required -->