### PR TITLE
make the code more robust for deserialisation of Bitmaps and loading of settings

### DIFF
--- a/Serialiser_Engine/Compute/Deserialise/Bitmap.cs
+++ b/Serialiser_Engine/Compute/Deserialise/Bitmap.cs
@@ -58,7 +58,15 @@ namespace BH.Engine.Serialiser
             }
 
             var stream = new MemoryStream(binaryData.Bytes);
-            return new Bitmap(stream);
+            try
+            {
+                return new Bitmap(stream);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                BH.Engine.Base.Compute.RecordWarning("Bitmap deserialisation is not supported in this environment. The icon will be null.");
+                return value;
+            }
         }
 
         /*******************************************/

--- a/Serialiser_Engine/Serialiser_Engine.csproj
+++ b/Serialiser_Engine/Serialiser_Engine.csproj
@@ -14,7 +14,7 @@
     <OutputPath>..\Build\</OutputPath>
   </PropertyGroup>
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)MongoDB.Bson.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.Drawing.Common.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.Runtime.CompilerServices.Unsafe.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
+    <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)MongoDB.Bson.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(NuGetPackageRoot)system.drawing.common\5.0.0\lib\net461\System.Drawing.Common.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y&#xD;&#xA;xcopy &quot;$(TargetDir)System.Runtime.CompilerServices.Unsafe.dll&quot;  &quot;C:\ProgramData\BHoM\Assemblies&quot; /Y" />
   </Target>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />

--- a/Settings_Engine/Compute/LoadSettings.cs
+++ b/Settings_Engine/Compute/LoadSettings.cs
@@ -70,9 +70,14 @@ namespace BH.Engine.Settings
                 try
                 {
                     ISettings settings = BH.Engine.Serialiser.Convert.FromJson(contents) as ISettings;
-                    Type type = settings.GetType();
-                    Global.BHoMSettings[type] = settings;
-                    Global.BHoMSettingsFilePaths[type] = file;
+                    if (settings != null)
+                    {
+                        Type type = settings.GetType();
+                        Global.BHoMSettings[type] = settings;
+                        Global.BHoMSettingsFilePaths[type] = file;
+                    }
+                    else
+                        BH.Engine.Base.Compute.RecordWarning($"Cannot deserialise the contents of {file} to an ISettings object.");
                 }
                 catch (Exception ex)
                 {
@@ -121,9 +126,14 @@ namespace BH.Engine.Settings
             try
             {
                 ISettings settings = BH.Engine.Serialiser.Convert.FromJson(contents) as ISettings;
-                Type type = settings.GetType();
-                Global.BHoMSettings[type] = settings;
-                Global.BHoMSettingsFilePaths[type] = filePath;
+                if (settings != null)
+                {
+                    Type type = settings.GetType();
+                    Global.BHoMSettings[type] = settings;
+                    Global.BHoMSettingsFilePaths[type] = filePath;
+                }
+                else
+                    BH.Engine.Base.Compute.RecordWarning($"Cannot deserialise the contents of {filePath} to an ISettings object.");
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

### NOTE: used by
https://github.com/BHoM/BHoM_UI/pull/551
https://github.com/BHoM/Grasshopper_UI/pull/751
https://github.com/BHoM/Excel_UI/pull/435
   
### Issues addressed by this PR
 - The new custom ribbon functionality created in https://github.com/BHoM/BHoM_UI/pull/551 was a bit fragile due missing try-catches and null checks.
 - I also made sure the correct package for System.Drawing.Common was copied to the assembly folder since the one that is currently copied is a stub.


### Test files
Excel UI was the most affected by those changes so I recommend testing the loading of the  custom ribbon settings (which includes deseralisation of bitmaps too) in that UI.


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->